### PR TITLE
feat: support diagonal image dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 下载
 
-当前 `main` 源码版本为 `1.2.3`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
+当前 `main` 源码版本为 `1.2.4`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
 
 ## 构建
 

--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1695,13 +1695,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1747,13 +1747,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -3980,7 +3980,7 @@ struct FullScreenImageView: View {
                 bottomBar
             }
         }
-        .accessibilityHint("双指捏合或双击缩放，轻点图片返回来源页面")
+        .accessibilityHint("双指捏合或双击缩放，单指可斜向拖动图片，轻点图片返回来源页面")
         .alert(item: $downloadNotice) { notice in
             Alert(
                 title: Text(notice.title),
@@ -4584,7 +4584,7 @@ enum FullScreenImageDismissAxis: Equatable {
 }
 
 enum FullScreenImageDismissGesturePolicy {
-    private static let directionDominance: CGFloat = 1.15
+    private static let horizontalPagingDominance: CGFloat = 1.15
 
     static func axis(
         velocity: CGPoint,
@@ -4594,15 +4594,10 @@ enum FullScreenImageDismissGesturePolicy {
         guard isZoomed == false else { return nil }
         let horizontalSpeed = abs(velocity.x)
         let verticalSpeed = abs(velocity.y)
-        if verticalSpeed > horizontalSpeed * directionDominance {
-            return .vertical
+        if horizontalSpeed > verticalSpeed * horizontalPagingDominance {
+            return isFirstImage && velocity.x > 0 ? .horizontalRight : nil
         }
-        if isFirstImage,
-           velocity.x > 0,
-           horizontalSpeed > verticalSpeed * directionDominance {
-            return .horizontalRight
-        }
-        return nil
+        return verticalSpeed > 0 ? .vertical : nil
     }
 
     static func adjustedTranslation(
@@ -4611,9 +4606,9 @@ enum FullScreenImageDismissGesturePolicy {
     ) -> CGPoint {
         switch axis {
         case .horizontalRight:
-            return CGPoint(x: max(translation.x, 0), y: 0)
+            return CGPoint(x: max(translation.x, 0), y: translation.y)
         case .vertical:
-            return CGPoint(x: 0, y: translation.y)
+            return translation
         }
     }
 

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -1113,6 +1113,45 @@ final class TiebaPureSmokeTests: XCTestCase {
             isFirstImage: true,
             isZoomed: true
         ))
+        XCTAssertEqual(
+            FullScreenImageDismissGesturePolicy.axis(
+                velocity: CGPoint(x: 900, y: 800),
+                isFirstImage: false,
+                isZoomed: false
+            ),
+            .vertical,
+            "斜向手势必须由退出手势接管，不能落入方向死区"
+        )
+        XCTAssertNil(FullScreenImageDismissGesturePolicy.axis(
+            velocity: .zero,
+            isFirstImage: true,
+            isZoomed: false
+        ))
+    }
+
+    func testFullScreenImageDismissMovementPreservesDiagonalTranslation() {
+        XCTAssertEqual(
+            FullScreenImageDismissGesturePolicy.adjustedTranslation(
+                CGPoint(x: 48, y: 96),
+                for: .vertical
+            ),
+            CGPoint(x: 48, y: 96)
+        )
+        XCTAssertEqual(
+            FullScreenImageDismissGesturePolicy.adjustedTranslation(
+                CGPoint(x: 96, y: 48),
+                for: .horizontalRight
+            ),
+            CGPoint(x: 96, y: 48)
+        )
+        XCTAssertEqual(
+            FullScreenImageDismissGesturePolicy.adjustedTranslation(
+                CGPoint(x: -24, y: 48),
+                for: .horizontalRight
+            ),
+            CGPoint(x: 0, y: 48),
+            "首图右划退出不能在手指回拉时向左越界"
+        )
     }
 
     func testFullScreenImageDismissThresholdRequiresDistanceOrIntentionalFlick() {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -2415,13 +2415,15 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(pager.waitForExistence(timeout: 8))
         XCTAssertTrue(zoomSurface.waitForExistence(timeout: 5))
 
-        let shortStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.42))
-        let shortEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.49))
+        let shortStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.38, dy: 0.42))
+        let shortEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.55, dy: 0.50))
         shortStart.press(forDuration: 0.2, thenDragTo: shortEnd)
-        XCTAssertTrue(pager.waitForExistence(timeout: 2), "未达到阈值的上下拖动应回弹")
+        XCTAssertTrue(pager.waitForExistence(timeout: 2), "未达到阈值的斜向拖动应回弹")
 
-        let downStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.32))
-        let downEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.78))
+        // Keep the physical x/y travel equal across device sizes. This used to
+        // fall into the axis-lock dead zone and leave the image stationary.
+        let downStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.20, dy: 0.35))
+        let downEnd = downStart.withOffset(CGVector(dx: 240, dy: 240))
         downStart.press(forDuration: 0.1, thenDragTo: downEnd)
         XCTAssertTrue(app.staticTexts["图片来源页"].waitForExistence(timeout: 5))
 
@@ -2431,8 +2433,10 @@ final class TiebaPureUITests: XCTestCase {
         sourceImage.tap()
         XCTAssertTrue(pager.waitForExistence(timeout: 5))
 
-        let upStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.66))
-        let upEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.18))
+        // Start above the bottom controls on compact screens so the image pan,
+        // rather than the original-image button, owns the gesture.
+        let upStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.30))
+        let upEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.04))
         upStart.press(forDuration: 0.1, thenDragTo: upEnd)
         XCTAssertTrue(app.staticTexts["图片来源页"].waitForExistence(timeout: 5))
 

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.2.3
-        CURRENT_PROJECT_VERSION: 13
+        MARKETING_VERSION: 1.2.4
+        CURRENT_PROJECT_VERSION: 14
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## Summary
- preserve both translation axes while an unzoomed image follows a dismissal pan
- route near-diagonal motion to image dismissal without stealing obvious horizontal paging
- bump the app to 1.2.4 (14)

## Verification
- 308 unit tests passed, 1 skipped, 0 failed
- iPhone 17: 4 image-viewer UI regressions passed
- iPhone SE 3: diagonal/right/vertical dismissal flow passed twice consecutively
- iPad Pro 11-inch: diagonal/right/vertical dismissal flow passed
- XcodeGen regeneration matches the checked-in project
- unsigned Release IPA package and privacy manifest validated

## Release
After CI and review, merge this PR and publish v1.2.4 with the unsigned IPA.