### PR TITLE
feat: add reading preferences

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -124,8 +124,10 @@
 		DE64CDA4FA60F57188F7BC53 /* UserProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */; };
 		DEA70B990FBB4F0B3A27998B /* SearchRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DFFE894245E0C72DB94FFD /* SearchRoute.swift */; };
 		DEF7E4F5C3BB5C3AC25E89EF /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C482CF17BA5520B13F1B03 /* AppAppearance.swift */; };
+		E1835BAE94DEB0B7D30F0B13 /* ReadingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638DEF254549D0D4DE625487 /* ReadingPreferences.swift */; };
 		E3CF1C9A62133316FF6D93E2 /* UserProfileMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F7C671CDA66E5F18CEC24 /* UserProfileMapper.swift */; };
 		E4BC7D1B10FF88D762725986 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E2287E1195B4261B0B88E8 /* SettingsView.swift */; };
+		E6FCA5689969E1EE7020CF44 /* ReadingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432F97822473B7D42DB148EC /* ReadingSettingsView.swift */; };
 		EAADABB00751D25DB084C26D /* TiebaHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF65BFE5160CFC6F1F12CEF /* TiebaHTTPClient.swift */; };
 		ECDE960EDA7E9E0E186B2D3C /* ExternalRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFA01B546626F59DF261F1 /* ExternalRoute.swift */; };
 		ED0AA7A2777C1AD628FF19AA /* TiebaContentFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CA90EA6BEF04EEA9AD1C3 /* TiebaContentFilter.swift */; };
@@ -220,6 +222,7 @@
 		41F406332470AF7C30B532A5 /* TiebaPureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPureApp.swift; sourceTree = "<group>"; };
 		42BC57D4AB4F3F67B48877D9 /* ThreadFavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadFavoritesView.swift; sourceTree = "<group>"; };
 		431A697F330BBEC18E2252D0 /* ReaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCard.swift; sourceTree = "<group>"; };
+		432F97822473B7D42DB148EC /* ReadingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSettingsView.swift; sourceTree = "<group>"; };
 		44C549F603F6A8B5988B0B31 /* BrowsingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingHistory.swift; sourceTree = "<group>"; };
 		475452DA26606C9EEF2982D2 /* ReaderStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderStateView.swift; sourceTree = "<group>"; };
 		47A8570B3E26BDD92BF4524C /* TiebaMessageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaMessageAPI.swift; sourceTree = "<group>"; };
@@ -238,6 +241,7 @@
 		5E7B54C9EC311DDB57FEBB4F /* ThreadAuthorBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadAuthorBadgeTests.swift; sourceTree = "<group>"; };
 		5E92E90BB801373B85685DDD /* Forum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Forum.swift; sourceTree = "<group>"; };
 		62D2754EBACAEEB97F2E3E7E /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
+		638DEF254549D0D4DE625487 /* ReadingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferences.swift; sourceTree = "<group>"; };
 		63DFA01B546626F59DF261F1 /* ExternalRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalRoute.swift; sourceTree = "<group>"; };
 		6443B9D2D0368D0B870565A7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		674313EBDA3BABF79049EF20 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
@@ -452,6 +456,7 @@
 				93E0B943190782C7374C3690 /* ForumThreadCategory.swift */,
 				8B097E875FE8B825D77AD05F /* LocalThreadLibrary.swift */,
 				CD2C30123EFF90A5F9BEE7C2 /* Post.swift */,
+				638DEF254549D0D4DE625487 /* ReadingPreferences.swift */,
 				FDE02417BF13C2E0A1D7824E /* RecentForum.swift */,
 				16DDB351392A69BC42810B9E /* SearchResult.swift */,
 				81C9E000B6A70DAE855C1F80 /* ThreadSummary.swift */,
@@ -633,6 +638,7 @@
 			isa = PBXGroup;
 			children = (
 				582A83F679EC3456CD6D08E4 /* BlocklistSettingsView.swift */,
+				432F97822473B7D42DB148EC /* ReadingSettingsView.swift */,
 				10E2287E1195B4261B0B88E8 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -920,6 +926,8 @@
 				22C326EADD75278D51629E56 /* ReaderCard.swift in Sources */,
 				143BCEEE525C98950A8466D8 /* ReaderSplitLayout.swift in Sources */,
 				BF3E65570A0501F384F8C0BA /* ReaderStateView.swift in Sources */,
+				E1835BAE94DEB0B7D30F0B13 /* ReadingPreferences.swift in Sources */,
+				E6FCA5689969E1EE7020CF44 /* ReadingSettingsView.swift in Sources */,
 				D0EB13806B12EBFE42C8D71B /* RecentForum.swift in Sources */,
 				A4FCD6601BAA005BF0F264D0 /* RootView.swift in Sources */,
 				C02D20CEC3FEDED464983D96 /* SafariActionPayload.swift in Sources */,
@@ -1087,13 +1095,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1104,14 +1112,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1157,14 +1165,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1177,13 +1185,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/App/TiebaPureApp.swift
+++ b/TiebaPure/App/TiebaPureApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct TiebaPureApp: App {
     @StateObject private var environment = AppEnvironment.live()
     @StateObject private var appearanceStore = AppAppearanceStore.live()
+    @StateObject private var readingPreferencesStore = ReadingPreferencesStore.live()
 
     var body: some Scene {
         WindowGroup {
@@ -12,6 +13,8 @@ struct TiebaPureApp: App {
 #if DEBUG
                 if ProcessInfo.processInfo.arguments.contains("UITEST_REMOTE_IMAGE_REUSE") {
                     RemoteImageReuseUITestHost()
+                } else if ProcessInfo.processInfo.arguments.contains("UITEST_READER_MEDIA_POLICY") {
+                    ReaderMediaPolicyUITestHost()
                 } else if ProcessInfo.processInfo.arguments.contains("UITEST_IMAGE_VIEWER") {
                     ImageViewerUITestHost()
                 } else {
@@ -23,6 +26,8 @@ struct TiebaPureApp: App {
             }
             .environmentObject(environment)
             .environmentObject(appearanceStore)
+            .environmentObject(readingPreferencesStore)
+            .environment(\.readingPreferences, readingPreferencesStore.preferences)
             .preferredColorScheme(appearanceStore.selection.preferredColorScheme)
         }
     }

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -91,6 +91,12 @@ struct FixtureTiebaAPI: TiebaAPIService {
             copy.forumName = forumName
             return copy
         }
+        if scenario == .imageGesture {
+            fixtureThreads = threadsWithSyntheticMediaURLs(
+                fixtureThreads,
+                pathPrefix: "forum"
+            )
+        }
 
         if scenario == .emptyThenSuccess {
             let requestNumber = await state.nextForumPageOneRequestNumber()
@@ -430,21 +436,7 @@ struct FixtureTiebaAPI: TiebaAPIService {
     private var personalizedFixtureThreads: [ThreadSummary] {
         switch scenario {
         case .imageGesture:
-            return Self.threads.map { thread in
-                var thread = thread
-                thread.blocks = thread.blocks.enumerated().map { blockIndex, block in
-                    guard case let .image(value) = block else { return block }
-                    var image = value
-                    image.thumbnailURL = URL(string:
-                        "https://fixture-success.invalid/home-\(thread.id)-\(blockIndex)-thumbnail.png"
-                    )
-                    image.originalURL = URL(string:
-                        "https://fixture-success.invalid/home-\(thread.id)-\(blockIndex)-original.png"
-                    )
-                    return .image(image)
-                }
-                return thread
-            }
+            return threadsWithSyntheticMediaURLs(Self.threads, pathPrefix: "home")
         case .forumIDOnly:
             var idOnly = Self.threads[0]
             idOnly.id = 1801
@@ -458,6 +450,27 @@ struct FixtureTiebaAPI: TiebaAPIService {
             return [idOnly, sameForum, Self.threads[1]]
         default:
             return Self.threads
+        }
+    }
+
+    private func threadsWithSyntheticMediaURLs(
+        _ threads: [ThreadSummary],
+        pathPrefix: String
+    ) -> [ThreadSummary] {
+        threads.map { thread in
+            var thread = thread
+            thread.blocks = thread.blocks.enumerated().map { blockIndex, block in
+                guard case let .image(value) = block else { return block }
+                var image = value
+                image.thumbnailURL = URL(string:
+                    "https://fixture-success.invalid/\(pathPrefix)-\(thread.id)-\(blockIndex)-thumbnail.png"
+                )
+                image.originalURL = URL(string:
+                    "https://fixture-success.invalid/\(pathPrefix)-\(thread.id)-\(blockIndex)-original.png"
+                )
+                return .image(image)
+            }
+            return thread
         }
     }
 

--- a/TiebaPure/Core/UI/AvatarView.swift
+++ b/TiebaPure/Core/UI/AvatarView.swift
@@ -399,7 +399,7 @@ private final class TiebaRemoteImageModel: ObservableObject {
     func load(urls: [URL], force: Bool = false) {
         let key = urls.map(\.absoluteString).joined(separator: "|")
         let sourceChanged = key != sourceKey
-        guard force || sourceChanged || isFailed else { return }
+        guard force || sourceChanged || isEmpty || isFailed else { return }
         sourceKey = key
         task?.cancel()
 
@@ -424,12 +424,30 @@ private final class TiebaRemoteImageModel: ObservableObject {
         }
     }
 
+    func suspendAutomaticLoad(urls: [URL]) {
+        let key = urls.map(\.absoluteString).joined(separator: "|")
+        if sourceKey != key {
+            task?.cancel()
+            sourceKey = key
+            phase = .empty
+            return
+        }
+        guard case .loading = phase else { return }
+        task?.cancel()
+        phase = .empty
+    }
+
     func represents(urls: [URL]) -> Bool {
         sourceKey == urls.map(\.absoluteString).joined(separator: "|")
     }
 
     private var isFailed: Bool {
         if case .failure = phase { return true }
+        return false
+    }
+
+    private var isEmpty: Bool {
+        if case .empty = phase { return true }
         return false
     }
 
@@ -461,6 +479,7 @@ struct TiebaRemoteImage: View {
     var retryTrigger = 0
     var showsRetryButton = true
     var showsResolvedImage = true
+    var loadsAutomatically = true
     var onLoadStateChange: ((TiebaRemoteImageLoadState) -> Void)?
     var onImageResolved: ((UIImage) -> Void)?
     var onImageLayoutResolved: ((UIImage, CGRect) -> Void)?
@@ -476,6 +495,7 @@ struct TiebaRemoteImage: View {
         retryTrigger: Int = 0,
         showsRetryButton: Bool = true,
         showsResolvedImage: Bool = true,
+        loadsAutomatically: Bool = true,
         onLoadStateChange: ((TiebaRemoteImageLoadState) -> Void)? = nil,
         onImageResolved: ((UIImage) -> Void)? = nil,
         onImageLayoutResolved: ((UIImage, CGRect) -> Void)? = nil,
@@ -487,6 +507,7 @@ struct TiebaRemoteImage: View {
         self.retryTrigger = retryTrigger
         self.showsRetryButton = showsRetryButton
         self.showsResolvedImage = showsResolvedImage
+        self.loadsAutomatically = loadsAutomatically
         self.onLoadStateChange = onLoadStateChange
         self.onImageResolved = onImageResolved
         self.onImageLayoutResolved = onImageLayoutResolved
@@ -524,7 +545,14 @@ struct TiebaRemoteImage: View {
                 } else {
                     Color.clear
                 }
-            case .empty, .loading:
+            case .empty:
+                if showsProgress, loadsAutomatically {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Color.clear
+                }
+            case .loading:
                 if showsProgress {
                     ProgressView()
                         .controlSize(.small)
@@ -547,7 +575,11 @@ struct TiebaRemoteImage: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task(id: "\(urls.map(\.absoluteString).joined(separator: "|"))#\(retryTrigger)") {
+        .task(id: "\(urls.map(\.absoluteString).joined(separator: "|"))#\(retryTrigger)#\(loadsAutomatically)") {
+            guard loadsAutomatically else {
+                model.suspendAutomaticLoad(urls: urls)
+                return
+            }
             model.load(urls: urls, force: retryTrigger > 0)
         }
         .onReceive(model.$phase) { phase in
@@ -587,11 +619,24 @@ struct TiebaRemoteImage: View {
 struct RemoteImageReuseUITestHost: View {
     @State private var selectedSource = "A"
     @State private var resolvedSource = ""
+    @State private var manualAuthorization: String?
+
+    private var usesManualLoading: Bool {
+        ProcessInfo.processInfo.arguments.contains("UITEST_REMOTE_IMAGE_REUSE_MANUAL")
+    }
 
     private var sourceURL: URL? {
         URL(string: selectedSource == "A"
             ? "https://fixture-success.invalid/reuse-a.png"
             : "https://fixture-success.invalid/reuse-b.png")
+    }
+
+    private var sourceIdentity: String {
+        sourceURL?.absoluteString ?? selectedSource
+    }
+
+    private var allowsLoading: Bool {
+        usesManualLoading == false || manualAuthorization == sourceIdentity
     }
 
     var body: some View {
@@ -600,6 +645,7 @@ struct RemoteImageReuseUITestHost: View {
                 primaryURL: sourceURL,
                 contentMode: .fill,
                 showsProgress: true,
+                loadsAutomatically: allowsLoading,
                 onLoadStateChange: { state in
                     if state == .success {
                         resolvedSource = selectedSource
@@ -612,8 +658,16 @@ struct RemoteImageReuseUITestHost: View {
             .accessibilityIdentifier("remote-image-reuse-surface")
             .accessibilityLabel("复用图片 \(selectedSource)")
 
-            Text(resolvedSource.isEmpty ? "正在加载" : "已加载 \(resolvedSource)")
+            Text(stateText)
                 .accessibilityIdentifier("remote-image-reuse-state")
+
+            if usesManualLoading {
+                Button("加载当前图片") {
+                    manualAuthorization = sourceIdentity
+                }
+                .disabled(resolvedSource == selectedSource)
+                .accessibilityIdentifier("remote-image-reuse-load")
+            }
 
             Button("切换到图片 B") {
                 selectedSource = "B"
@@ -623,6 +677,13 @@ struct RemoteImageReuseUITestHost: View {
             .accessibilityIdentifier("remote-image-reuse-switch")
         }
         .padding()
+    }
+
+    private var stateText: String {
+        if resolvedSource.isEmpty == false {
+            return "已加载 \(resolvedSource)"
+        }
+        return allowsLoading ? "正在加载" : "等待加载 \(selectedSource)"
     }
 }
 #endif

--- a/TiebaPure/Core/UI/MediaGridView.swift
+++ b/TiebaPure/Core/UI/MediaGridView.swift
@@ -48,6 +48,8 @@ struct MediaGridView: View {
     let totalItemCount: Int
     let usesCompactFeedLayout: Bool
     let isInteractive: Bool
+    let destinationAccessibilityLabel: String?
+    let destinationAccessibilityHint: String?
     let onTap: (ReaderMediaItem, CGRect?, UIImage?, ImagePreviewSourceAnchor?) -> Void
 
     init(
@@ -56,6 +58,8 @@ struct MediaGridView: View {
         totalItemCount: Int? = nil,
         usesCompactFeedLayout: Bool = false,
         isInteractive: Bool = true,
+        destinationAccessibilityLabel: String? = nil,
+        destinationAccessibilityHint: String? = nil,
         onTap: @escaping (ReaderMediaItem, CGRect?, UIImage?, ImagePreviewSourceAnchor?) -> Void = { _, _, _, _ in }
     ) {
         self.items = items
@@ -63,6 +67,8 @@ struct MediaGridView: View {
         self.totalItemCount = max(totalItemCount ?? items.count, items.count)
         self.usesCompactFeedLayout = usesCompactFeedLayout
         self.isInteractive = isInteractive
+        self.destinationAccessibilityLabel = destinationAccessibilityLabel
+        self.destinationAccessibilityHint = destinationAccessibilityHint
         self.onTap = onTap
     }
 
@@ -126,6 +132,8 @@ struct MediaGridView: View {
                     aspectRatioOverride: usesCompactFeedLayout ? nil : thumbnailAspectRatio,
                     fillsAvailableSpace: usesCompactFeedLayout,
                     totalItemCount: totalItemCount,
+                    destinationAccessibilityLabel: destinationAccessibilityLabel,
+                    destinationAccessibilityHint: destinationAccessibilityHint,
                     onTap: onTap
                 )
             } else {
@@ -135,6 +143,9 @@ struct MediaGridView: View {
                     aspectRatioOverride: usesCompactFeedLayout ? nil : thumbnailAspectRatio,
                     fillsAvailableSpace: usesCompactFeedLayout,
                     retryTrigger: 0,
+                    isManualLoadAuthorized: false,
+                    explicitOriginalAuthorization: nil,
+                    showsManualLoadIndicator: false,
                     onLoadStateChange: { _ in }
                 )
                 .accessibilityHidden(true)
@@ -166,15 +177,21 @@ struct MediaGridView: View {
 }
 
 private struct MediaItemButton: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let item: ReaderMediaItem
     let maxHeight: CGFloat?
     let aspectRatioOverride: CGFloat?
     let fillsAvailableSpace: Bool
     let totalItemCount: Int
+    let destinationAccessibilityLabel: String?
+    let destinationAccessibilityHint: String?
     let onTap: (ReaderMediaItem, CGRect?, UIImage?, ImagePreviewSourceAnchor?) -> Void
 
     @State private var loadState: TiebaRemoteImageLoadState = .empty
     @State private var retryTrigger = 0
+    @State private var manualLoadAuthorization: String?
+    @State private var explicitFallbackAuthorization: String?
     @StateObject private var previewSource: ImagePreviewSourceAnchor
 
     init(
@@ -183,6 +200,8 @@ private struct MediaItemButton: View {
         aspectRatioOverride: CGFloat?,
         fillsAvailableSpace: Bool,
         totalItemCount: Int,
+        destinationAccessibilityLabel: String?,
+        destinationAccessibilityHint: String?,
         onTap: @escaping (ReaderMediaItem, CGRect?, UIImage?, ImagePreviewSourceAnchor?) -> Void
     ) {
         self.item = item
@@ -190,6 +209,8 @@ private struct MediaItemButton: View {
         self.aspectRatioOverride = aspectRatioOverride
         self.fillsAvailableSpace = fillsAvailableSpace
         self.totalItemCount = totalItemCount
+        self.destinationAccessibilityLabel = destinationAccessibilityLabel
+        self.destinationAccessibilityHint = destinationAccessibilityHint
         self.onTap = onTap
         _previewSource = StateObject(
             wrappedValue: ImagePreviewSourceAnchor(
@@ -206,6 +227,9 @@ private struct MediaItemButton: View {
                 aspectRatioOverride: aspectRatioOverride,
                 fillsAvailableSpace: fillsAvailableSpace,
                 retryTrigger: retryTrigger,
+                isManualLoadAuthorized: isManualLoadAuthorized,
+                explicitOriginalAuthorization: explicitFallbackAuthorization,
+                showsManualLoadIndicator: true,
                 previewSource: item.kind == .image ? previewSource : nil,
                 onTransitionTap: item.kind == .image ? activate : nil,
                 onLoadStateChange: { loadState = $0 },
@@ -225,39 +249,143 @@ private struct MediaItemButton: View {
         ))
         .minTouchTarget()
         .accessibilityIdentifier("media-item-\(item.id)")
-        .accessibilityLabel(loadState == .failure
-            ? "\(item.accessibilityLabel)加载失败，重新加载，共\(totalItemCount)项媒体"
-            : "\(item.accessibilityLabel)，共\(totalItemCount)项媒体")
-        .accessibilityHint(loadState == .failure ? "重新请求当前媒体缩略图" : "打开媒体")
+        .accessibilityLabel(mediaAccessibilityLabel)
+        .accessibilityHint(mediaAccessibilityHint)
     }
 
     private func activate() {
         if loadState == .failure {
+            if item.kind == .video {
+                openDestination()
+                return
+            }
+            if shouldOfferExplicitFallback {
+                explicitFallbackAuthorization = item.previewSourceIdentity
+            }
             retryTrigger += 1
+        } else if item.thumbnailURL != nil,
+                  loadState == .empty,
+                  mediaRequestPolicy.loadsAutomatically == false {
+            if isManualLoadAuthorized == false {
+                manualLoadAuthorization = item.previewSourceIdentity
+            }
+            return
+        } else if loadState == .loading,
+                  ReaderMediaActivationPolicy.blocksWhileLoading(
+                    requestPolicy: mediaRequestPolicy
+                  ) {
+            return
         } else {
-            onTap(
-                item,
-                ImagePreviewSourceRegistry.shared
-                    .frameInWindow(for: item.previewSourceIdentity)
-                    ?? previewSource.frameInWindow,
-                previewSource.image,
-                previewSource
-            )
+            openDestination()
         }
+    }
+
+    private func openDestination() {
+        onTap(
+            item,
+            ImagePreviewSourceRegistry.shared
+                .frameInWindow(for: item.previewSourceIdentity)
+                ?? previewSource.frameInWindow,
+            previewSource.image,
+            previewSource
+        )
+    }
+
+    private var mediaAccessibilityLabel: String {
+        let base: String
+        if loadState == .failure {
+            if item.kind == .video {
+                base = "\(destinationAccessibilityLabel ?? item.accessibilityLabel)，封面加载失败"
+            } else {
+                base = shouldOfferExplicitFallback
+                ? "\(item.accessibilityLabel)预览加载失败，加载原图"
+                : "\(item.accessibilityLabel)加载失败，重新加载"
+            }
+        } else if item.thumbnailURL != nil,
+                  loadState == .empty,
+                  mediaRequestPolicy.loadsAutomatically == false,
+                  isManualLoadAuthorized == false {
+            base = "加载\(item.accessibilityLabel)"
+        } else if loadState == .loading,
+                  ReaderMediaActivationPolicy.blocksWhileLoading(
+                    requestPolicy: mediaRequestPolicy
+                  ) {
+            base = "正在加载\(item.accessibilityLabel)"
+        } else {
+            base = destinationAccessibilityLabel ?? item.accessibilityLabel
+        }
+        return "\(base)，共\(totalItemCount)项媒体"
+    }
+
+    private var mediaAccessibilityHint: String {
+        if loadState == .failure {
+            if item.kind == .video {
+                return destinationAccessibilityHint ?? "打开媒体，封面加载失败不影响内容"
+            }
+            return shouldOfferExplicitFallback
+                ? "明确请求当前媒体原图"
+                : "重新请求当前媒体缩略图"
+        }
+        if item.thumbnailURL != nil,
+           loadState == .empty,
+           mediaRequestPolicy.loadsAutomatically == false,
+           isManualLoadAuthorized == false {
+            return "加载当前媒体缩略图"
+        }
+        if loadState == .loading,
+           ReaderMediaActivationPolicy.blocksWhileLoading(
+            requestPolicy: mediaRequestPolicy
+           ) {
+            return "请等待媒体缩略图加载完成"
+        }
+        return destinationAccessibilityHint ?? "打开媒体"
+    }
+
+    private var mediaRequestPolicy: ReaderMediaRequestPolicy {
+        ReaderMediaRequestPolicy.resolve(readingPreferences.mediaLoading)
+    }
+
+    private var isManualLoadAuthorized: Bool {
+        mediaRequestPolicy.allowsLoading(
+            sourceIdentity: item.previewSourceIdentity,
+            manualAuthorization: manualLoadAuthorization
+        )
+    }
+
+    private var hasExplicitOriginalAuthorization: Bool {
+        mediaRequestPolicy.allowsFallback(
+            sourceIdentity: item.previewSourceIdentity,
+            explicitAuthorization: explicitFallbackAuthorization
+        )
+    }
+
+    private var shouldOfferExplicitFallback: Bool {
+        guard readingPreferences.mediaLoading == .dataSaving,
+              hasExplicitOriginalAuthorization == false,
+              let originalURL = item.image?.originalURL else {
+            return false
+        }
+        return originalURL != item.thumbnailURL
     }
 }
 
 private struct MediaThumbnailView: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let item: ReaderMediaItem
     let maxHeight: CGFloat?
     let aspectRatioOverride: CGFloat?
     let fillsAvailableSpace: Bool
     let retryTrigger: Int
+    let isManualLoadAuthorized: Bool
+    let explicitOriginalAuthorization: String?
+    let showsManualLoadIndicator: Bool
     var previewSource: ImagePreviewSourceAnchor? = nil
     var onTransitionTap: (() -> Void)? = nil
     let onLoadStateChange: (TiebaRemoteImageLoadState) -> Void
     var onImageResolved: ((UIImage) -> Void)? = nil
     var onDebugImageObserverResolved: ((UIView, UIImage) -> Void)? = nil
+    @State private var internalLoadState: TiebaRemoteImageLoadState = .empty
 
     var body: some View {
         Group {
@@ -283,15 +411,17 @@ private struct MediaThumbnailView: View {
             Rectangle()
                 .fill(TiebaPureTheme.ColorToken.readerTertiarySurface)
 
-            if let thumbnailURL = item.thumbnailURL {
+            if item.thumbnailURL != nil {
                 TiebaRemoteImage(
-                    primaryURL: thumbnailURL,
-                    fallbackURL: item.image?.originalURL,
+                    primaryURL: requestSources.primaryURL,
+                    fallbackURL: requestSources.fallbackURL,
                     contentMode: .fill,
                     retryTrigger: retryTrigger,
                     showsRetryButton: false,
                     showsResolvedImage: previewSource == nil,
+                    loadsAutomatically: isManualLoadAuthorized,
                     onLoadStateChange: {
+                        internalLoadState = $0
                         onLoadStateChange($0)
                         if $0 != .success {
                             previewSource?.clearImage(
@@ -312,11 +442,18 @@ private struct MediaThumbnailView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .allowsHitTesting(false)
                 }
+
+                if showsManualLoadIndicator,
+                   requestPolicy.loadsAutomatically == false,
+                   isManualLoadAuthorized == false,
+                   internalLoadState == .empty {
+                    manualLoadIndicator
+                }
             } else {
                 placeholder
             }
 
-            if item.kind == .video {
+            if item.kind == .video, waitsForManualLoad == false {
                 Image(systemName: "play.circle.fill")
                     .font(.system(size: TiebaPureTheme.IconSize.play))
                     .foregroundStyle(.white)
@@ -331,6 +468,37 @@ private struct MediaThumbnailView: View {
             .font(.system(size: 28))
             .foregroundStyle(.secondary)
             .accessibilityHidden(true)
+    }
+
+    private var manualLoadIndicator: some View {
+        Image(systemName: "arrow.down.circle")
+            .font(.system(size: 28, weight: .medium))
+            .foregroundStyle(.secondary)
+            .frame(width: 44, height: 44)
+            .background(.regularMaterial, in: Circle())
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+
+    private var requestPolicy: ReaderMediaRequestPolicy {
+        ReaderMediaRequestPolicy.resolve(readingPreferences.mediaLoading)
+    }
+
+    private var requestSources: ReaderImageRequestSources {
+        ReaderImageRequestSourcePolicy.resolve(
+            previewURL: item.thumbnailURL,
+            originalURL: item.image?.originalURL,
+            requestPolicy: requestPolicy,
+            sourceIdentity: item.previewSourceIdentity,
+            explicitOriginalAuthorization: explicitOriginalAuthorization
+        )
+    }
+
+    private var waitsForManualLoad: Bool {
+        item.thumbnailURL != nil
+            && requestPolicy.loadsAutomatically == false
+            && isManualLoadAuthorized == false
+            && internalLoadState == .empty
     }
 }
 

--- a/TiebaPure/Domain/Models/ReadingPreferences.swift
+++ b/TiebaPure/Domain/Models/ReadingPreferences.swift
@@ -1,0 +1,433 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+enum ReaderFontSize: String, CaseIterable, Identifiable, Sendable {
+    case small
+    case standard
+    case large
+    case extraLarge
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .small:
+            return "较小"
+        case .standard:
+            return "标准"
+        case .large:
+            return "较大"
+        case .extraLarge:
+            return "特大"
+        }
+    }
+
+    var shortTitle: String {
+        switch self {
+        case .small:
+            return "小"
+        case .standard:
+            return "标准"
+        case .large:
+            return "大"
+        case .extraLarge:
+            return "特大"
+        }
+    }
+
+    var scale: CGFloat {
+        switch self {
+        case .small:
+            return 0.90
+        case .standard:
+            return 1
+        case .large:
+            return 1.12
+        case .extraLarge:
+            return 1.25
+        }
+    }
+}
+
+enum ReaderLineSpacing: String, CaseIterable, Identifiable, Sendable {
+    case compact
+    case standard
+    case relaxed
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .compact:
+            return "紧凑"
+        case .standard:
+            return "标准"
+        case .relaxed:
+            return "宽松"
+        }
+    }
+
+    fileprivate var multiplier: CGFloat {
+        switch self {
+        case .compact:
+            return 0.75
+        case .standard:
+            return 1
+        case .relaxed:
+            return 1.5
+        }
+    }
+}
+
+enum ReaderMediaLoadingPolicy: String, CaseIterable, Identifiable, Sendable {
+    case automatic
+    case dataSaving
+    case manual
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .automatic:
+            return "自动加载"
+        case .dataSaving:
+            return "节省流量"
+        case .manual:
+            return "手动加载"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .automatic:
+            return "自动加载媒体，失败时尝试备用地址"
+        case .dataSaving:
+            return "自动加载预览，不额外请求备用原图"
+        case .manual:
+            return "仅在点击后加载媒体"
+        }
+    }
+}
+
+struct ReadingPreferences: Equatable, Sendable {
+    var fontSize: ReaderFontSize
+    var lineSpacing: ReaderLineSpacing
+    var defaultReplySort: ThreadReplySort
+    var mediaLoading: ReaderMediaLoadingPolicy
+
+    static let `default` = ReadingPreferences(
+        fontSize: .standard,
+        lineSpacing: .standard,
+        defaultReplySort: .hot,
+        mediaLoading: .automatic
+    )
+}
+
+enum ReaderTextContext: Equatable, Sendable {
+    case body
+    case subpost
+}
+
+enum ReaderTypographyPolicy {
+    static func font(
+        textStyle: UIFont.TextStyle,
+        weight: UIFont.Weight = .regular,
+        fontSize: ReaderFontSize,
+        compatibleWith traitCollection: UITraitCollection? = nil
+    ) -> UIFont {
+        let referenceTraits = UITraitCollection(preferredContentSizeCategory: .large)
+        let referenceFont = UIFont.preferredFont(
+            forTextStyle: textStyle,
+            compatibleWith: referenceTraits
+        )
+        let descriptor = referenceFont.fontDescriptor.addingAttributes([
+            .traits: [UIFontDescriptor.TraitKey.weight: weight]
+        ])
+        let preferredFont = UIFont(
+            descriptor: descriptor,
+            size: referenceFont.pointSize * fontSize.scale
+        )
+        return UIFontMetrics(forTextStyle: textStyle).scaledFont(
+            for: preferredFont,
+            compatibleWith: traitCollection
+        )
+    }
+
+    static func lineSpacing(
+        _ preference: ReaderLineSpacing,
+        context: ReaderTextContext
+    ) -> CGFloat {
+        let standardSpacing: CGFloat = context == .subpost ? 2 : 4
+        return standardSpacing * preference.multiplier
+    }
+}
+
+struct ReaderMediaRequestPolicy: Equatable, Sendable {
+    let loadsAutomatically: Bool
+    let allowsFallback: Bool
+
+    func allowsLoading(
+        sourceIdentity: String,
+        manualAuthorization: String?
+    ) -> Bool {
+        loadsAutomatically || manualAuthorization == sourceIdentity
+    }
+
+    func allowsFallback(
+        sourceIdentity: String,
+        explicitAuthorization: String?
+    ) -> Bool {
+        allowsFallback || explicitAuthorization == sourceIdentity
+    }
+
+    static func resolve(_ preference: ReaderMediaLoadingPolicy) -> ReaderMediaRequestPolicy {
+        switch preference {
+        case .automatic:
+            return ReaderMediaRequestPolicy(loadsAutomatically: true, allowsFallback: true)
+        case .dataSaving:
+            return ReaderMediaRequestPolicy(loadsAutomatically: true, allowsFallback: false)
+        case .manual:
+            return ReaderMediaRequestPolicy(loadsAutomatically: false, allowsFallback: true)
+        }
+    }
+}
+
+struct ReaderImageRequestSources: Equatable, Sendable {
+    let primaryURL: URL?
+    let fallbackURL: URL?
+}
+
+enum ReaderImageRequestSourcePolicy {
+    static func resolve(
+        previewURL: URL?,
+        originalURL: URL?,
+        requestPolicy: ReaderMediaRequestPolicy,
+        sourceIdentity: String,
+        explicitOriginalAuthorization: String?
+    ) -> ReaderImageRequestSources {
+        if explicitOriginalAuthorization == sourceIdentity,
+           let originalURL {
+            return ReaderImageRequestSources(
+                primaryURL: originalURL,
+                fallbackURL: nil
+            )
+        }
+        return ReaderImageRequestSources(
+            primaryURL: previewURL ?? originalURL,
+            fallbackURL: requestPolicy.allowsFallback ? originalURL : nil
+        )
+    }
+}
+
+enum ReaderMediaActivationPolicy {
+    static func blocksWhileLoading(
+        requestPolicy: ReaderMediaRequestPolicy
+    ) -> Bool {
+        requestPolicy.loadsAutomatically == false
+    }
+}
+
+enum ThreadInitialReplySortPolicy {
+    static func resolve(
+        defaultReplySort: ThreadReplySort,
+        initialPostID: UInt64?
+    ) -> ThreadReplySort {
+        // Server-side post-ID paging is deterministic only in floor order.
+        // Search results and deep links therefore take precedence over the
+        // user's default for newly opened threads.
+        initialPostID == nil ? defaultReplySort : .ascending
+    }
+}
+
+@MainActor
+final class ReadingPreferencesStore: ObservableObject {
+    struct StorageKeys: Equatable, Sendable {
+        var fontSize: String
+        var lineSpacing: String
+        var defaultReplySort: String
+        var mediaLoading: String
+
+        static let live = StorageKeys(
+            fontSize: "dev.infinityf4p.tiebapure.reader.font-size",
+            lineSpacing: "dev.infinityf4p.tiebapure.reader.line-spacing",
+            defaultReplySort: "dev.infinityf4p.tiebapure.reader.default-reply-sort",
+            mediaLoading: "dev.infinityf4p.tiebapure.reader.media-loading"
+        )
+    }
+
+    @Published private(set) var preferences: ReadingPreferences
+
+    private let defaults: UserDefaults
+    private let keys: StorageKeys
+
+    init(defaults: UserDefaults = .standard, keys: StorageKeys = .live) {
+        self.defaults = defaults
+        self.keys = keys
+
+        let fontSize = Self.readStringValue(
+            ReaderFontSize.self,
+            defaultValue: ReadingPreferences.default.fontSize,
+            defaults: defaults,
+            key: keys.fontSize
+        )
+        let lineSpacing = Self.readStringValue(
+            ReaderLineSpacing.self,
+            defaultValue: ReadingPreferences.default.lineSpacing,
+            defaults: defaults,
+            key: keys.lineSpacing
+        )
+        let defaultReplySort = Self.readReplySort(defaults: defaults, key: keys.defaultReplySort)
+        let mediaLoading = Self.readStringValue(
+            ReaderMediaLoadingPolicy.self,
+            defaultValue: ReadingPreferences.default.mediaLoading,
+            defaults: defaults,
+            key: keys.mediaLoading
+        )
+        preferences = ReadingPreferences(
+            fontSize: fontSize,
+            lineSpacing: lineSpacing,
+            defaultReplySort: defaultReplySort,
+            mediaLoading: mediaLoading
+        )
+    }
+
+    func update(_ preferences: ReadingPreferences) {
+        persist(preferences.fontSize, defaultValue: ReadingPreferences.default.fontSize, key: keys.fontSize)
+        persist(preferences.lineSpacing, defaultValue: ReadingPreferences.default.lineSpacing, key: keys.lineSpacing)
+        persist(preferences.defaultReplySort, defaultValue: ReadingPreferences.default.defaultReplySort, key: keys.defaultReplySort)
+        persist(preferences.mediaLoading, defaultValue: ReadingPreferences.default.mediaLoading, key: keys.mediaLoading)
+        self.preferences = preferences
+    }
+
+    func select(fontSize: ReaderFontSize) {
+        guard preferences.fontSize != fontSize else { return }
+        var updated = preferences
+        updated.fontSize = fontSize
+        persist(fontSize, defaultValue: ReadingPreferences.default.fontSize, key: keys.fontSize)
+        preferences = updated
+    }
+
+    func select(lineSpacing: ReaderLineSpacing) {
+        guard preferences.lineSpacing != lineSpacing else { return }
+        var updated = preferences
+        updated.lineSpacing = lineSpacing
+        persist(lineSpacing, defaultValue: ReadingPreferences.default.lineSpacing, key: keys.lineSpacing)
+        preferences = updated
+    }
+
+    func select(defaultReplySort: ThreadReplySort) {
+        guard preferences.defaultReplySort != defaultReplySort else { return }
+        var updated = preferences
+        updated.defaultReplySort = defaultReplySort
+        persist(
+            defaultReplySort,
+            defaultValue: ReadingPreferences.default.defaultReplySort,
+            key: keys.defaultReplySort
+        )
+        preferences = updated
+    }
+
+    func select(mediaLoading: ReaderMediaLoadingPolicy) {
+        guard preferences.mediaLoading != mediaLoading else { return }
+        var updated = preferences
+        updated.mediaLoading = mediaLoading
+        persist(
+            mediaLoading,
+            defaultValue: ReadingPreferences.default.mediaLoading,
+            key: keys.mediaLoading
+        )
+        preferences = updated
+    }
+
+    func reset() {
+        defaults.removeObject(forKey: keys.fontSize)
+        defaults.removeObject(forKey: keys.lineSpacing)
+        defaults.removeObject(forKey: keys.defaultReplySort)
+        defaults.removeObject(forKey: keys.mediaLoading)
+        preferences = .default
+    }
+
+    static func live() -> ReadingPreferencesStore {
+        let store = ReadingPreferencesStore()
+
+#if DEBUG
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains("UITEST_RESET_READING_PREFERENCES") {
+            store.reset()
+        }
+        if arguments.contains("UITEST_READING_REPLY_SORT_DESCENDING") {
+            store.select(defaultReplySort: .descending)
+        }
+        if arguments.contains("UITEST_READING_MEDIA_MANUAL") {
+            store.select(mediaLoading: .manual)
+        } else if arguments.contains("UITEST_READING_MEDIA_DATA_SAVING") {
+            store.select(mediaLoading: .dataSaving)
+        }
+#endif
+
+        return store
+    }
+
+    private static func readStringValue<Value: RawRepresentable>(
+        _ type: Value.Type,
+        defaultValue: Value,
+        defaults: UserDefaults,
+        key: String
+    ) -> Value where Value.RawValue == String {
+        guard let storedObject = defaults.object(forKey: key) else { return defaultValue }
+        guard let rawValue = storedObject as? String,
+              let value = Value(rawValue: rawValue) else {
+            defaults.removeObject(forKey: key)
+            return defaultValue
+        }
+        return value
+    }
+
+    private static func readReplySort(defaults: UserDefaults, key: String) -> ThreadReplySort {
+        guard let storedObject = defaults.object(forKey: key) else {
+            return ReadingPreferences.default.defaultReplySort
+        }
+        guard let number = storedObject as? NSNumber,
+              let value = ThreadReplySort(rawValue: number.intValue) else {
+            defaults.removeObject(forKey: key)
+            return ReadingPreferences.default.defaultReplySort
+        }
+        return value
+    }
+
+    private func persist<Value: RawRepresentable & Equatable>(
+        _ value: Value,
+        defaultValue: Value,
+        key: String
+    ) where Value.RawValue == String {
+        if value == defaultValue {
+            defaults.removeObject(forKey: key)
+        } else {
+            defaults.set(value.rawValue, forKey: key)
+        }
+    }
+
+    private func persist(
+        _ value: ThreadReplySort,
+        defaultValue: ThreadReplySort,
+        key: String
+    ) {
+        if value == defaultValue {
+            defaults.removeObject(forKey: key)
+        } else {
+            defaults.set(value.rawValue, forKey: key)
+        }
+    }
+}
+
+private struct ReadingPreferencesEnvironmentKey: EnvironmentKey {
+    static let defaultValue = ReadingPreferences.default
+}
+
+extension EnvironmentValues {
+    var readingPreferences: ReadingPreferences {
+        get { self[ReadingPreferencesEnvironmentKey.self] }
+        set { self[ReadingPreferencesEnvironmentKey.self] = newValue }
+    }
+}

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -737,19 +737,23 @@ struct ForumThreadRow: View {
                 let allMedia = mediaItems
                 let previewMedia = mediaPreviewItems(from: allMedia)
                 if previewMedia.isEmpty == false {
-                    decorativeMediaOpensThread {
-                        MediaGridView(
-                            items: previewMedia,
-                            maxItemHeight: presentation.mediaMaxHeight(itemCount: previewMedia.count),
-                            totalItemCount: allMedia.count,
-                            usesCompactFeedLayout: presentation.usesCompactFeedLayout,
-                            isInteractive: onOpenMedia != nil,
-                            onTap: { item, sourceFrame, sourceImage, sourceAnchor in
+                    MediaGridView(
+                        items: previewMedia,
+                        maxItemHeight: presentation.mediaMaxHeight(itemCount: previewMedia.count),
+                        totalItemCount: allMedia.count,
+                        usesCompactFeedLayout: presentation.usesCompactFeedLayout,
+                        isInteractive: onOpenMedia != nil || onOpenThread != nil,
+                        destinationAccessibilityLabel: onOpenMedia == nil ? "打开帖子" : nil,
+                        destinationAccessibilityHint: onOpenMedia == nil ? "进入帖子详情" : nil,
+                        onTap: { item, sourceFrame, sourceImage, sourceAnchor in
+                            if let onOpenMedia {
                                 guard ForumThreadTapPolicy.destination(for: .media) == .media else { return }
-                                onOpenMedia?(item, allMedia, sourceFrame, sourceImage, sourceAnchor)
+                                onOpenMedia(item, allMedia, sourceFrame, sourceImage, sourceAnchor)
+                            } else {
+                                onOpenThread?()
                             }
-                        )
-                    }
+                        }
+                    )
                 }
 
                 InteractionStatsView(
@@ -822,31 +826,6 @@ struct ForumThreadRow: View {
                     )
                 }
             }
-        }
-    }
-
-    /// Decorative media exposes no controls of its own, so taps on it keep the
-    /// pre-split whole-row behavior and open the thread. The overlay stays out
-    /// of the accessibility tree; "thread-open-area" already provides the
-    /// accessible open action for the row.
-    @ViewBuilder
-    private func decorativeMediaOpensThread<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        if onOpenMedia == nil, let onOpenThread {
-            content()
-                .overlay {
-                    Button {
-                        guard ForumThreadTapPolicy.destination(for: .threadBody) == .thread else { return }
-                        onOpenThread()
-                    } label: {
-                        Color.clear
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityHidden(true)
-                }
-        } else {
-            content()
         }
     }
 

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -6,6 +6,7 @@ struct HomeView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.readingPreferences) private var readingPreferences
     let account: Account?
     var refreshToken: Int = 0
 
@@ -337,7 +338,8 @@ struct HomeView: View {
                                         initialIndex: index,
                                         sourceFrame: sourceFrame,
                                         sourceImage: sourceImage,
-                                        sourceAnchor: sourceAnchor
+                                        sourceAnchor: sourceAnchor,
+                                        prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
                                     )
                                 )
                             case let .playVideo(video):

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -3,12 +3,16 @@ import UIKit
 import Combine
 
 struct ImageViewer: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let image: ImageContent
     let galleryImages: [ImageContent]
     let galleryIndex: Int
 
     @State private var inlineLoadState: TiebaRemoteImageLoadState = .empty
     @State private var inlineRetryTrigger = 0
+    @State private var manualLoadAuthorization: String?
+    @State private var explicitFallbackAuthorization: String?
     @StateObject private var previewSource: ImagePreviewSourceAnchor
     private let previewSourceIdentity: String
 
@@ -38,12 +42,8 @@ struct ImageViewer: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityAddTraits(.isButton)
                 .accessibilityIdentifier("thread-inline-image")
-                .accessibilityLabel(inlineLoadState == .failure
-                    ? "图片加载失败，重新加载"
-                    : (isTallImage ? "查看长图原图" : "查看图片"))
-                .accessibilityHint(inlineLoadState == .failure
-                    ? "重新请求当前图片，不会打开全屏预览"
-                    : "全屏显示完整图片")
+                .accessibilityLabel(inlineAccessibilityLabel)
+                .accessibilityHint(inlineAccessibilityHint)
                 .accessibilityAction {
                     activateInlineImage()
                 }
@@ -72,7 +72,19 @@ struct ImageViewer: View {
 
     private func activateInlineImage() {
         if inlineLoadState == .failure {
+            if shouldOfferExplicitFallback {
+                explicitFallbackAuthorization = previewSourceIdentity
+            }
             inlineRetryTrigger += 1
+        } else if inlineLoadState == .empty,
+                  mediaRequestPolicy.loadsAutomatically == false {
+            manualLoadAuthorization = previewSourceIdentity
+            return
+        } else if inlineLoadState == .loading,
+                  ReaderMediaActivationPolicy.blocksWhileLoading(
+                    requestPolicy: mediaRequestPolicy
+                  ) {
+            return
         } else {
             ImagePreviewCoordinator.shared.present(
                 ImagePreviewSession(
@@ -83,7 +95,8 @@ struct ImageViewer: View {
                         ?? previewSource.frameInWindow,
                     sourceImage: previewSource.image,
                     sourceAnchor: previewSource,
-                    sourceIdentity: previewSourceIdentity
+                    sourceIdentity: previewSourceIdentity,
+                    prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
                 )
             )
         }
@@ -99,13 +112,14 @@ struct ImageViewer: View {
                     .fill(TiebaPureTheme.ColorToken.readerTertiarySurface)
 
                 TiebaRemoteImage(
-                    primaryURL: image.thumbnailURL ?? image.originalURL,
-                    fallbackURL: image.originalURL,
+                    primaryURL: imageRequestSources.primaryURL,
+                    fallbackURL: imageRequestSources.fallbackURL,
                     contentMode: .fill,
                     showsProgress: true,
                     retryTrigger: inlineRetryTrigger,
                     showsRetryButton: false,
                     showsResolvedImage: false,
+                    loadsAutomatically: isManualLoadAuthorized,
                     onLoadStateChange: {
                         inlineLoadState = $0
                         if $0 != .success {
@@ -122,6 +136,17 @@ struct ImageViewer: View {
                     }
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                if mediaRequestPolicy.loadsAutomatically == false,
+                   inlineLoadState == .empty {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.system(size: 30, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 44, height: 44)
+                        .background(.regularMaterial, in: Circle())
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
 
                 // This is the sole visible thumbnail and the canonical source
                 // registered with the app-owned transition scene. Keeping one
@@ -183,6 +208,73 @@ struct ImageViewer: View {
             String(image.height)
         ].joined(separator: "|")
     }
+
+    private var mediaRequestPolicy: ReaderMediaRequestPolicy {
+        ReaderMediaRequestPolicy.resolve(readingPreferences.mediaLoading)
+    }
+
+    private var isManualLoadAuthorized: Bool {
+        mediaRequestPolicy.allowsLoading(
+            sourceIdentity: previewSourceIdentity,
+            manualAuthorization: manualLoadAuthorization
+        )
+    }
+
+    private var allowsExplicitFallback: Bool {
+        mediaRequestPolicy.allowsFallback(
+            sourceIdentity: previewSourceIdentity,
+            explicitAuthorization: explicitFallbackAuthorization
+        )
+    }
+
+    private var imageRequestSources: ReaderImageRequestSources {
+        ReaderImageRequestSourcePolicy.resolve(
+            previewURL: image.thumbnailURL,
+            originalURL: image.originalURL,
+            requestPolicy: mediaRequestPolicy,
+            sourceIdentity: previewSourceIdentity,
+            explicitOriginalAuthorization: explicitFallbackAuthorization
+        )
+    }
+
+    private var shouldOfferExplicitFallback: Bool {
+        guard readingPreferences.mediaLoading == .dataSaving,
+              allowsExplicitFallback == false,
+              let originalURL = image.originalURL else {
+            return false
+        }
+        return originalURL != image.thumbnailURL
+    }
+
+    private var inlineAccessibilityLabel: String {
+        switch inlineLoadState {
+        case .empty where mediaRequestPolicy.loadsAutomatically == false:
+            return "加载图片"
+        case .loading:
+            return "正在加载图片"
+        case .failure:
+            return shouldOfferExplicitFallback
+                ? "图片预览加载失败，加载原图"
+                : "图片加载失败，重新加载"
+        case .empty, .success:
+            return isTallImage ? "查看长图原图" : "查看图片"
+        }
+    }
+
+    private var inlineAccessibilityHint: String {
+        switch inlineLoadState {
+        case .empty where mediaRequestPolicy.loadsAutomatically == false:
+            return "加载当前图片预览"
+        case .loading:
+            return "请等待图片加载完成"
+        case .failure:
+            return shouldOfferExplicitFallback
+                ? "明确请求当前图片原图"
+                : "重新请求当前图片，不会打开全屏预览"
+        case .empty, .success:
+            return "全屏显示完整图片"
+        }
+    }
 }
 
 enum InlineImageLayoutPolicy {
@@ -221,6 +313,7 @@ struct ImagePreviewSession: Identifiable {
     /// resolves the live source view through this, never through a cached
     /// view reference, so cell recycling cannot redirect it to another post.
     let sourceIdentity: String?
+    let prefetchesAdjacentPages: Bool
 
     @MainActor
     init(
@@ -229,7 +322,8 @@ struct ImagePreviewSession: Identifiable {
         sourceFrame: CGRect? = nil,
         sourceImage: UIImage? = nil,
         sourceAnchor: ImagePreviewSourceAnchor? = nil,
-        sourceIdentity: String? = nil
+        sourceIdentity: String? = nil,
+        prefetchesAdjacentPages: Bool = true
     ) {
         self.images = images
         self.initialIndex = ImagePreviewIndexPolicy.clampedIndex(
@@ -241,6 +335,7 @@ struct ImagePreviewSession: Identifiable {
         self.sourceAnchor = sourceAnchor
         sourceToken = sourceAnchor?.transitionToken
         self.sourceIdentity = sourceIdentity ?? sourceAnchor?.sourceIdentity
+        self.prefetchesAdjacentPages = prefetchesAdjacentPages
     }
 }
 
@@ -2743,9 +2838,14 @@ enum FullScreenImageLoadSchedulingPolicy {
     static func allowsLoading(
         pageIndex: Int,
         currentIndex: Int,
-        didFinishPresentation: Bool
+        didFinishPresentation: Bool,
+        prefetchesAdjacentPages: Bool = true
     ) -> Bool {
-        didFinishPresentation && abs(pageIndex - currentIndex) <= 1
+        guard didFinishPresentation else { return false }
+        if prefetchesAdjacentPages {
+            return abs(pageIndex - currentIndex) <= 1
+        }
+        return pageIndex == currentIndex
     }
 }
 
@@ -2785,6 +2885,7 @@ private struct FullScreenZoomableRemoteImage: UIViewControllerRepresentable {
     let transitionState: ImagePreviewPresentationState
     let imageIndex: Int
     let coordinatesWithParentPager: Bool
+    let prefetchesAdjacentPages: Bool
     let originalLoadRequest: Int
     let onImageResolved: (UIImage, CGRect?) -> Void
     let onOriginalLoadStateChange: (FullScreenOriginalImageLoadState) -> Void
@@ -2804,6 +2905,7 @@ private struct FullScreenZoomableRemoteImage: UIViewControllerRepresentable {
             transitionState: transitionState,
             imageIndex: imageIndex,
             coordinatesWithParentPager: coordinatesWithParentPager,
+            prefetchesAdjacentPages: prefetchesAdjacentPages,
             onImageResolved: onImageResolved,
             onOriginalLoadStateChange: onOriginalLoadStateChange,
             onOriginalLoadProgressChange: onOriginalLoadProgressChange,
@@ -2864,6 +2966,7 @@ private final class FullScreenZoomImageController: UIViewController,
     private let placeholderImage: UIImage?
     private let transitionState: ImagePreviewPresentationState
     private let coordinatesWithParentPager: Bool
+    private let prefetchesAdjacentPages: Bool
     private var imageIndex: Int
     private var lastViewportSize: CGSize = .zero
     private var resolvedImage: UIImage?
@@ -2920,6 +3023,7 @@ private final class FullScreenZoomImageController: UIViewController,
         transitionState: ImagePreviewPresentationState,
         imageIndex: Int,
         coordinatesWithParentPager: Bool,
+        prefetchesAdjacentPages: Bool,
         onImageResolved: @escaping (UIImage, CGRect?) -> Void,
         onOriginalLoadStateChange: @escaping (FullScreenOriginalImageLoadState) -> Void,
         onOriginalLoadProgressChange: @escaping (BoundedURLSessionProgress?) -> Void,
@@ -2936,6 +3040,7 @@ private final class FullScreenZoomImageController: UIViewController,
         self.transitionState = transitionState
         self.imageIndex = imageIndex
         self.coordinatesWithParentPager = coordinatesWithParentPager
+        self.prefetchesAdjacentPages = prefetchesAdjacentPages
         if FullScreenImagePlaceholderPolicy.canReuseAsPreview(
             placeholderSize: placeholderImage?.size,
             imageAspectRatio: imageAspectRatio
@@ -3324,7 +3429,8 @@ private final class FullScreenZoomImageController: UIViewController,
         guard FullScreenImageLoadSchedulingPolicy.allowsLoading(
             pageIndex: imageIndex,
             currentIndex: transitionState.currentIndex,
-            didFinishPresentation: transitionState.didFinishPresentation
+            didFinishPresentation: transitionState.didFinishPresentation,
+            prefetchesAdjacentPages: prefetchesAdjacentPages
         ) else {
             return
         }
@@ -3831,6 +3937,7 @@ struct FullScreenImageView: View {
     private let onCurrentImageResolved: ((Int, UIImage, CGRect?) -> Void)?
     private let onZoomStateChange: ((Int, Bool) -> Void)?
     private let transitionState: ImagePreviewPresentationState
+    private let prefetchesAdjacentPages: Bool
     @State private var currentIndex: Int
     @State private var originalLoadStates: [String: FullScreenOriginalImageLoadState]
     @State private var originalLoadRequests: [String: Int]
@@ -3860,6 +3967,7 @@ struct FullScreenImageView: View {
         self.onCurrentImageResolved = onCurrentImageResolved
         onZoomStateChange = nil
         self.transitionState = transitionState
+        prefetchesAdjacentPages = true
         _currentIndex = State(initialValue: 0)
         _originalLoadStates = State(initialValue: Self.initialOriginalLoadStates(for: [item]))
         _originalLoadRequests = State(initialValue: [:])
@@ -3891,6 +3999,7 @@ struct FullScreenImageView: View {
         self.onCurrentImageResolved = onCurrentImageResolved
         self.onZoomStateChange = onZoomStateChange
         self.transitionState = transitionState
+        prefetchesAdjacentPages = session.prefetchesAdjacentPages
         _currentIndex = State(initialValue: ImagePreviewIndexPolicy.clampedIndex(
             session.initialIndex,
             totalCount: resolvedItems.count
@@ -3926,6 +4035,7 @@ struct FullScreenImageView: View {
         self.onCurrentImageResolved = onCurrentImageResolved
         onZoomStateChange = nil
         self.transitionState = transitionState
+        prefetchesAdjacentPages = true
         _currentIndex = State(initialValue: initialIndex)
         _originalLoadStates = State(initialValue: Self.initialOriginalLoadStates(for: finalItems))
         _originalLoadRequests = State(initialValue: [:])
@@ -4023,6 +4133,7 @@ struct FullScreenImageView: View {
             transitionState: transitionState,
             imageIndex: index,
             coordinatesWithParentPager: items.count > 1,
+            prefetchesAdjacentPages: prefetchesAdjacentPages,
             originalLoadRequest: originalLoadRequests[item.id, default: 0],
             onImageResolved: { image, frameInWindow in
                 onCurrentImageResolved?(index, image, frameInWindow)
@@ -4543,6 +4654,53 @@ struct ImageViewerUITestHost: View {
             ),
             saveAction: { _ in }
         )
+    }
+}
+
+struct ReaderMediaPolicyUITestHost: View {
+    @State private var mediaGridAction = "等待媒体网格操作"
+
+    private let image = ImageContent(
+        thumbnailURL: URL(string: "https://fixture.invalid/media-policy-thumbnail.png"),
+        originalURL: URL(string: "https://fixture-success.invalid/media-policy-original.png"),
+        width: 640,
+        height: 400,
+        showOriginalButton: true
+    )
+    private let video = VideoContent(
+        videoURL: URL(string: "https://fixture-success.invalid/media-policy-video.mp4"),
+        coverURL: URL(string: "https://fixture.invalid/media-policy-video-cover.png"),
+        webURL: nil,
+        width: 640,
+        height: 360,
+        duration: 12
+    )
+
+    private var mediaGridVideoItem: ReaderMediaItem {
+        ReaderMediaItem(
+            id: "policy-video",
+            kind: .video,
+            thumbnailURL: video.coverURL,
+            video: video,
+            aspectRatio: CGFloat(video.aspectRatio),
+            accessibilityLabel: "测试视频"
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.lg) {
+                ImageViewer(image: image)
+                VideoPlayerView(video: video)
+                MediaGridView(items: [mediaGridVideoItem]) { _, _, _, _ in
+                    mediaGridAction = "已打开媒体网格目标"
+                }
+                Text(mediaGridAction)
+                    .accessibilityIdentifier("reader-media-grid-action")
+            }
+            .padding()
+        }
+        .accessibilityIdentifier("reader-media-policy-host")
     }
 }
 #endif

--- a/TiebaPure/Features/Media/VideoPlayerView.swift
+++ b/TiebaPure/Features/Media/VideoPlayerView.swift
@@ -13,19 +13,30 @@ enum TiebaVideoSourcePolicy {
 }
 
 struct VideoPlayerView: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let video: VideoContent
 
     @State private var showsPlayer = false
     @State private var showsSafari = false
     @State private var coverLoadState: TiebaRemoteImageLoadState = .empty
-    @State private var coverRetryTrigger = 0
+    @State private var manualCoverAuthorization: String?
 
     var body: some View {
         Group {
             if resolvedVideoURL != nil || resolvedWebURL != nil {
                 Button {
                     if coverLoadState == .failure {
-                        coverRetryTrigger += 1
+                        openVideo()
+                    } else if coverLoadState == .empty,
+                              isManualCoverMode {
+                        manualCoverAuthorization = coverSourceIdentity
+                        return
+                    } else if coverLoadState == .loading,
+                              ReaderMediaActivationPolicy.blocksWhileLoading(
+                                requestPolicy: mediaRequestPolicy
+                              ) {
+                        return
                     } else {
                         openVideo()
                     }
@@ -34,8 +45,8 @@ struct VideoPlayerView: View {
                 }
                 .buttonStyle(.plain)
                 .minTouchTarget()
-                .accessibilityLabel(coverLoadState == .failure ? "视频封面加载失败，重新加载" : "播放视频")
-                .accessibilityHint(coverLoadState == .failure ? "重新请求视频封面" : "打开视频播放器")
+                .accessibilityLabel(videoAccessibilityLabel)
+                .accessibilityHint(videoAccessibilityHint)
             } else {
                 thumbnail
                     .accessibilityLabel("视频不可用")
@@ -80,19 +91,32 @@ struct VideoPlayerView: View {
                     primaryURL: coverURL,
                     contentMode: .fill,
                     showsProgress: true,
-                    retryTrigger: coverRetryTrigger,
                     showsRetryButton: false,
+                    loadsAutomatically: mediaRequestPolicy.loadsAutomatically || isManualCoverLoadAuthorized,
                     onLoadStateChange: { coverLoadState = $0 }
                 )
             } else {
                 placeholderIcon
             }
 
-            Image(systemName: "play.circle.fill")
-                .font(.system(size: TiebaPureTheme.IconSize.play))
-                .foregroundStyle(.white)
-                .shadow(radius: 3)
-                .accessibilityHidden(true)
+            if waitsForManualCoverLoad == false || coverLoadState != .empty {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: TiebaPureTheme.IconSize.play))
+                    .foregroundStyle(.white)
+                    .shadow(radius: 3)
+                    .accessibilityHidden(true)
+            }
+
+            if waitsForManualCoverLoad,
+               coverLoadState == .empty {
+                Image(systemName: "arrow.down.circle")
+                    .font(.system(size: 30, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+                    .background(.black.opacity(0.45), in: Circle())
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
         }
         .overlay(alignment: .bottomLeading) {
             if let durationText {
@@ -131,6 +155,53 @@ struct VideoPlayerView: View {
         ]
         .map { String(format: "%02d", $0) }
         .joined(separator: ":")
+    }
+
+    private var mediaRequestPolicy: ReaderMediaRequestPolicy {
+        ReaderMediaRequestPolicy.resolve(readingPreferences.mediaLoading)
+    }
+
+    private var waitsForManualCoverLoad: Bool {
+        isManualCoverMode && isManualCoverLoadAuthorized == false
+    }
+
+    private var isManualCoverMode: Bool {
+        video.coverURL != nil && mediaRequestPolicy.loadsAutomatically == false
+    }
+
+    private var coverSourceIdentity: String? {
+        video.coverURL?.absoluteString
+    }
+
+    private var isManualCoverLoadAuthorized: Bool {
+        guard let coverSourceIdentity else { return false }
+        return manualCoverAuthorization == coverSourceIdentity
+    }
+
+    private var videoAccessibilityLabel: String {
+        switch coverLoadState {
+        case .empty where waitsForManualCoverLoad:
+            return "加载视频封面"
+        case .loading:
+            return "正在加载视频封面"
+        case .failure:
+            return "播放视频，封面加载失败"
+        case .empty, .success:
+            return "播放视频"
+        }
+    }
+
+    private var videoAccessibilityHint: String {
+        switch coverLoadState {
+        case .empty where waitsForManualCoverLoad:
+            return "加载当前视频封面"
+        case .loading:
+            return "请等待视频封面加载完成"
+        case .failure:
+            return "封面不可用，仍可打开视频播放器"
+        case .empty, .success:
+            return "打开视频播放器"
+        }
     }
 }
 

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -13,6 +13,7 @@ private struct UserProfileThreadRoute {
 struct UserProfileView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.readingPreferences) private var readingPreferences
 
     let account: Account?
     let user: UserSummary
@@ -254,7 +255,8 @@ struct UserProfileView: View {
                                     initialIndex: index,
                                     sourceFrame: sourceFrame,
                                     sourceImage: sourceImage,
-                                    sourceAnchor: sourceAnchor
+                                    sourceAnchor: sourceAnchor,
+                                    prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
                                 )
                                 )
                             case let .playVideo(video):

--- a/TiebaPure/Features/Search/SearchResultsView.swift
+++ b/TiebaPure/Features/Search/SearchResultsView.swift
@@ -33,6 +33,7 @@ enum SearchScope: Equatable {
 
 struct SearchResultsView: View {
     @EnvironmentObject private var environment: AppEnvironment
+    @Environment(\.readingPreferences) private var readingPreferences
     @ObservedObject private var historyStore = SearchHistoryStore.shared
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     let account: Account?
@@ -341,7 +342,8 @@ struct SearchResultsView: View {
                                                     initialIndex: index,
                                                     sourceFrame: sourceFrame,
                                                     sourceImage: sourceImage,
-                                                    sourceAnchor: sourceAnchor
+                                                    sourceAnchor: sourceAnchor,
+                                                    prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
                                                 )
                                             )
                                         case let .playVideo(video):

--- a/TiebaPure/Features/Settings/ReadingSettingsView.swift
+++ b/TiebaPure/Features/Settings/ReadingSettingsView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+struct ReadingSettingsView: View {
+    @EnvironmentObject private var store: ReadingPreferencesStore
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("字号", selection: fontSizeSelection) {
+                    ForEach(ReaderFontSize.allCases) { size in
+                        Text(size.shortTitle)
+                            .tag(size)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("reading-font-size-picker")
+
+                Picker("正文间距", selection: lineSpacingSelection) {
+                    ForEach(ReaderLineSpacing.allCases) { spacing in
+                        Text(spacing.title)
+                            .tag(spacing)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("reading-line-spacing-picker")
+
+                InlineContentText(
+                    blocks: [.text("阅读设置会应用到主贴、楼层回复和楼中楼正文。")],
+                    style: .body,
+                    lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
+                    readerFontSize: store.preferences.fontSize,
+                    readerLineSpacing: store.preferences.lineSpacing,
+                    allowsLinkInteraction: false,
+                    accessibilityIdentifier: "reading-typography-preview"
+                )
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, TiebaPureTheme.Spacing.xs)
+            } header: {
+                Text("正文")
+            } footer: {
+                Text("系统大字体仍会继续生效；首页和吧页的帖子摘要保持紧凑显示。")
+            }
+
+            Section {
+                Picker("帖子回复默认排序", selection: replySortSelection) {
+                    ForEach(ThreadReplySort.allCases) { sort in
+                        Text(sort.title)
+                            .tag(sort)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("reading-reply-sort-picker")
+            } header: {
+                Text("回复")
+            } footer: {
+                Text("只影响新打开的帖子；恢复上次阅读位置时会使用正序定位。")
+            }
+
+            Section {
+                Picker("媒体加载", selection: mediaLoadingSelection) {
+                    ForEach(ReaderMediaLoadingPolicy.allCases) { policy in
+                        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
+                            Text(policy.title)
+                            Text(policy.detail)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(policy)
+                    }
+                }
+                .pickerStyle(.inline)
+                .accessibilityIdentifier("reading-media-loading-picker")
+            } header: {
+                Text("图片与视频")
+            } footer: {
+                Text("此设置只影响帖子媒体和视频封面，不影响头像、贴吧图标或表情。")
+            }
+
+            Section {
+                Button("恢复默认设置", role: .destructive) {
+                    store.reset()
+                }
+                .disabled(store.preferences == .default)
+                .accessibilityIdentifier("reading-settings-reset")
+            }
+        }
+        .navigationTitle("阅读设置")
+        .fullScreenInteractiveNavigationPop()
+    }
+
+    private var fontSizeSelection: Binding<ReaderFontSize> {
+        Binding(
+            get: { store.preferences.fontSize },
+            set: { store.select(fontSize: $0) }
+        )
+    }
+
+    private var lineSpacingSelection: Binding<ReaderLineSpacing> {
+        Binding(
+            get: { store.preferences.lineSpacing },
+            set: { store.select(lineSpacing: $0) }
+        )
+    }
+
+    private var replySortSelection: Binding<ThreadReplySort> {
+        Binding(
+            get: { store.preferences.defaultReplySort },
+            set: { store.select(defaultReplySort: $0) }
+        )
+    }
+
+    private var mediaLoadingSelection: Binding<ReaderMediaLoadingPolicy> {
+        Binding(
+            get: { store.preferences.mediaLoading },
+            set: { store.select(mediaLoading: $0) }
+        )
+    }
+}

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -43,6 +43,14 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
+                    ReadingSettingsView()
+                } label: {
+                    Label("阅读设置", systemImage: "textformat.size")
+                }
+                .accessibilityHint("调整帖子正文、回复排序和媒体加载方式")
+                .accessibilityIdentifier("settings-reading-entry")
+
+                NavigationLink {
                     BlocklistSettingsView()
                 } label: {
                     Label("屏蔽设置", systemImage: "hand.raised")
@@ -52,7 +60,7 @@ struct SettingsView: View {
             } header: {
                 Text("内容")
             } footer: {
-                Text("被屏蔽的关键词、用户和吧会在浏览时隐藏，规则仅保存在本机。")
+                Text("阅读偏好和屏蔽规则仅保存在本机。")
             }
 
             if let account {

--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -30,6 +30,8 @@ struct ContentBlocksView: View {
     let blocks: [ContentBlock]
     var textStyle: InlineContentText.Style = .body
     var lineLimit: Int = ThreadContentDisplayPolicy.detailLineLimit
+    var readerFontSize: ReaderFontSize = .standard
+    var readerLineSpacing: ReaderLineSpacing = .standard
     var inlineAccessibilityIdentifier: String?
     var onOpenUser: ((UserSummary) -> Void)?
 
@@ -42,6 +44,8 @@ struct ContentBlocksView: View {
                         blocks: inlineBlocks,
                         style: textStyle,
                         lineLimit: lineLimit,
+                        readerFontSize: readerFontSize,
+                        readerLineSpacing: readerLineSpacing,
                         allowsTextSelection: ThreadContentInteractionPolicy.allowsTextSelection(
                             for: lineLimit
                         ),
@@ -418,18 +422,33 @@ struct InlineContentText: UIViewRepresentable {
         case reply
         case subpost
 
-        var font: UIFont {
+        func font(readerFontSize: ReaderFontSize) -> UIFont {
             switch self {
             case .body:
-                return .preferredFont(forTextStyle: .body)
+                return ReaderTypographyPolicy.font(
+                    textStyle: .body,
+                    fontSize: readerFontSize
+                )
             case .title:
-                return .preferredFont(forTextStyle: .title2)
+                return ReaderTypographyPolicy.font(
+                    textStyle: .title2,
+                    fontSize: readerFontSize
+                )
             case .preview:
-                return .preferredFont(forTextStyle: .subheadline)
+                return ReaderTypographyPolicy.font(
+                    textStyle: .subheadline,
+                    fontSize: readerFontSize
+                )
             case .reply:
-                return .preferredFont(forTextStyle: .callout)
+                return ReaderTypographyPolicy.font(
+                    textStyle: .callout,
+                    fontSize: readerFontSize
+                )
             case .subpost:
-                return .preferredFont(forTextStyle: .subheadline)
+                return ReaderTypographyPolicy.font(
+                    textStyle: .subheadline,
+                    fontSize: readerFontSize
+                )
             }
         }
 
@@ -461,6 +480,8 @@ struct InlineContentText: UIViewRepresentable {
     let blocks: [ContentBlock]
     var style: Style = .body
     var lineLimit: Int = ThreadContentDisplayPolicy.detailLineLimit
+    var readerFontSize: ReaderFontSize = .standard
+    var readerLineSpacing: ReaderLineSpacing = .standard
     var prefix: String?
     var prefixParts: [PrefixPart] = []
     var highlightKeyword: String?
@@ -567,9 +588,12 @@ struct InlineContentText: UIViewRepresentable {
 
     func attributedString() -> NSAttributedString {
         let result = NSMutableAttributedString()
-        let font = style.font
+        let font = style.font(readerFontSize: readerFontSize)
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineSpacing = style == .subpost ? 2 : 4
+        paragraph.lineSpacing = ReaderTypographyPolicy.lineSpacing(
+            readerLineSpacing,
+            context: style == .subpost ? .subpost : .body
+        )
         paragraph.lineBreakMode = ThreadContentDisplayPolicy.paragraphLineBreakMode
 
         let baseAttributes: [NSAttributedString.Key: Any] = [

--- a/TiebaPure/Features/Thread/PostRowView.swift
+++ b/TiebaPure/Features/Thread/PostRowView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PostRowView: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let post: Post
     let threadTitle: String?
     let threadAuthorID: Int64?
@@ -65,6 +67,8 @@ struct PostRowView: View {
                         blocks: post.blocks,
                         textStyle: isMainPost ? .body : .reply,
                         lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
+                        readerFontSize: readingPreferences.fontSize,
+                        readerLineSpacing: readingPreferences.lineSpacing,
                         inlineAccessibilityIdentifier: isMainPost
                             ? "thread-main-text"
                             : "thread-reply-text"

--- a/TiebaPure/Features/Thread/SubpostPreviewView.swift
+++ b/TiebaPure/Features/Thread/SubpostPreviewView.swift
@@ -81,6 +81,8 @@ enum SubpostPreviewLayout {
 }
 
 struct SubpostInlineRow: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let subpost: Subpost
     let threadAuthorID: Int64?
     var lineLimit: Int = ThreadContentDisplayPolicy.detailLineLimit
@@ -91,6 +93,8 @@ struct SubpostInlineRow: View {
             blocks: subpost.blocks,
             style: .subpost,
             lineLimit: lineLimit,
+            readerFontSize: readingPreferences.fontSize,
+            readerLineSpacing: readingPreferences.lineSpacing,
             prefixParts: SubpostInlinePrefix.parts(
                 author: subpost.author,
                 isThreadAuthor: isThreadAuthor

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -6,6 +6,7 @@ struct ThreadDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.readingPreferences) private var readingPreferences
     @ObservedObject private var localThreadLibraryStore = LocalThreadLibraryStore.shared
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     let account: Account?
@@ -26,6 +27,7 @@ struct ThreadDetailView: View {
     @State private var errorMessage: String?
     @State private var seeLz = false
     @State private var sortType: ThreadReplySort = .hot
+    @State private var didApplyDefaultReplySort = false
     @State private var selectedSubpostPost: Post?
     @State private var selectedUser: UserSummary?
     @State private var userResolutionTask: Task<Void, Never>?
@@ -371,6 +373,7 @@ struct ThreadDetailView: View {
         }
         .task {
             guard didLoad == false else { return }
+            applyDefaultReplySortIfNeeded()
             await reload()
         }
         .onChange(of: account?.id) { _ in
@@ -661,6 +664,15 @@ struct ThreadDetailView: View {
         // order also reshuffles between visits, so resuming into it would be
         // meaningless anyway. Resume in floor order for deterministic paging.
         sortType = .ascending
+    }
+
+    private func applyDefaultReplySortIfNeeded() {
+        guard didApplyDefaultReplySort == false else { return }
+        didApplyDefaultReplySort = true
+        sortType = ThreadInitialReplySortPolicy.resolve(
+            defaultReplySort: readingPreferences.defaultReplySort,
+            initialPostID: initialPostID
+        )
     }
 
     private func showRestoredReadingBanner() {
@@ -1295,6 +1307,8 @@ private struct ReplyControlBar: View {
         .buttonStyle(.plain)
         .minTouchTarget()
         .accessibilityLabel("按\(item.title)排列回复")
+        .accessibilityValue(sortType == item ? "已选择" : "未选择")
+        .accessibilityIdentifier("thread-reply-sort-\(item.rawValue)")
         .accessibilityAddTraits(sortType == item ? [.isSelected] : [])
     }
 
@@ -1312,6 +1326,7 @@ private struct ReplyControlBar: View {
 
 private struct SubpostListSheet: View {
     @EnvironmentObject private var environment: AppEnvironment
+    @Environment(\.readingPreferences) private var readingPreferences
     @ObservedObject private var blocklistStore = BlocklistStore.shared
 
     // pb/floor carries no client page-size field; the server pages replies
@@ -1399,6 +1414,8 @@ private struct SubpostListSheet: View {
                                             blocks: post.blocks,
                                             textStyle: .reply,
                                             lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
+                                            readerFontSize: readingPreferences.fontSize,
+                                            readerLineSpacing: readingPreferences.lineSpacing,
                                             inlineAccessibilityIdentifier: "thread-subpost-parent-text"
                                         )
                                         ThreadPostMetadataView(
@@ -1759,6 +1776,8 @@ private struct SubpostSectionSeparator: View {
 }
 
 private struct SubpostRowView: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+
     let subpost: Subpost
     let threadAuthorID: Int64?
     let onOpenUser: ((UserSummary) -> Void)?
@@ -1787,6 +1806,8 @@ private struct SubpostRowView: View {
                         blocks: subpost.blocks,
                         textStyle: .reply,
                         lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
+                        readerFontSize: readingPreferences.fontSize,
+                        readerLineSpacing: readingPreferences.lineSpacing,
                         inlineAccessibilityIdentifier: "thread-subpost-text",
                         onOpenUser: onOpenUser
                     )

--- a/TiebaPureTests/StateRegressionTests.swift
+++ b/TiebaPureTests/StateRegressionTests.swift
@@ -1461,4 +1461,304 @@ final class StateRegressionTests: XCTestCase {
         } catch is CancellationError {
         }
     }
+
+    @MainActor
+    func testReadingPreferencesPersistIndependentlyAndRemoveDefaultValues() throws {
+        let defaults = try makeScratchDefaults()
+        let keys = ReadingPreferencesStore.StorageKeys(
+            fontSize: "reader-font",
+            lineSpacing: "reader-spacing",
+            defaultReplySort: "reader-sort",
+            mediaLoading: "reader-media"
+        )
+        let store = ReadingPreferencesStore(defaults: defaults, keys: keys)
+
+        XCTAssertEqual(store.preferences, .default)
+        XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
+        XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
+        XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
+
+        store.select(fontSize: .large)
+        XCTAssertEqual(defaults.string(forKey: keys.fontSize), ReaderFontSize.large.rawValue)
+        XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
+        XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
+        XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
+
+        store.select(lineSpacing: .relaxed)
+        store.select(defaultReplySort: .descending)
+        store.select(mediaLoading: .manual)
+        XCTAssertEqual(
+            ReadingPreferencesStore(defaults: defaults, keys: keys).preferences,
+            ReadingPreferences(
+                fontSize: .large,
+                lineSpacing: .relaxed,
+                defaultReplySort: .descending,
+                mediaLoading: .manual
+            )
+        )
+
+        store.select(fontSize: .standard)
+        XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertEqual(defaults.string(forKey: keys.lineSpacing), ReaderLineSpacing.relaxed.rawValue)
+        XCTAssertEqual(defaults.integer(forKey: keys.defaultReplySort), ThreadReplySort.descending.rawValue)
+        XCTAssertEqual(defaults.string(forKey: keys.mediaLoading), ReaderMediaLoadingPolicy.manual.rawValue)
+
+        store.update(.default)
+        XCTAssertEqual(store.preferences, .default)
+        XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
+        XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
+        XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
+    }
+
+    @MainActor
+    func testReadingPreferencesSanitizeOnlyInvalidStoredValues() throws {
+        let defaults = try makeScratchDefaults()
+        let keys = ReadingPreferencesStore.StorageKeys(
+            fontSize: "reader-font",
+            lineSpacing: "reader-spacing",
+            defaultReplySort: "reader-sort",
+            mediaLoading: "reader-media"
+        )
+        defaults.set("oversized", forKey: keys.fontSize)
+        defaults.set(ReaderLineSpacing.compact.rawValue, forKey: keys.lineSpacing)
+        defaults.set(ThreadReplySort.ascending.rawValue, forKey: keys.defaultReplySort)
+        defaults.set(ReaderMediaLoadingPolicy.dataSaving.rawValue, forKey: keys.mediaLoading)
+
+        let store = ReadingPreferencesStore(defaults: defaults, keys: keys)
+        XCTAssertEqual(store.preferences.fontSize, .standard)
+        XCTAssertEqual(store.preferences.lineSpacing, .compact)
+        XCTAssertEqual(store.preferences.defaultReplySort, .ascending)
+        XCTAssertEqual(store.preferences.mediaLoading, .dataSaving)
+        XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertEqual(defaults.string(forKey: keys.lineSpacing), ReaderLineSpacing.compact.rawValue)
+        XCTAssertEqual(defaults.integer(forKey: keys.defaultReplySort), ThreadReplySort.ascending.rawValue)
+        XCTAssertEqual(
+            defaults.string(forKey: keys.mediaLoading),
+            ReaderMediaLoadingPolicy.dataSaving.rawValue
+        )
+
+        defaults.set("invalid-media-policy", forKey: keys.mediaLoading)
+        let sanitizedMedia = ReadingPreferencesStore(defaults: defaults, keys: keys)
+        XCTAssertEqual(sanitizedMedia.preferences.lineSpacing, .compact)
+        XCTAssertEqual(sanitizedMedia.preferences.defaultReplySort, .ascending)
+        XCTAssertEqual(sanitizedMedia.preferences.mediaLoading, .automatic)
+        XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
+        XCTAssertNotNil(defaults.object(forKey: keys.lineSpacing))
+        XCTAssertNotNil(defaults.object(forKey: keys.defaultReplySort))
+    }
+
+    @MainActor
+    func testReadingPreferencesResetRemovesEveryOverride() throws {
+        let defaults = try makeScratchDefaults()
+        let keys = ReadingPreferencesStore.StorageKeys(
+            fontSize: "reader-font",
+            lineSpacing: "reader-spacing",
+            defaultReplySort: "reader-sort",
+            mediaLoading: "reader-media"
+        )
+        let store = ReadingPreferencesStore(defaults: defaults, keys: keys)
+        store.update(ReadingPreferences(
+            fontSize: .extraLarge,
+            lineSpacing: .relaxed,
+            defaultReplySort: .descending,
+            mediaLoading: .manual
+        ))
+
+        store.reset()
+
+        XCTAssertEqual(store.preferences, .default)
+        XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
+        XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
+        XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
+    }
+
+    func testReaderFontSizeAndDynamicTypeScalingAreMonotonic() {
+        let largeCategory = UITraitCollection(preferredContentSizeCategory: .large)
+        let pointSizes = ReaderFontSize.allCases.map {
+            ReaderTypographyPolicy.font(
+                textStyle: .body,
+                fontSize: $0,
+                compatibleWith: largeCategory
+            ).pointSize
+        }
+        XCTAssertEqual(pointSizes.count, 4)
+        XCTAssertLessThan(pointSizes[0], pointSizes[1])
+        XCTAssertLessThan(pointSizes[1], pointSizes[2])
+        XCTAssertLessThan(pointSizes[2], pointSizes[3])
+
+        let accessibilityCategory = UITraitCollection(
+            preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge
+        )
+        let standardFont = ReaderTypographyPolicy.font(
+            textStyle: .body,
+            fontSize: .standard,
+            compatibleWith: largeCategory
+        )
+        let accessibilityFont = ReaderTypographyPolicy.font(
+            textStyle: .body,
+            fontSize: .standard,
+            compatibleWith: accessibilityCategory
+        )
+        XCTAssertGreaterThan(accessibilityFont.pointSize, standardFont.pointSize)
+    }
+
+    func testReaderLineSpacingPreservesExistingDefaultsAndMapsPreferences() {
+        XCTAssertEqual(
+            ReaderTypographyPolicy.lineSpacing(.standard, context: .body),
+            4,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderTypographyPolicy.lineSpacing(.standard, context: .subpost),
+            2,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderTypographyPolicy.lineSpacing(.compact, context: .body),
+            3,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderTypographyPolicy.lineSpacing(.relaxed, context: .body),
+            6,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderTypographyPolicy.lineSpacing(.compact, context: .subpost),
+            1.5,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            ReaderTypographyPolicy.lineSpacing(.relaxed, context: .subpost),
+            3,
+            accuracy: 0.001
+        )
+    }
+
+    func testReaderMediaRequestPolicyControlsAutomaticAndFallbackRequests() {
+        XCTAssertEqual(
+            ReaderMediaRequestPolicy.resolve(.automatic),
+            ReaderMediaRequestPolicy(loadsAutomatically: true, allowsFallback: true)
+        )
+        XCTAssertEqual(
+            ReaderMediaRequestPolicy.resolve(.dataSaving),
+            ReaderMediaRequestPolicy(loadsAutomatically: true, allowsFallback: false)
+        )
+        XCTAssertEqual(
+            ReaderMediaRequestPolicy.resolve(.manual),
+            ReaderMediaRequestPolicy(loadsAutomatically: false, allowsFallback: true)
+        )
+
+        let manual = ReaderMediaRequestPolicy.resolve(.manual)
+        XCTAssertFalse(manual.allowsLoading(sourceIdentity: "image-a", manualAuthorization: nil))
+        XCTAssertTrue(manual.allowsLoading(sourceIdentity: "image-a", manualAuthorization: "image-a"))
+        XCTAssertFalse(
+            manual.allowsLoading(sourceIdentity: "image-b", manualAuthorization: "image-a"),
+            "手动加载授权不得跟随复用视图泄漏到新的媒体 URL"
+        )
+
+        let dataSaving = ReaderMediaRequestPolicy.resolve(.dataSaving)
+        XCTAssertFalse(dataSaving.allowsFallback(sourceIdentity: "image-a", explicitAuthorization: nil))
+        XCTAssertTrue(
+            dataSaving.allowsFallback(
+                sourceIdentity: "image-a",
+                explicitAuthorization: "image-a"
+            )
+        )
+        XCTAssertFalse(
+            dataSaving.allowsFallback(
+                sourceIdentity: "image-b",
+                explicitAuthorization: "image-a"
+            ),
+            "显式原图授权只属于用户点击的当前媒体"
+        )
+    }
+
+    func testReaderImageRequestSourcePolicySkipsFailedPreviewAfterExplicitOriginalTap() throws {
+        let preview = try XCTUnwrap(URL(string: "https://example.com/preview.jpg"))
+        let original = try XCTUnwrap(URL(string: "https://example.com/original.jpg"))
+        let sourceIdentity = "image-a"
+
+        XCTAssertEqual(
+            ReaderImageRequestSourcePolicy.resolve(
+                previewURL: preview,
+                originalURL: original,
+                requestPolicy: .resolve(.automatic),
+                sourceIdentity: sourceIdentity,
+                explicitOriginalAuthorization: nil
+            ),
+            ReaderImageRequestSources(primaryURL: preview, fallbackURL: original)
+        )
+        XCTAssertEqual(
+            ReaderImageRequestSourcePolicy.resolve(
+                previewURL: preview,
+                originalURL: original,
+                requestPolicy: .resolve(.dataSaving),
+                sourceIdentity: sourceIdentity,
+                explicitOriginalAuthorization: nil
+            ),
+            ReaderImageRequestSources(primaryURL: preview, fallbackURL: nil)
+        )
+        XCTAssertEqual(
+            ReaderImageRequestSourcePolicy.resolve(
+                previewURL: preview,
+                originalURL: original,
+                requestPolicy: .resolve(.dataSaving),
+                sourceIdentity: sourceIdentity,
+                explicitOriginalAuthorization: sourceIdentity
+            ),
+            ReaderImageRequestSources(primaryURL: original, fallbackURL: nil),
+            "明确点击加载原图后必须跳过已经失败的缩略图"
+        )
+        XCTAssertEqual(
+            ReaderImageRequestSourcePolicy.resolve(
+                previewURL: preview,
+                originalURL: original,
+                requestPolicy: .resolve(.dataSaving),
+                sourceIdentity: "image-b",
+                explicitOriginalAuthorization: sourceIdentity
+            ),
+            ReaderImageRequestSources(primaryURL: preview, fallbackURL: nil),
+            "原图授权不得泄漏到复用后的另一张图片"
+        )
+    }
+
+    func testAutomaticMediaRemainsActivatableWhilePreviewLoads() {
+        XCTAssertFalse(ReaderMediaActivationPolicy.blocksWhileLoading(
+            requestPolicy: .resolve(.automatic)
+        ))
+        XCTAssertFalse(ReaderMediaActivationPolicy.blocksWhileLoading(
+            requestPolicy: .resolve(.dataSaving)
+        ))
+        XCTAssertTrue(ReaderMediaActivationPolicy.blocksWhileLoading(
+            requestPolicy: .resolve(.manual)
+        ))
+    }
+
+    func testInitialPostTargetOverridesDefaultReplySort() {
+        XCTAssertEqual(
+            ThreadInitialReplySortPolicy.resolve(
+                defaultReplySort: .descending,
+                initialPostID: 2_002
+            ),
+            .ascending
+        )
+        XCTAssertEqual(
+            ThreadInitialReplySortPolicy.resolve(
+                defaultReplySort: .hot,
+                initialPostID: 2_002
+            ),
+            .ascending
+        )
+        XCTAssertEqual(
+            ThreadInitialReplySortPolicy.resolve(
+                defaultReplySort: .descending,
+                initialPostID: nil
+            ),
+            .descending
+        )
+    }
 }

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -1194,6 +1194,33 @@ final class TiebaPureSmokeTests: XCTestCase {
         ))
     }
 
+    func testFullScreenManualMediaOnlyLoadsTheVisiblePage() {
+        XCTAssertTrue(FullScreenImageLoadSchedulingPolicy.allowsLoading(
+            pageIndex: 2,
+            currentIndex: 2,
+            didFinishPresentation: true,
+            prefetchesAdjacentPages: false
+        ))
+        XCTAssertFalse(FullScreenImageLoadSchedulingPolicy.allowsLoading(
+            pageIndex: 3,
+            currentIndex: 2,
+            didFinishPresentation: true,
+            prefetchesAdjacentPages: false
+        ))
+        XCTAssertTrue(FullScreenImageLoadSchedulingPolicy.allowsLoading(
+            pageIndex: 3,
+            currentIndex: 2,
+            didFinishPresentation: true,
+            prefetchesAdjacentPages: true
+        ))
+        XCTAssertFalse(FullScreenImageLoadSchedulingPolicy.allowsLoading(
+            pageIndex: 2,
+            currentIndex: 2,
+            didFinishPresentation: false,
+            prefetchesAdjacentPages: false
+        ))
+    }
+
     func testSyntheticFixtureImageFailureNeverUsesNetwork() throws {
         let fixture = try XCTUnwrap(URL(string: "https://fixture.invalid/long-image.png"))
         let lookalike = try XCTUnwrap(URL(string: "https://fixture.invalid.example/long-image.png"))
@@ -2811,6 +2838,29 @@ final class TiebaPureSmokeTests: XCTestCase {
                             prefixParts: [.text("合成作者 "), .threadAuthorBadge, .text(": ")],
                             onOpenUser: { _ in }
                         )
+                    ),
+                    (
+                        "reader-extra-large-relaxed",
+                        InlineContentText(
+                            blocks: [.text("A\u{0301}\u{0307} 超大字号与宽松间距的首行仍应完整显示。")],
+                            style: .reply,
+                            readerFontSize: .extraLarge,
+                            readerLineSpacing: .relaxed
+                        )
+                    ),
+                    (
+                        "reader-small-compact-link",
+                        InlineContentText(
+                            blocks: [
+                                .text("紧凑正文 "),
+                                .mention(userID: 42, text: "被回复用户"),
+                                .text(" 仍需保持完整字形。")
+                            ],
+                            style: .subpost,
+                            readerFontSize: .small,
+                            readerLineSpacing: .compact,
+                            onOpenUser: { _ in }
+                        )
                     )
                 ]
                 var recordedHeights: [String: CGFloat] = [:]
@@ -3068,6 +3118,45 @@ final class TiebaPureSmokeTests: XCTestCase {
 
         XCTAssertNil(InlineUserProfileLink.url(userID: 0, displayText: "  "))
         XCTAssertNil(InlineUserProfileLink.user(from: URL(string: "https://tieba.baidu.com")!))
+    }
+
+    func testInlineContentTextAppliesReaderTypographyWithoutChangingDefaultSummaryStyle() throws {
+        let standard = InlineContentText(
+            blocks: [.text("正文")],
+            style: .reply
+        ).attributedString()
+        let customized = InlineContentText(
+            blocks: [.text("正文")],
+            style: .reply,
+            readerFontSize: .extraLarge,
+            readerLineSpacing: .relaxed
+        ).attributedString()
+        let summary = InlineContentText(
+            blocks: [.text("摘要")],
+            style: .preview,
+            lineLimit: ThreadContentDisplayPolicy.summaryLineLimit
+        ).attributedString()
+
+        let standardFont = try XCTUnwrap(
+            standard.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        )
+        let customizedFont = try XCTUnwrap(
+            customized.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        )
+        let customizedParagraph = try XCTUnwrap(
+            customized.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        )
+        let summaryFont = try XCTUnwrap(
+            summary.attribute(.font, at: 0, effectiveRange: nil) as? UIFont
+        )
+
+        XCTAssertGreaterThan(customizedFont.pointSize, standardFont.pointSize)
+        XCTAssertEqual(customizedParagraph.lineSpacing, 6, accuracy: 0.001)
+        XCTAssertEqual(
+            summaryFont.pointSize,
+            InlineContentText.Style.preview.font(readerFontSize: .standard).pointSize,
+            accuracy: 0.001
+        )
     }
 
     func testInlineReplyUserNamesStaySecondaryWhenUIDIsMissing() throws {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -943,7 +943,7 @@ final class TiebaPureUITests: XCTestCase {
     }
 
     func testSearchResultRoutesToMatchedReply() {
-        let app = launchApp()
+        let app = launchApp(additionalArguments: ["UITEST_READING_REPLY_SORT_DESCENDING"])
 
         let searchField = openGlobalSearch(in: app)
         searchField.typeText("iPhone")
@@ -954,6 +954,13 @@ final class TiebaPureUITests: XCTestCase {
         let firstResult = threadRows(in: app).firstMatch
         XCTAssertTrue(firstResult.waitForExistence(timeout: 10))
         app.descendants(matching: .any).matching(identifier: "thread-open-area").firstMatch.tap()
+        let ascendingSort = app.buttons["thread-reply-sort-0"]
+        XCTAssertTrue(ascendingSort.waitForExistence(timeout: 8))
+        XCTAssertEqual(
+            ascendingSort.value as? String,
+            "已选择",
+            "搜索回复携带 postID 时必须覆盖倒序默认值，使用可确定定位的正序"
+        )
         XCTAssertTrue(waitForLabelContaining("已定位搜索命中回复", in: app, maxSwipes: 10))
     }
 
@@ -2639,6 +2646,103 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
+    func testManualRemoteImageAuthorizationDoesNotLeakAcrossReusedURL() {
+        let app = launchApp(additionalArguments: [
+            "UITEST_REMOTE_IMAGE_REUSE",
+            "UITEST_REMOTE_IMAGE_REUSE_MANUAL"
+        ])
+        let state = app.staticTexts["remote-image-reuse-state"]
+        let load = app.buttons["remote-image-reuse-load"]
+        XCTAssertTrue(state.waitForExistence(timeout: 5))
+        XCTAssertEqual(state.label, "等待加载 A")
+
+        load.tap()
+        let loadedA = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "已加载 A"),
+            object: state
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [loadedA], timeout: 5), .completed)
+
+        app.buttons["remote-image-reuse-switch"].tap()
+        XCTAssertEqual(state.label, "等待加载 B")
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        XCTAssertEqual(
+            state.label,
+            "等待加载 B",
+            "加载 A 的手动授权不得在同一复用视图换成 B 后继续生效"
+        )
+
+        load.tap()
+        let loadedB = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "已加载 B"),
+            object: state
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [loadedB], timeout: 5), .completed)
+    }
+
+    func testDataSavingImageFailureAllowsExplicitOriginalFallback() {
+        let app = launchApp(additionalArguments: [
+            "UITEST_READER_MEDIA_POLICY",
+            "UITEST_READING_MEDIA_DATA_SAVING"
+        ])
+        let image = app.descendants(matching: .any)["thread-inline-image"]
+        XCTAssertTrue(image.waitForExistence(timeout: 5))
+        let failedPreview = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "图片预览加载失败，加载原图"),
+            object: image
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [failedPreview], timeout: 5), .completed)
+
+        image.tap()
+        let loadedOriginal = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label BEGINSWITH %@", "查看"),
+            object: image
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [loadedOriginal], timeout: 5), .completed)
+        image.tap()
+        XCTAssertTrue(app.buttons["关闭图片"].waitForExistence(timeout: 8))
+    }
+
+    func testManualVideoCoverFailureStillAllowsPlayback() {
+        let app = launchApp(additionalArguments: [
+            "UITEST_READER_MEDIA_POLICY",
+            "UITEST_READING_MEDIA_MANUAL"
+        ])
+        let video = app.buttons["加载视频封面"]
+        XCTAssertTrue(video.waitForExistence(timeout: 5))
+        video.tap()
+
+        let failedCover = app.buttons["播放视频，封面加载失败"]
+        XCTAssertTrue(failedCover.waitForExistence(timeout: 5))
+        failedCover.tap()
+        XCTAssertTrue(app.buttons["关闭视频"].waitForExistence(timeout: 5))
+    }
+
+    func testAutomaticVideoCoverFailureDoesNotBlockMediaDestinations() {
+        let app = launchApp(additionalArguments: ["UITEST_READER_MEDIA_POLICY"])
+
+        let video = app.buttons["播放视频，封面加载失败"]
+        XCTAssertTrue(video.waitForExistence(timeout: 5))
+        video.tap()
+        let closeVideo = app.buttons["关闭视频"]
+        XCTAssertTrue(closeVideo.waitForExistence(timeout: 5))
+        closeVideo.tap()
+
+        let gridVideo = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "测试视频，封面加载失败")
+        ).firstMatch
+        XCTAssertTrue(gridVideo.waitForExistence(timeout: 5))
+        gridVideo.tap()
+        XCTAssertTrue(
+            app.staticTexts["reader-media-grid-action"]
+                .waitForExistence(timeout: 5)
+        )
+        XCTAssertEqual(
+            app.staticTexts["reader-media-grid-action"].label,
+            "已打开媒体网格目标"
+        )
+    }
+
     func testFullScreenImageTransitionHandlesCroppedThumbnailAndOriginalRatio() {
         let arguments = [
             "UITEST_IMAGE_VIEWER",
@@ -2782,6 +2886,133 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(systemOption.waitForExistence(timeout: 5))
         systemOption.tap()
         XCTAssertTrue(waitForAppearance(expectedSystemAppearance, in: app))
+    }
+
+    func testReadingSettingsPersistAndApplyToNewThreadAndManualMedia() {
+        var app = launchApp(scenario: "imageGesture")
+        rootTab("我的", in: app).tap()
+
+        let settingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(settingsEntry, in: app, maxSwipes: 8))
+        settingsEntry.tap()
+        XCTAssertTrue(app.navigationBars["设置"].waitForExistence(timeout: 8))
+
+        let readingEntry = app.buttons["settings-reading-entry"]
+        XCTAssertTrue(revealBySwipingUp(readingEntry, in: app, maxSwipes: 4))
+        readingEntry.tap()
+        XCTAssertTrue(app.navigationBars["阅读设置"].waitForExistence(timeout: 8))
+
+        let extraLarge = pickerOption(
+            "特大",
+            identifier: "reading-font-size-picker",
+            in: app
+        )
+        let relaxed = pickerOption(
+            "宽松",
+            identifier: "reading-line-spacing-picker",
+            in: app
+        )
+        XCTAssertTrue(revealBySwipingUp(extraLarge, in: app, maxSwipes: 2))
+        extraLarge.tap()
+        XCTAssertTrue(revealBySwipingUp(relaxed, in: app, maxSwipes: 2))
+        relaxed.tap()
+        XCTAssertTrue(app.descendants(matching: .any)["reading-typography-preview"].exists)
+
+        let replySortPicker = app.segmentedControls["reading-reply-sort-picker"]
+        XCTAssertTrue(revealBySwipingUp(replySortPicker, in: app, maxSwipes: 4))
+        let descending = replySortPicker.buttons["倒序"]
+        XCTAssertTrue(descending.waitForExistence(timeout: 2))
+        descending.tap()
+
+        let manual = pickerOption(
+            "手动加载",
+            identifier: "reading-media-loading-picker",
+            exactLabel: false,
+            in: app
+        )
+        XCTAssertTrue(revealBySwipingUp(manual, in: app, maxSwipes: 4))
+        manual.tap()
+
+        app.terminate()
+        app = launchApp(
+            scenario: "imageGesture",
+            resetReadingPreferences: false
+        )
+        rootTab("我的", in: app).tap()
+        let persistedSettingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(persistedSettingsEntry, in: app, maxSwipes: 8))
+        persistedSettingsEntry.tap()
+        let persistedReadingEntry = app.buttons["settings-reading-entry"]
+        XCTAssertTrue(revealBySwipingUp(persistedReadingEntry, in: app, maxSwipes: 4))
+        persistedReadingEntry.tap()
+        XCTAssertTrue(app.navigationBars["阅读设置"].waitForExistence(timeout: 8))
+        let persistedExtraLarge = pickerOption(
+            "特大",
+            identifier: "reading-font-size-picker",
+            in: app
+        )
+        XCTAssertTrue(revealBySwipingUp(persistedExtraLarge, in: app, maxSwipes: 2))
+        XCTAssertTrue(persistedExtraLarge.isSelected)
+        let persistedRelaxed = pickerOption(
+            "宽松",
+            identifier: "reading-line-spacing-picker",
+            in: app
+        )
+        XCTAssertTrue(revealBySwipingUp(persistedRelaxed, in: app, maxSwipes: 2))
+        XCTAssertTrue(persistedRelaxed.isSelected)
+        let persistedReplySortPicker = app.segmentedControls["reading-reply-sort-picker"]
+        XCTAssertTrue(revealBySwipingUp(persistedReplySortPicker, in: app, maxSwipes: 4))
+        XCTAssertTrue(persistedReplySortPicker.buttons["倒序"].isSelected)
+        let persistedManual = pickerOption(
+            "手动加载",
+            identifier: "reading-media-loading-picker",
+            exactLabel: false,
+            in: app
+        )
+        XCTAssertTrue(revealBySwipingUp(persistedManual, in: app, maxSwipes: 4))
+        XCTAssertTrue(persistedManual.isSelected)
+
+        rootTab("首页", in: app).tap()
+        openFirstThread(in: app)
+        let descendingSort = app.buttons["thread-reply-sort-1"]
+        XCTAssertTrue(revealBySwipingUp(descendingSort, in: app, maxSwipes: 8))
+        XCTAssertEqual(descendingSort.value as? String, "已选择")
+
+        let inlineImage = visibleThreadInlineImage(in: app, searchingTowardTop: true)
+        XCTAssertNotNil(inlineImage)
+        XCTAssertEqual(inlineImage?.label, "加载图片")
+        inlineImage?.tap()
+        let loaded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label BEGINSWITH %@", "查看"),
+            object: inlineImage
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [loaded], timeout: 5), .completed)
+        inlineImage?.tap()
+        XCTAssertTrue(app.buttons["关闭图片"].waitForExistence(timeout: 8))
+        app.buttons["关闭图片"].tap()
+
+        // A saved reading position must still restore in deterministic floor
+        // order even when the persisted default for new threads is descending.
+        app.terminate()
+        app = launchApp(
+            scenario: "imageGesture",
+            additionalArguments: ["UITEST_SEED_LOCAL_THREAD_LIBRARY"],
+            resetReadingPreferences: false
+        )
+        rootTab("我的", in: app).tap()
+        let favoritesEntry = app.buttons["thread-favorites-entry"]
+        XCTAssertTrue(revealBySwipingUp(favoritesEntry, in: app, maxSwipes: 8))
+        favoritesEntry.tap()
+        let favoriteRow = app.buttons["thread-favorite-row-1001"]
+        XCTAssertTrue(favoriteRow.waitForExistence(timeout: 8))
+        favoriteRow.tap()
+        XCTAssertTrue(app.otherElements["restored-reading-banner"].waitForExistence(timeout: 5))
+        let returnToTop = app.buttons["restored-reading-return-top"]
+        XCTAssertTrue(returnToTop.waitForExistence(timeout: 5))
+        returnToTop.tap()
+        let ascendingSort = app.buttons["thread-reply-sort-0"]
+        XCTAssertTrue(revealBySwipingUp(ascendingSort, in: app, maxSwipes: 8))
+        XCTAssertEqual(ascendingSort.value as? String, "已选择")
     }
 
     func testFailedInlineImageRetryDoesNotOpenOrClosePreview() {
@@ -3079,7 +3310,7 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
-    func testForumListMediaIsDecorativeAndWholeRowOpensThread() {
+    func testForumListMediaAndWholeRowOpenThread() {
         let app = launchApp(scenario: "forumPinned")
         rootTab("进吧", in: app).tap()
         let forumField = app.textFields["输入吧名"]
@@ -3110,10 +3341,48 @@ final class TiebaPureUITests: XCTestCase {
 
         let row = threadRows(in: app).firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 8))
-        XCTAssertEqual(app.buttons.matching(NSPredicate(format: "label CONTAINS %@", "帖子图片")).count, 0)
+        let media = app.buttons["media-item-image-1001-1"]
+        XCTAssertTrue(media.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            media.label.hasPrefix("打开帖子"),
+            "吧页媒体的 VoiceOver 动作必须说明真实目的地是帖子"
+        )
 
         row.tap()
         XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
+    }
+
+    func testForumManualMediaLoadsBeforeOpeningThread() {
+        let app = launchApp(
+            scenario: "imageGesture",
+            additionalArguments: ["UITEST_READING_MEDIA_MANUAL"]
+        )
+        rootTab("进吧", in: app).tap()
+        let forumField = app.textFields["输入吧名"]
+        XCTAssertTrue(forumField.waitForExistence(timeout: 8))
+        forumField.tap()
+        forumField.typeText("测试\n")
+        XCTAssertTrue(app.navigationBars["测试吧"].waitForExistence(timeout: 8))
+
+        let media = app.buttons["media-item-image-1001-1"]
+        XCTAssertTrue(media.waitForExistence(timeout: 8))
+        XCTAssertTrue(media.label.hasPrefix("加载帖子图片"))
+        media.tap()
+        XCTAssertTrue(app.navigationBars["测试吧"].exists)
+        XCTAssertFalse(app.buttons["thread-favorite-button"].exists)
+
+        let loaded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(
+                format: "NOT (label BEGINSWITH %@) AND NOT (label BEGINSWITH %@)",
+                "加载帖子图片",
+                "正在加载帖子图片"
+            ),
+            object: media
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [loaded], timeout: 5), .completed)
+        XCTAssertTrue(media.label.hasPrefix("打开帖子"))
+        media.tap()
+        XCTAssertTrue(app.buttons["thread-favorite-button"].waitForExistence(timeout: 8))
     }
 
     func testForumLatestMenuSwitchesReplyPublishAndFeaturedCategories() {
@@ -3394,7 +3663,8 @@ final class TiebaPureUITests: XCTestCase {
         scenario: String = "success",
         account: String? = nil,
         additionalArguments: [String] = [],
-        resetAppearance: Bool = true
+        resetAppearance: Bool = true,
+        resetReadingPreferences: Bool = true
     ) -> XCUIApplication {
         let app = XCUIApplication()
         var launchArguments = [
@@ -3408,6 +3678,9 @@ final class TiebaPureUITests: XCTestCase {
         ]
         if resetAppearance {
             launchArguments.append("UITEST_RESET_APPEARANCE")
+        }
+        if resetReadingPreferences {
+            launchArguments.append("UITEST_RESET_READING_PREFERENCES")
         }
         app.launchArguments = launchArguments + additionalArguments
         app.launchEnvironment["TIEBAPURE_FIXTURE_SCENARIO"] = scenario
@@ -3611,6 +3884,41 @@ final class TiebaPureUITests: XCTestCase {
             .firstMatch
     }
 
+    private func pickerOption(
+        _ title: String,
+        identifier: String,
+        exactLabel: Bool = true,
+        in app: XCUIApplication
+    ) -> XCUIElement {
+        if identifier != "reading-media-loading-picker" {
+            return app.segmentedControls[identifier].buttons[title]
+        }
+        let labelPredicate = exactLabel
+            ? NSPredicate(format: "label == %@", title)
+            : NSPredicate(format: "label BEGINSWITH %@", title)
+        return app.buttons
+            .matching(identifier: identifier)
+            .matching(labelPredicate)
+            .firstMatch
+    }
+
+    private func revealBySwipingUp(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        maxSwipes: Int
+    ) -> Bool {
+        if element.waitForExistence(timeout: 2), element.isHittable {
+            return true
+        }
+        for _ in 0..<maxSwipes {
+            app.swipeUp()
+            if element.exists, element.isHittable {
+                return true
+            }
+        }
+        return element.exists && element.isHittable
+    }
+
     private func threadRows(in app: XCUIApplication) -> XCUIElementQuery {
         app.descendants(matching: .any).matching(identifier: "thread-row")
     }
@@ -3725,13 +4033,26 @@ final class TiebaPureUITests: XCTestCase {
         start.press(forDuration: 0.05, thenDragTo: end)
     }
 
-    private func visibleThreadInlineImage(in app: XCUIApplication) -> XCUIElement? {
+    private func visibleThreadInlineImage(
+        in app: XCUIApplication,
+        searchingTowardTop: Bool = false
+    ) -> XCUIElement? {
         let inlineImage = app.descendants(matching: .any)["thread-inline-image"]
-        guard inlineImage.waitForExistence(timeout: 8) else { return nil }
-        for _ in 0..<8 where inlineImage.isHittable == false {
-            app.swipeUp()
+        if inlineImage.waitForExistence(timeout: 2), inlineImage.isHittable {
+            return inlineImage
         }
-        return inlineImage.isHittable ? inlineImage : nil
+        let scrollView = app.scrollViews["thread-detail-scroll-view"]
+        for _ in 0..<20 {
+            if inlineImage.exists, inlineImage.isHittable {
+                return inlineImage
+            }
+            if searchingTowardTop {
+                scrollView.swipeDown()
+            } else {
+                scrollView.swipeUp()
+            }
+        }
+        return inlineImage.exists && inlineImage.isHittable ? inlineImage : nil
     }
 
     private func waitForElement(named name: String, in app: XCUIApplication, maxSwipes: Int) -> Bool {

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.3.2
-        CURRENT_PROJECT_VERSION: 20
+        MARKETING_VERSION: 1.3.3
+        CURRENT_PROJECT_VERSION: 21
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.3.2
-        CURRENT_PROJECT_VERSION: 20
+        MARKETING_VERSION: 1.3.3
+        CURRENT_PROJECT_VERSION: 21
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 变更
- 新增阅读字号、行距、默认帖子排序和媒体加载策略，并持久化到本机设置
- 仅调整帖子详情排版，首页、吧页和搜索摘要维持简略显示
- 为手动加载与节省流量模式加入按媒体源隔离的授权、失败降级和无障碍状态
- 补齐帖子定位、阅读位置恢复时强制正序，以及吧页媒体两阶段点击

## 验证
- 单元测试：342 通过，1 个预期跳过，0 失败
- iPhone 17：9 条阅读设置与媒体状态 UI 测试通过
- iPhone SE 3：默认字号和 Accessibility XXXL 两轮通过
- iPad Pro 11-inch M5：阅读流程通过
- xcodebuild analyze、Debug/Release 构建、XcodeGen 一致性与 unsigned IPA 结构校验通过

## 依赖关系
这是基于 #8 的堆叠 PR；请先审查和合并 #8，再合并本 PR。