### PR TITLE
fix: keep Forum Hub title stable while scrolling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
             -only-testing:TiebaPureUITests/TiebaPureUITests/testLaunchShowsHomeWithoutLoginAndRootTabs \
             -only-testing:TiebaPureUITests/TiebaPureUITests/testSearchResultRoutesToMatchedReply \
             -only-testing:TiebaPureUITests/TiebaPureUITests/testForumLatestMenuSwitchesReplyPublishAndFeaturedCategories \
+            -only-testing:TiebaPureUITests/TiebaPureUITests/testForumHubTitleStaysInsideNavigationBarWhileScrolling \
             -only-testing:TiebaPureUITests/TiebaPureUITests/testFullScreenImageOffersDownloadAndTapReturnsToSource \
             -only-testing:TiebaPureUITests/TiebaPureUITests/testFullScreenImageControlsFitAtAccessibilityXXXL \
             -only-testing:TiebaPureUITests/TiebaPureUITests/testFullScreenImageControlsFitAtXXXL \

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 下载
 
-当前 `main` 源码版本为 `1.2.2`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
+当前 `main` 源码版本为 `1.2.3`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
 
 ## 构建
 

--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1695,13 +1695,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1747,13 +1747,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Features/ForumHub/ForumHubView.swift
+++ b/TiebaPure/Features/ForumHub/ForumHubView.swift
@@ -117,8 +117,7 @@ struct ForumHubView: View {
                 }
             }
         }
-        .navigationTitle("进吧")
-        .interactiveNavigationPopRevealSource()
+        .accessibilityIdentifier("forum-hub-list")
         .shortPullRefresh(
             isEnabled: isLoadingFollowed == false,
             accessibilityIdentifier: "forum-hub-refresh-animation"
@@ -128,6 +127,9 @@ struct ForumHubView: View {
                 await loadFollowed(account: account)
             }
         }
+        .navigationTitle("进吧")
+        .navigationBarTitleDisplayMode(.inline)
+        .interactiveNavigationPopRevealSource()
         .task {
             guard let account, didLoadFollowed == false else { return }
             await loadFollowed(account: account)

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -655,6 +655,67 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
+    func testForumHubTitleStaysInsideNavigationBarWhileScrolling() {
+        let app = launchApp(
+            account: "loggedIn",
+            additionalArguments: [
+                "UITEST_EXTENDED_REFRESH_ANIMATION",
+                "-UIPreferredContentSizeCategoryName",
+                "UICTContentSizeCategoryAccessibilityXXXL"
+            ]
+        )
+
+        rootTab("进吧", in: app).tap()
+        let navigationBar = app.navigationBars["进吧"]
+        let title = navigationBar.staticTexts["进吧"]
+        let forumList = app.descendants(matching: .any)["forum-hub-list"]
+        let forumField = app.textFields["输入吧名"]
+        let firstForumRow = app.buttons.matching(identifier: "forum-hub-forum-row").firstMatch
+        XCTAssertTrue(navigationBar.waitForExistence(timeout: 10))
+        XCTAssertTrue(title.waitForExistence(timeout: 5))
+        XCTAssertTrue(forumList.waitForExistence(timeout: 5))
+        XCTAssertTrue(forumField.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            firstForumRow.waitForExistence(timeout: 10),
+            "关注贴吧加载完成后才验证下拉刷新"
+        )
+
+        let initialFrame = title.frame
+        assertForumHubTitle(title, staysInside: navigationBar)
+
+        let pullDelta = min(96 / max(forumList.frame.height, 1), 0.20)
+        let refreshStart = forumList.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.20)
+        )
+        let refreshEnd = forumList.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.20 + pullDelta)
+        )
+        refreshStart.press(forDuration: 0.1, thenDragTo: refreshEnd)
+        let refreshAnimation = app.descendants(matching: .any)[
+            "forum-hub-refresh-animation"
+        ]
+        XCTAssertTrue(refreshAnimation.waitForExistence(timeout: 2))
+        assertForumHubTitle(title, staysInside: navigationBar)
+        XCTAssertTrue(refreshAnimation.waitForNonExistence(timeout: 8))
+        assertForumHubTitle(title, staysInside: navigationBar)
+
+        for _ in 0..<6 {
+            forumList.swipeUp()
+            assertForumHubTitle(title, staysInside: navigationBar)
+        }
+        XCTAssertFalse(forumField.isHittable, "测试必须先让进吧列表明确离开顶部")
+        for _ in 0..<12 where forumField.isHittable == false {
+            forumList.swipeDown()
+            assertForumHubTitle(title, staysInside: navigationBar)
+        }
+        XCTAssertTrue(forumField.isHittable, "滚动验证结束后必须回到进吧页顶部")
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+
+        XCTAssertEqual(title.frame.midX, initialFrame.midX, accuracy: 1)
+        XCTAssertEqual(title.frame.midY, initialFrame.midY, accuracy: 1)
+        attachScreenshot(named: "fixture-forum-hub-inline-title-after-scroll")
+    }
+
     func testViewingThreadAddsBrowsingHistoryInMeAndReopensIt() {
         let app = launchApp()
         openFirstThread(in: app)
@@ -3324,6 +3385,23 @@ final class TiebaPureUITests: XCTestCase {
         )
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: button)
         return XCTWaiter.wait(for: [expectation], timeout: 5) == .completed
+    }
+
+    private func assertForumHubTitle(
+        _ title: XCUIElement,
+        staysInside navigationBar: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let titleFrame = title.frame
+        let navigationFrame = navigationBar.frame.insetBy(dx: -1, dy: -1)
+        XCTAssertFalse(titleFrame.isEmpty, "进吧标题必须保持可见", file: file, line: line)
+        XCTAssertTrue(
+            navigationFrame.contains(titleFrame),
+            "进吧标题必须完整位于导航栏内，不能在滚动后错位或被裁切",
+            file: file,
+            line: line
+        )
     }
 
     private func visibleLevelBadge(authorID: Int64, in app: XCUIApplication) -> XCUIElement {

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.2.2
-        CURRENT_PROJECT_VERSION: 12
+        MARKETING_VERSION: 1.2.3
+        CURRENT_PROJECT_VERSION: 13
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## Summary
- keep the Forum Hub title in the navigation bar instead of the refresh wrapper
- use an inline title to avoid large-title scroll-edge clipping on iOS 26
- add deterministic UI coverage for refresh and repeated scrolling at Accessibility XXXL
- bump the app to 1.2.3 (13)

## Verification
- 306/306 unit tests passed
- Forum Hub title UI test passed on iPhone 17, iPhone SE 3, and iPad Pro 11-inch M5
- final iPhone 17 test repeated three times, then rerun with explicit scroll and loading-state assertions
- related navigation UI tests passed
- XcodeGen regeneration matches the checked-in project
- unsigned Release IPA packaged and structure-checked