### PR TITLE
fix: 简化楼中楼内容分隔

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 下载
 
-当前 `main` 源码版本为 `1.2.5`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
+当前 `main` 源码版本为 `1.2.6`；[Releases](https://github.com/infinityf4p/TiebaPure-iOS/releases/latest) 提供已发布版本的 **未签名** IPA，功能可能落后于 `main`，安装前需要使用自己的证书重新签名。
 
 ## 构建
 

--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1695,13 +1695,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1747,13 +1747,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.5;
+				MARKETING_VERSION = 1.2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Core/UI/TiebaPureTheme.swift
+++ b/TiebaPure/Core/UI/TiebaPureTheme.swift
@@ -37,6 +37,7 @@ enum TiebaPureTheme {
         static let primaryAccent = Color(uiColor: .systemBlue)
         static let videoAccent = Color(red: 0.96, green: 0.62, blue: 0.04)
         static let readerGroupedBackground = Color(uiColor: .systemGroupedBackground)
+        static let readerSectionBand = Color(uiColor: .secondarySystemBackground)
         static let readerSecondarySurface = Color(uiColor: .secondarySystemGroupedBackground)
         static let readerTertiarySurface = Color(uiColor: .tertiarySystemGroupedBackground)
         static let readerSeparator = Color(uiColor: .separator)

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -1381,11 +1381,6 @@ private struct SubpostListSheet: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 0) {
-                            SubpostSectionHeader(
-                                title: "层主内容",
-                                accessibilityIdentifier: "subpost-parent-section-header"
-                            )
-
                             ReaderCard(showsDivider: false) {
                                 VStack(alignment: .leading, spacing: ThreadReplyLayout.headerContentSpacing) {
                                     UserHeaderView(
@@ -1420,16 +1415,7 @@ private struct SubpostListSheet: View {
                                 }
                             }
 
-                            Rectangle()
-                                .fill(TiebaPureTheme.ColorToken.readerGroupedBackground)
-                                .frame(height: SubpostDetailSectionLayout.separatorHeight)
-                                .accessibilityHidden(true)
-
-                            SubpostSectionHeader(
-                                title: "楼中楼回复",
-                                count: max(post.subpostCount, subposts.count),
-                                accessibilityIdentifier: "subpost-replies-section-header"
-                            )
+                            SubpostSectionSeparator()
 
                             ForEach(Array(subposts.enumerated()), id: \.element.id) { index, subpost in
                                 SubpostRowView(
@@ -1755,57 +1741,21 @@ private struct SubpostListSheet: View {
 
 enum SubpostDetailSectionLayout {
     static let separatorHeight: CGFloat = TiebaPureTheme.Spacing.sm
-    static let headerVerticalPadding: CGFloat = TiebaPureTheme.Spacing.xs
-
-    static func accessibilityLabel(title: String, count: Int?) -> String {
-        guard let count else { return title }
-        return "\(title)，共\(max(count, 0))条"
-    }
 }
 
-private struct SubpostSectionHeader: View {
-    let title: String
-    var count: Int?
-    let accessibilityIdentifier: String
-
-    init(
-        title: String,
-        count: Int? = nil,
-        accessibilityIdentifier: String
-    ) {
-        self.title = title
-        self.count = count
-        self.accessibilityIdentifier = accessibilityIdentifier
-    }
-
+private struct SubpostSectionSeparator: View {
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: TiebaPureTheme.Spacing.xxs) {
-            Text(title)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+        ZStack {
+            TiebaPureTheme.ColorToken.readerSectionBand
 
-            if let count {
-                Text("\(max(count, 0))条")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
+            VStack(spacing: 0) {
+                Divider()
+                Spacer(minLength: 0)
+                Divider()
             }
-
-            Spacer(minLength: TiebaPureTheme.Spacing.xs)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, TiebaPureTheme.Spacing.md)
-        .padding(.vertical, SubpostDetailSectionLayout.headerVerticalPadding)
-        .background(Color(uiColor: .systemBackground))
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(
-            SubpostDetailSectionLayout.accessibilityLabel(title: title, count: count)
-        )
-        .accessibilityAddTraits(.isHeader)
-        .accessibilityIdentifier(accessibilityIdentifier)
+        .frame(height: SubpostDetailSectionLayout.separatorHeight)
+        .accessibilityHidden(true)
     }
 }
 

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -2480,24 +2480,11 @@ final class TiebaPureSmokeTests: XCTestCase {
         XCTAssertEqual(SubpostSheetTitle.text(floor: 2, count: 10), "2楼的回复(10条)")
     }
 
-    func testSubpostDetailUsesDistinctCompactSections() {
+    func testSubpostDetailUsesCompactLabelFreeSeparator() {
         XCTAssertEqual(SubpostDetailSectionLayout.separatorHeight, 12)
-        XCTAssertEqual(SubpostDetailSectionLayout.headerVerticalPadding, 8)
         XCTAssertGreaterThan(
             SubpostDetailSectionLayout.separatorHeight,
             ThreadReplyLayout.sectionSeparatorHeight
-        )
-        XCTAssertEqual(
-            SubpostDetailSectionLayout.accessibilityLabel(title: "层主内容", count: nil),
-            "层主内容"
-        )
-        XCTAssertEqual(
-            SubpostDetailSectionLayout.accessibilityLabel(title: "楼中楼回复", count: 4),
-            "楼中楼回复，共4条"
-        )
-        XCTAssertEqual(
-            SubpostDetailSectionLayout.accessibilityLabel(title: "楼中楼回复", count: -1),
-            "楼中楼回复，共0条"
         )
     }
 

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -1994,7 +1994,7 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["被回复用户"].waitForExistence(timeout: 5))
     }
 
-    func testExpandedSubpostSeparatesParentAndReplySections() {
+    func testExpandedSubpostUsesLabelFreeSectionDivider() {
         let app = launchApp(scenario: "subpostReference")
         openFirstThread(in: app)
 
@@ -2002,28 +2002,22 @@ final class TiebaPureUITests: XCTestCase {
         app.buttons["查看全部4条回复"].tap()
         XCTAssertTrue(app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8))
 
-        let parentHeader = app.descendants(matching: .any)["subpost-parent-section-header"]
         let parentMetadata = app.descendants(matching: .any)["thread-subpost-parent-metadata"]
-        let repliesHeader = app.descendants(matching: .any)["subpost-replies-section-header"]
         let firstReply = app.descendants(matching: .any)
             .matching(identifier: "thread-subpost-text")
             .firstMatch
 
-        XCTAssertTrue(parentHeader.waitForExistence(timeout: 5))
-        XCTAssertEqual(parentHeader.label, "层主内容")
         XCTAssertTrue(parentMetadata.waitForExistence(timeout: 5))
-        XCTAssertTrue(repliesHeader.waitForExistence(timeout: 5))
-        XCTAssertEqual(repliesHeader.label, "楼中楼回复，共4条")
         XCTAssertTrue(firstReply.waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["层主内容"].exists)
+        XCTAssertFalse(app.staticTexts["楼中楼回复"].exists)
 
-        XCTAssertLessThan(parentHeader.frame.maxY, parentMetadata.frame.minY)
-        XCTAssertLessThan(parentMetadata.frame.maxY, repliesHeader.frame.minY)
+        XCTAssertLessThan(parentMetadata.frame.maxY, firstReply.frame.minY)
         XCTAssertGreaterThanOrEqual(
-            repliesHeader.frame.minY - parentMetadata.frame.maxY,
+            firstReply.frame.minY - parentMetadata.frame.maxY,
             12
         )
-        XCTAssertLessThan(repliesHeader.frame.maxY, firstReply.frame.minY)
-        attachScreenshot(named: "fixture-expanded-subpost-section-boundary")
+        attachScreenshot(named: "fixture-expanded-subpost-label-free-divider")
     }
 
     func testSubpostUserProfileRightSwipeReturnsOnlyToSubpostSheet() {
@@ -2105,16 +2099,12 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(navigationBar.exists, "楼中楼下滑只能滚动内容，不应退出")
 
         let restingFrame = navigationBar.frame
-        let neutralSectionHeader = app.descendants(matching: .any)[
-            "subpost-parent-section-header"
-        ]
-        XCTAssertTrue(neutralSectionHeader.waitForExistence(timeout: 5))
-        let partialSwipeStart = neutralSectionHeader.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.35, dy: 0.45)
+        let parentMetadata = app.descendants(matching: .any)["thread-subpost-parent-metadata"]
+        XCTAssertTrue(parentMetadata.waitForExistence(timeout: 5))
+        let partialSwipeStart = parentMetadata.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)
         )
-        let partialSwipeEnd = neutralSectionHeader.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.49, dy: 0.45)
-        )
+        let partialSwipeEnd = partialSwipeStart.withOffset(CGVector(dx: 56, dy: 0))
         partialSwipeStart.press(
             forDuration: 0.05,
             thenDragTo: partialSwipeEnd,

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.2.5
-        CURRENT_PROJECT_VERSION: 15
+        MARKETING_VERSION: 1.2.6
+        CURRENT_PROJECT_VERSION: 16
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容
- 移除楼中楼详细页的‘层主内容’和‘楼中楼回复’标题
- 使用 12pt 自适应分隔带与上下系统细线区分内容
- 分隔带支持浅色、深色和增强对比度，且不产生额外读屏内容
- 版本更新至 1.2.6 (16)

## 验证
- 完整单元测试 308/308 通过
- 无文字分隔、楼中楼右划和长文本 UI 回归通过
- iPhone 17、iPhone SE 3、iPad Pro 11-inch M5 通过
- 深色模式与 Accessibility XXXL 通过
- unsigned IPA 结构、隐私清单和版本校验通过