### PR TITLE
fix: 区分楼中楼层主内容与回复

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 下载
 
-当前 `main` 源码版本为 `1.2.4`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
+当前 `main` 源码版本为 `1.2.5`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
 
 ## 构建
 

--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1695,13 +1695,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1747,13 +1747,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -1381,6 +1381,11 @@ private struct SubpostListSheet: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 0) {
+                            SubpostSectionHeader(
+                                title: "层主内容",
+                                accessibilityIdentifier: "subpost-parent-section-header"
+                            )
+
                             ReaderCard(showsDivider: false) {
                                 VStack(alignment: .leading, spacing: ThreadReplyLayout.headerContentSpacing) {
                                     UserHeaderView(
@@ -1417,8 +1422,14 @@ private struct SubpostListSheet: View {
 
                             Rectangle()
                                 .fill(TiebaPureTheme.ColorToken.readerGroupedBackground)
-                                .frame(height: ThreadReplyLayout.sectionSeparatorHeight)
+                                .frame(height: SubpostDetailSectionLayout.separatorHeight)
                                 .accessibilityHidden(true)
+
+                            SubpostSectionHeader(
+                                title: "楼中楼回复",
+                                count: max(post.subpostCount, subposts.count),
+                                accessibilityIdentifier: "subpost-replies-section-header"
+                            )
 
                             ForEach(Array(subposts.enumerated()), id: \.element.id) { index, subpost in
                                 SubpostRowView(
@@ -1739,6 +1750,62 @@ private struct SubpostListSheet: View {
         likeTasks.values.forEach { $0.cancel() }
         likeTasks.removeAll()
         updatingLikeIDs.removeAll()
+    }
+}
+
+enum SubpostDetailSectionLayout {
+    static let separatorHeight: CGFloat = TiebaPureTheme.Spacing.sm
+    static let headerVerticalPadding: CGFloat = TiebaPureTheme.Spacing.xs
+
+    static func accessibilityLabel(title: String, count: Int?) -> String {
+        guard let count else { return title }
+        return "\(title)，共\(max(count, 0))条"
+    }
+}
+
+private struct SubpostSectionHeader: View {
+    let title: String
+    var count: Int?
+    let accessibilityIdentifier: String
+
+    init(
+        title: String,
+        count: Int? = nil,
+        accessibilityIdentifier: String
+    ) {
+        self.title = title
+        self.count = count
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: TiebaPureTheme.Spacing.xxs) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+
+            if let count {
+                Text("\(max(count, 0))条")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            Spacer(minLength: TiebaPureTheme.Spacing.xs)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, TiebaPureTheme.Spacing.md)
+        .padding(.vertical, SubpostDetailSectionLayout.headerVerticalPadding)
+        .background(Color(uiColor: .systemBackground))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            SubpostDetailSectionLayout.accessibilityLabel(title: title, count: count)
+        )
+        .accessibilityAddTraits(.isHeader)
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -2480,6 +2480,27 @@ final class TiebaPureSmokeTests: XCTestCase {
         XCTAssertEqual(SubpostSheetTitle.text(floor: 2, count: 10), "2楼的回复(10条)")
     }
 
+    func testSubpostDetailUsesDistinctCompactSections() {
+        XCTAssertEqual(SubpostDetailSectionLayout.separatorHeight, 12)
+        XCTAssertEqual(SubpostDetailSectionLayout.headerVerticalPadding, 8)
+        XCTAssertGreaterThan(
+            SubpostDetailSectionLayout.separatorHeight,
+            ThreadReplyLayout.sectionSeparatorHeight
+        )
+        XCTAssertEqual(
+            SubpostDetailSectionLayout.accessibilityLabel(title: "层主内容", count: nil),
+            "层主内容"
+        )
+        XCTAssertEqual(
+            SubpostDetailSectionLayout.accessibilityLabel(title: "楼中楼回复", count: 4),
+            "楼中楼回复，共4条"
+        )
+        XCTAssertEqual(
+            SubpostDetailSectionLayout.accessibilityLabel(title: "楼中楼回复", count: -1),
+            "楼中楼回复，共0条"
+        )
+    }
+
     func testSubpostRightSwipeDismissPolicyAcceptsOnlyIntentionalRightSwipes() {
         XCTAssertTrue(SubpostRightSwipeDismissPolicy.shouldBegin(
             translation: CGSize(width: 32, height: 8)

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -1994,6 +1994,38 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["被回复用户"].waitForExistence(timeout: 5))
     }
 
+    func testExpandedSubpostSeparatesParentAndReplySections() {
+        let app = launchApp(scenario: "subpostReference")
+        openFirstThread(in: app)
+
+        XCTAssertTrue(waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 20))
+        app.buttons["查看全部4条回复"].tap()
+        XCTAssertTrue(app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8))
+
+        let parentHeader = app.descendants(matching: .any)["subpost-parent-section-header"]
+        let parentMetadata = app.descendants(matching: .any)["thread-subpost-parent-metadata"]
+        let repliesHeader = app.descendants(matching: .any)["subpost-replies-section-header"]
+        let firstReply = app.descendants(matching: .any)
+            .matching(identifier: "thread-subpost-text")
+            .firstMatch
+
+        XCTAssertTrue(parentHeader.waitForExistence(timeout: 5))
+        XCTAssertEqual(parentHeader.label, "层主内容")
+        XCTAssertTrue(parentMetadata.waitForExistence(timeout: 5))
+        XCTAssertTrue(repliesHeader.waitForExistence(timeout: 5))
+        XCTAssertEqual(repliesHeader.label, "楼中楼回复，共4条")
+        XCTAssertTrue(firstReply.waitForExistence(timeout: 5))
+
+        XCTAssertLessThan(parentHeader.frame.maxY, parentMetadata.frame.minY)
+        XCTAssertLessThan(parentMetadata.frame.maxY, repliesHeader.frame.minY)
+        XCTAssertGreaterThanOrEqual(
+            repliesHeader.frame.minY - parentMetadata.frame.maxY,
+            12
+        )
+        XCTAssertLessThan(repliesHeader.frame.maxY, firstReply.frame.minY)
+        attachScreenshot(named: "fixture-expanded-subpost-section-boundary")
+    }
+
     func testSubpostUserProfileRightSwipeReturnsOnlyToSubpostSheet() {
         let app = launchApp(scenario: "subpostReference")
         openFirstThread(in: app)
@@ -2073,10 +2105,14 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(navigationBar.exists, "楼中楼下滑只能滚动内容，不应退出")
 
         let restingFrame = navigationBar.frame
-        let partialSwipeStart = app.coordinate(
+        let neutralSectionHeader = app.descendants(matching: .any)[
+            "subpost-parent-section-header"
+        ]
+        XCTAssertTrue(neutralSectionHeader.waitForExistence(timeout: 5))
+        let partialSwipeStart = neutralSectionHeader.coordinate(
             withNormalizedOffset: CGVector(dx: 0.35, dy: 0.45)
         )
-        let partialSwipeEnd = app.coordinate(
+        let partialSwipeEnd = neutralSectionHeader.coordinate(
             withNormalizedOffset: CGVector(dx: 0.49, dy: 0.45)
         )
         partialSwipeStart.press(

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.2.4
-        CURRENT_PROJECT_VERSION: 14
+        MARKETING_VERSION: 1.2.5
+        CURRENT_PROJECT_VERSION: 15
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容
- 为楼中楼详细页增加‘层主内容’与‘楼中楼回复’分区标题
- 使用 12pt 分隔带和列表分割线强化内容层级
- 补充动态字体、深色模式和中文无障碍语义
- 版本更新至 1.2.5 (15)

## 验证
- 单元测试 308/308 通过
- 楼中楼相关 UI 测试通过
- iPhone 17、iPhone SE 3、iPad Pro 11-inch M5 布局验证通过
- 深色模式与 Accessibility XXXL 验证通过
- unsigned IPA 结构与隐私清单校验通过