### PR TITLE
修复刷新背景与视频预览交互

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		388FED0A277CBB09D2C252F5 /* TiebaEmoticonRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9BED7F7A1BE8C617FE2F15 /* TiebaEmoticonRepository.swift */; };
 		3C76B30ACE505A1329C35516 /* SubpostSheetInteractiveDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BC2EF1ED11AC6A71B3CED6 /* SubpostSheetInteractiveDismiss.swift */; };
 		3E83765E473D5A072792B006 /* TiebaPureProfile_UserProfile.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094A7B97C027D43346675B29 /* TiebaPureProfile_UserProfile.pb.swift */; };
+		3E9872C838729BB48E4DD67A /* VideoPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */; };
 		3F0E94381375C8E91ECFC5F4 /* ThreadMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946B2D7B6BCE7C2C716A3EB2 /* ThreadMapper.swift */; };
 		4121F3AF9F06FDC97D3C39C1 /* Media.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD087D4F0E7FA8246D26D8CB /* Media.pb.swift */; };
 		41274F99F33CBB936296671F /* SafariActionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872607E2663432D3116C5BB6 /* SafariActionPayload.swift */; };
@@ -68,6 +69,7 @@
 		61AC96A8DF8D9A6671239F30 /* TiebaURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3321457BFA9611243ABF93 /* TiebaURL.swift */; };
 		66CB3F6B00C11572EF7276D1 /* TiebaUserProfileAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55649E6AEA1AD2EF4813452 /* TiebaUserProfileAPI.swift */; };
 		691639A3C4F64DE3F892A98D /* ContentBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B4550B620AEBC6B7EA4F46 /* ContentBlockView.swift */; };
+		6A3F2F36CE6C23941BD07F7E /* MediaPreviewPresentationArbiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A89193F661C5F61F3470AC /* MediaPreviewPresentationArbiter.swift */; };
 		6BF8CB32442EA2DD70E1BEE9 /* SocialRelationshipStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A829A6D2ABD0F1D55D90E6 /* SocialRelationshipStateTests.swift */; };
 		71CE2CA03E418210ED2CCF8B /* CapsuleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994E9D3128F82A0683DA39E0 /* CapsuleLabel.swift */; };
 		736CA9D7B75258F513F36463 /* TiebaPureTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25F6DDA828E44F9B5A0E5D9 /* TiebaPureTheme.swift */; };
@@ -130,6 +132,7 @@
 		D0EB13806B12EBFE42C8D71B /* RecentForum.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE02417BF13C2E0A1D7824E /* RecentForum.swift */; };
 		D3B0D1E46535FF84CB41BAB7 /* SecurityRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594CFFAE35B27CDF27D9B903 /* SecurityRegressionTests.swift */; };
 		D3F2C72D1BAA5E6241C68B52 /* MetadataLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5F7218DA6FD8845675AE38 /* MetadataLine.swift */; };
+		D4E99B8D333718179465BF3E /* VideoPreviewTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF513D0BD122423A4CA7423D /* VideoPreviewTransition.swift */; };
 		D650566AC4F83CB216678D7B /* SwiftProtobuf-Apache-2.0.txt in Resources */ = {isa = PBXBuildFile; fileRef = B6698EB80DB6FC3196AA8060 /* SwiftProtobuf-Apache-2.0.txt */; };
 		D7489E995A495B30B67EBE11 /* TiebaPureOpenIn.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B571B662CFFFF46F507E2FC5 /* TiebaPureOpenIn.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D7C5F5C2AC1C00249AD9BC1E /* TiebaEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33822A8A48EC0393DD592DDA /* TiebaEndpoint.swift */; };
@@ -142,6 +145,7 @@
 		DE64CDA4FA60F57188F7BC53 /* UserProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */; };
 		DEA70B990FBB4F0B3A27998B /* SearchRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DFFE894245E0C72DB94FFD /* SearchRoute.swift */; };
 		DEF7E4F5C3BB5C3AC25E89EF /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C482CF17BA5520B13F1B03 /* AppAppearance.swift */; };
+		DFDB57457FFB61942BC48E4E /* MediaPreviewHeroAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034D76B7DA1D80733B718828 /* MediaPreviewHeroAnimator.swift */; };
 		E1835BAE94DEB0B7D30F0B13 /* ReadingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638DEF254549D0D4DE625487 /* ReadingPreferences.swift */; };
 		E3CF1C9A62133316FF6D93E2 /* UserProfileMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F7C671CDA66E5F18CEC24 /* UserProfileMapper.swift */; };
 		E4BC7D1B10FF88D762725986 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E2287E1195B4261B0B88E8 /* SettingsView.swift */; };
@@ -205,6 +209,7 @@
 /* Begin PBXFileReference section */
 		00339148CB9511CB5F6A624F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0060EA54C03E209E46FB2C40 /* ForumThreadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumThreadsView.swift; sourceTree = "<group>"; };
+		034D76B7DA1D80733B718828 /* MediaPreviewHeroAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewHeroAnimator.swift; sourceTree = "<group>"; };
 		06BFF7EDD31716056CE12B69 /* TiebaAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaAPI.swift; sourceTree = "<group>"; };
 		07566334FE43A9F9BF360D89 /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		07C158046155BBD6748519CF /* TiebaContentSubmissionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaContentSubmissionAPI.swift; sourceTree = "<group>"; };
@@ -297,6 +302,7 @@
 		83A586DD3DD949672854FF9E /* ContentSubmissionNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSubmissionNetworkTests.swift; sourceTree = "<group>"; };
 		8567BF0F4AD60813192B13FB /* Agree.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agree.pb.swift; sourceTree = "<group>"; };
 		872607E2663432D3116C5BB6 /* SafariActionPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariActionPayload.swift; sourceTree = "<group>"; };
+		87A89193F661C5F61F3470AC /* MediaPreviewPresentationArbiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewPresentationArbiter.swift; sourceTree = "<group>"; };
 		8ADF8B92CA2483FCA22CEEE6 /* PostRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRowView.swift; sourceTree = "<group>"; };
 		8B097E875FE8B825D77AD05F /* LocalThreadLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalThreadLibrary.swift; sourceTree = "<group>"; };
 		8C21E4C8027927C8D821B1B6 /* VoicePlaybackCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlaybackCoordinator.swift; sourceTree = "<group>"; };
@@ -340,6 +346,7 @@
 		D9DDCEE2EB7CAB5604D83C90 /* SubPostList.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubPostList.pb.swift; sourceTree = "<group>"; };
 		DB22109F3B9CFD8850C4BEE0 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		DBA0A4653556BD11ACA8C0A3 /* AnonymousLiveSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLiveSmokeTests.swift; sourceTree = "<group>"; };
+		DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewTests.swift; sourceTree = "<group>"; };
 		DE6967B15A66331DA9F947F0 /* MessageAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAPITests.swift; sourceTree = "<group>"; };
 		E425761E05D459199869361A /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		E442EEBED99D57F019D339D0 /* VoiceAudioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioClient.swift; sourceTree = "<group>"; };
@@ -358,6 +365,7 @@
 		FD087D4F0E7FA8246D26D8CB /* Media.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.pb.swift; sourceTree = "<group>"; };
 		FDB42F9B13D5397C990ED17F /* SubPost.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubPost.pb.swift; sourceTree = "<group>"; };
 		FDE02417BF13C2E0A1D7824E /* RecentForum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentForum.swift; sourceTree = "<group>"; };
+		FF513D0BD122423A4CA7423D /* VideoPreviewTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewTransition.swift; sourceTree = "<group>"; };
 		FF76DC72E50AAADA883B8D85 /* SubpostPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubpostPreviewView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -621,6 +629,7 @@
 				53A22DDA746D43724E44B7D2 /* TiebaPureSmokeTests.swift */,
 				9CE43843ABF0E6FE36F6A7BD /* TiebaURLTests.swift */,
 				3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */,
+				DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */,
 				3ABAA8240FEE5D60D5C61349 /* VoicePlaybackControlTests.swift */,
 				273C5E55B0D298678C72F894 /* VoicePlaybackTests.swift */,
 			);
@@ -653,7 +662,10 @@
 			children = (
 				35CD0BAA4D26A1DBC8367F53 /* ImageDownloadService.swift */,
 				AF02A66EF1B9089518F9ED99 /* ImageViewer.swift */,
+				034D76B7DA1D80733B718828 /* MediaPreviewHeroAnimator.swift */,
+				87A89193F661C5F61F3470AC /* MediaPreviewPresentationArbiter.swift */,
 				AABE9716DCC2C5720A003041 /* VideoPlayerView.swift */,
+				FF513D0BD122423A4CA7423D /* VideoPreviewTransition.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -1005,6 +1017,8 @@
 				3350633EF8736792C66DA2B4 /* MeView.swift in Sources */,
 				4121F3AF9F06FDC97D3C39C1 /* Media.pb.swift in Sources */,
 				DB2E0B012007D19C5D4F3B9D /* MediaGridView.swift in Sources */,
+				DFDB57457FFB61942BC48E4E /* MediaPreviewHeroAnimator.swift in Sources */,
+				6A3F2F36CE6C23941BD07F7E /* MediaPreviewPresentationArbiter.swift in Sources */,
 				F60F13E9F3CF7AA790EE1C4A /* MessagesView.swift in Sources */,
 				D3F2C72D1BAA5E6241C68B52 /* MetadataLine.swift in Sources */,
 				4A8E23945EF79EAEFE3019DC /* MultipartFormData.swift in Sources */,
@@ -1068,6 +1082,7 @@
 				470AA98A8CA5F65598F45AFF /* UserProfileView.swift in Sources */,
 				AA3AF8E9A9956DD4FAEA8638 /* VideoInfo.pb.swift in Sources */,
 				CE70750547AFB3CB53EDE288 /* VideoPlayerView.swift in Sources */,
+				D4E99B8D333718179465BF3E /* VideoPreviewTransition.swift in Sources */,
 				B4A335E483F17819940BE505 /* Voice.pb.swift in Sources */,
 				DA522E7CE4A6AF749533B6C3 /* VoiceAudioClient.swift in Sources */,
 				FFA0818B86B2CCB9CDB7539F /* VoicePlaybackControl.swift in Sources */,
@@ -1102,6 +1117,7 @@
 				C0E5134C9E23DDD474D84DDA /* TiebaPureSmokeTests.swift in Sources */,
 				450F423517B8D1DEFD51B15B /* TiebaURLTests.swift in Sources */,
 				DE64CDA4FA60F57188F7BC53 /* UserProfileTests.swift in Sources */,
+				3E9872C838729BB48E4DD67A /* VideoPreviewTests.swift in Sources */,
 				8013F79EDBAB28236D574DAD /* VoicePlaybackControlTests.swift in Sources */,
 				07DE68396A13E2AD45D1B77F /* VoicePlaybackTests.swift in Sources */,
 			);
@@ -1207,13 +1223,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.6;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1224,14 +1240,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.6;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1277,14 +1293,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.6;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1297,13 +1313,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.6;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Core/UI/MediaGridView.swift
+++ b/TiebaPure/Core/UI/MediaGridView.swift
@@ -230,11 +230,10 @@ private struct MediaItemButton: View {
                 isManualLoadAuthorized: isManualLoadAuthorized,
                 explicitOriginalAuthorization: explicitFallbackAuthorization,
                 showsManualLoadIndicator: true,
-                previewSource: item.kind == .image ? previewSource : nil,
-                onTransitionTap: item.kind == .image ? activate : nil,
+                previewSource: previewSource,
+                onTransitionTap: activate,
                 onLoadStateChange: { loadState = $0 },
                 onImageResolved: {
-                    guard item.kind == .image else { return }
                     previewSource.store(
                         image: $0,
                         sourceIdentity: item.previewSourceIdentity

--- a/TiebaPure/Core/UI/ReaderStateView.swift
+++ b/TiebaPure/Core/UI/ReaderStateView.swift
@@ -121,11 +121,12 @@ struct ReaderStateScrollView<Content: View>: View {
                 content
                     .frame(maxWidth: .infinity)
                     // Keep the empty state genuinely scrollable so overscroll
-                    // geometry is still emitted for the 64-point refresh.
+                    // geometry is still emitted for the 80-point refresh.
                     .frame(minHeight: max(proxy.size.height + 1, 1))
             }
             .accessibilityIdentifier("reader-state-scroll-view")
             .shortPullRefresh(
+                surface: .grouped,
                 accessibilityIdentifier: "reader-state-refresh-animation",
                 action: refresh
             )

--- a/TiebaPure/Core/UI/ShortPullRefresh.swift
+++ b/TiebaPure/Core/UI/ShortPullRefresh.swift
@@ -143,6 +143,24 @@ enum ShortPullRefreshSource: Sendable {
     case programmatic
 }
 
+enum ShortPullRefreshSurface: Equatable, Sendable {
+    case grouped
+    case plain
+
+    var color: Color {
+        Color(uiColor: uiColor)
+    }
+
+    var uiColor: UIColor {
+        switch self {
+        case .grouped:
+            .systemGroupedBackground
+        case .plain:
+            .systemBackground
+        }
+    }
+}
+
 /// Small equatable projection keeps `onScrollGeometryChange` updates limited to
 /// the values that actually affect pull-to-refresh.
 struct ShortPullRefreshGeometry: Equatable {
@@ -205,12 +223,14 @@ extension View {
     /// Apply this modifier directly to a vertical `ScrollView` or `List`.
     func shortPullRefresh(
         isEnabled: Bool = true,
+        surface: ShortPullRefreshSurface = .grouped,
         accessibilityIdentifier: String = "short-pull-refresh-indicator",
         action: @escaping () async -> Void
     ) -> some View {
         modifier(
             ShortPullRefreshModifier(
                 isEnabled: isEnabled,
+                surface: surface,
                 accessibilityIdentifier: accessibilityIdentifier,
                 programmaticRefreshToken: 0,
                 action: { _ in await action() }
@@ -224,6 +244,7 @@ extension View {
     /// visually identical.
     func shortPullRefresh(
         isEnabled: Bool = true,
+        surface: ShortPullRefreshSurface = .grouped,
         accessibilityIdentifier: String = "short-pull-refresh-indicator",
         programmaticRefreshToken: Int,
         action: @escaping (ShortPullRefreshSource) async -> Void
@@ -231,6 +252,7 @@ extension View {
         modifier(
             ShortPullRefreshModifier(
                 isEnabled: isEnabled,
+                surface: surface,
                 accessibilityIdentifier: accessibilityIdentifier,
                 programmaticRefreshToken: programmaticRefreshToken,
                 action: action
@@ -255,6 +277,7 @@ private struct ShortPullRefreshModifier: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let isEnabled: Bool
+    let surface: ShortPullRefreshSurface
     let accessibilityIdentifier: String
     let programmaticRefreshToken: Int
     let action: (ShortPullRefreshSource) async -> Void
@@ -272,9 +295,15 @@ private struct ShortPullRefreshModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         ZStack(alignment: .top) {
+            surface.color
+                .accessibilityHidden(true)
+
             content
                 .background {
-                    ShortPullScrollViewPanObserver(onStateChange: handlePanChange)
+                    ShortPullScrollViewPanObserver(
+                        surfaceColor: surface.uiColor,
+                        onStateChange: handlePanChange
+                    )
                         .accessibilityHidden(true)
                 }
                 .onScrollGeometryChange(for: ShortPullRefreshGeometry.self) { geometry in
@@ -298,6 +327,7 @@ private struct ShortPullRefreshModifier: ViewModifier {
             refreshOverlay
                 .allowsHitTesting(false)
         }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .clipped()
             .onDisappear {
                 cancelRefresh()
@@ -535,10 +565,11 @@ private struct ShortPullRefreshModifier: ViewModifier {
 /// the existing recognizer, so native iOS navigation gestures keep their
 /// normal arbitration and no second gesture competes for the same touch.
 private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
+    let surfaceColor: UIColor
     let onStateChange: (UIGestureRecognizer.State, CGSize) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onStateChange: onStateChange)
+        Coordinator(surfaceColor: surfaceColor, onStateChange: onStateChange)
     }
 
     func makeUIView(context: Context) -> AttachmentView {
@@ -553,6 +584,7 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: AttachmentView, context: Context) {
+        context.coordinator.surfaceColor = surfaceColor
         context.coordinator.onStateChange = onStateChange
         context.coordinator.scheduleAttachment(from: uiView)
     }
@@ -577,11 +609,22 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject {
+        var surfaceColor: UIColor {
+            didSet {
+                attachedScrollView?.backgroundColor = surfaceColor
+            }
+        }
         var onStateChange: (UIGestureRecognizer.State, CGSize) -> Void
+        private weak var attachedScrollView: UIScrollView?
+        private var originalBackgroundColor: UIColor?
         private weak var panGestureRecognizer: UIPanGestureRecognizer?
         private var pendingAttachment: DispatchWorkItem?
 
-        init(onStateChange: @escaping (UIGestureRecognizer.State, CGSize) -> Void) {
+        init(
+            surfaceColor: UIColor,
+            onStateChange: @escaping (UIGestureRecognizer.State, CGSize) -> Void
+        ) {
+            self.surfaceColor = surfaceColor
             self.onStateChange = onStateChange
         }
 
@@ -600,14 +643,34 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
             pendingAttachment = nil
             panGestureRecognizer?.removeTarget(self, action: #selector(handlePan(_:)))
             panGestureRecognizer = nil
+            restoreScrollBackground()
         }
 
         private func attach(to scrollView: UIScrollView?) {
-            guard let recognizer = scrollView?.panGestureRecognizer else { return }
-            guard panGestureRecognizer !== recognizer else { return }
+            guard let scrollView else { return }
+            let recognizer = scrollView.panGestureRecognizer
+            if attachedScrollView === scrollView,
+               panGestureRecognizer === recognizer {
+                scrollView.backgroundColor = surfaceColor
+                return
+            }
             panGestureRecognizer?.removeTarget(self, action: #selector(handlePan(_:)))
+            restoreScrollBackground()
+            attachedScrollView = scrollView
+            originalBackgroundColor = scrollView.backgroundColor
+            // UIKit renders rubber-band overscroll using the scroll view's
+            // own background, not the SwiftUI background behind it. Keeping
+            // both surfaces identical prevents a white/gray seam while the
+            // refresh hold settles after release.
+            scrollView.backgroundColor = surfaceColor
             panGestureRecognizer = recognizer
             recognizer.addTarget(self, action: #selector(handlePan(_:)))
+        }
+
+        private func restoreScrollBackground() {
+            attachedScrollView?.backgroundColor = originalBackgroundColor
+            attachedScrollView = nil
+            originalBackgroundColor = nil
         }
 
         @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -382,6 +382,7 @@ struct ForumThreadsView: View {
             .accessibilityIdentifier("forum-threads-scroll-view")
             .shortPullRefresh(
                 isEnabled: didLoad && isLoading == false,
+                surface: .grouped,
                 accessibilityIdentifier: "forum-refresh-animation"
             ) {
                 guard isLoading == false else { return }

--- a/TiebaPure/Features/ForumHub/ForumHubView.swift
+++ b/TiebaPure/Features/ForumHub/ForumHubView.swift
@@ -117,9 +117,11 @@ struct ForumHubView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
         .accessibilityIdentifier("forum-hub-list")
         .shortPullRefresh(
             isEnabled: isLoadingFollowed == false,
+            surface: .grouped,
             accessibilityIdentifier: "forum-hub-refresh-animation"
         ) {
             recentStore.reload()
@@ -127,6 +129,7 @@ struct ForumHubView: View {
                 await loadFollowed(account: account)
             }
         }
+        .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
         .navigationTitle("进吧")
         .navigationBarTitleDisplayMode(.inline)
         .interactiveNavigationPopRevealSource()

--- a/TiebaPure/Features/ForumList/ForumListView.swift
+++ b/TiebaPure/Features/ForumList/ForumListView.swift
@@ -23,7 +23,12 @@ struct ForumListView: View {
     }
 
     var body: some View {
-        Group {
+        VStack(spacing: 0) {
+            if didLoad {
+                followedForumSearchField
+            }
+
+            Group {
                 if isLoading && didLoad == false {
                     ReaderStateView.loading("正在加载贴吧")
                 } else if let errorMessage, forums.isEmpty {
@@ -63,16 +68,21 @@ struct ForumListView: View {
                         }
                         .readableWidth()
                     }
+                    .accessibilityIdentifier("followed-forum-list")
                     .shortPullRefresh(
                         isEnabled: didLoad && isLoading == false,
+                        surface: .grouped,
                         accessibilityIdentifier: "forum-list-refresh-animation"
                     ) {
                         await reload()
                     }
-                    .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
                 }
             }
-        .navigationTitle("我的关注吧")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+        .navigationTitle("关注的吧")
+        .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(isPresented: selectedForumIsActive) {
             if let selectedForum {
                 ForumThreadsView(account: account, forum: selectedForum.forum)
@@ -81,7 +91,6 @@ struct ForumListView: View {
                     }
             }
         }
-        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "搜索贴吧")
         .task {
             guard didLoad == false else { return }
             await reload()
@@ -121,6 +130,42 @@ struct ForumListView: View {
             isLoading = false
         }
         .fullScreenInteractiveNavigationPop()
+    }
+
+    private var followedForumSearchField: some View {
+        HStack(spacing: TiebaPureTheme.Spacing.xs) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            TextField("搜索贴吧", text: $searchText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .accessibilityIdentifier("followed-forum-search-field")
+
+            if searchText.isEmpty == false {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .minTouchTarget()
+                .accessibilityLabel("清除搜索")
+            }
+        }
+        .frame(minHeight: 44)
+        .padding(.leading, TiebaPureTheme.Spacing.sm)
+        .padding(.trailing, searchText.isEmpty ? TiebaPureTheme.Spacing.sm : 0)
+        .background(
+            TiebaPureTheme.ColorToken.readerSecondarySurface,
+            in: RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card)
+        )
+        .padding(.horizontal, TiebaPureTheme.Spacing.md)
+        .padding(.vertical, TiebaPureTheme.Spacing.xs)
+        .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
     }
 
     private var selectedForumIsActive: Binding<Bool> {

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -19,7 +19,6 @@ struct HomeView: View {
     @State private var didLoad = false
     @State private var errorMessage: String?
     @State private var navigationPath: [HomeNavigationRoute] = []
-    @State private var selectedVideoPreview: HomeVideoPreview?
     @State private var selectedUser: UserSummary?
     @State private var programmaticRefreshToken = 0
     @State private var lastScenePhase: ScenePhase = .inactive
@@ -186,9 +185,6 @@ struct HomeView: View {
             }
             Task { await reload(trigger: .appOpen) }
         }
-        .fullScreenCover(item: $selectedVideoPreview) { preview in
-            DirectVideoPlaybackView(video: preview.video)
-        }
         .onDisappear {
             loadTask?.cancel()
             requestGeneration += 1
@@ -343,7 +339,14 @@ struct HomeView: View {
                                     )
                                 )
                             case let .playVideo(video):
-                                selectedVideoPreview = HomeVideoPreview(video: video)
+                                VideoPreviewCoordinator.shared.present(
+                                    VideoPreviewSession(
+                                        video: video,
+                                        sourceFrame: sourceFrame,
+                                        sourceImage: sourceImage,
+                                        sourceAnchor: sourceAnchor
+                                    )
+                                )
                             case .openThread:
                                 openThread(threadID: thread.id, forumID: thread.forumID)
                             }
@@ -414,6 +417,7 @@ struct HomeView: View {
             .accessibilityIdentifier("home-feed-scroll-view")
             .shortPullRefresh(
                 isEnabled: didLoad && isLoading == false,
+                surface: .grouped,
                 accessibilityIdentifier: "home-refresh-animation",
                 programmaticRefreshToken: programmaticRefreshToken
             ) { source in
@@ -637,11 +641,6 @@ enum HomeFeedMerge {
 
         return merged
     }
-}
-
-struct HomeVideoPreview: Identifiable {
-    let id = UUID()
-    let video: VideoContent
 }
 
 enum HomeMediaAction: Equatable {

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -573,6 +573,10 @@ final class ImagePreviewSourceAnchor: ObservableObject {
         view?.image = nil
     }
 
+    func prepareForReuse(sourceIdentity: String) {
+        bind(to: sourceIdentity)
+    }
+
 #if DEBUG
     func visibleImageObservation(
         token: ImagePreviewSourceToken?
@@ -1638,496 +1642,6 @@ final class ImagePreviewHeroSourceLease {
     }
 }
 
-@MainActor
-private final class ImagePreviewHeroAnimator: NSObject,
-    UIViewControllerAnimatedTransitioning {
-    enum Operation {
-        case presentation
-        case dismissal
-    }
-
-    private weak var controller: ImagePreviewHostingController?
-    private let operation: Operation
-    private var activeCleanup: ((Bool) -> Void)?
-    private var didReportOutcome = false
-    private var didEndTransition = false
-
-    /// Cubic Bezier approximation of the sinusoidal easing
-    /// `(1 - cos(.pi * progress)) / 2` that the removed display-link timeline
-    /// applied per tick, so the render-server-driven motion keeps the same feel.
-    private static let heroTimingFunction = CAMediaTimingFunction(
-        controlPoints: 0.37, 0, 0.63, 1
-    )
-
-    init(operation: Operation, controller: ImagePreviewHostingController) {
-        self.operation = operation
-        self.controller = controller
-        super.init()
-    }
-
-    func transitionDuration(
-        using transitionContext: UIViewControllerContextTransitioning?
-    ) -> TimeInterval {
-        0.32
-    }
-
-    func animateTransition(
-        using transitionContext: UIViewControllerContextTransitioning
-    ) {
-        guard let controller else {
-            transitionContext.completeTransition(false)
-            return
-        }
-        switch operation {
-        case .presentation:
-            animatePresentation(
-                controller: controller,
-                transitionContext: transitionContext
-            )
-        case .dismissal:
-            animateDismissal(
-                controller: controller,
-                transitionContext: transitionContext
-            )
-        }
-    }
-
-    func animationEnded(_ transitionCompleted: Bool) {
-        didEndTransition = true
-        runActiveCleanup(completed: transitionCompleted)
-        reportOutcome(completed: transitionCompleted)
-    }
-
-    private func animatePresentation(
-        controller: ImagePreviewHostingController,
-        transitionContext: UIViewControllerContextTransitioning
-    ) {
-        guard let sourceController = transitionContext.viewController(forKey: .from),
-              let destinationController = transitionContext.viewController(forKey: .to),
-              let destinationView = transitionContext.view(forKey: .to) else {
-            transitionContext.completeTransition(false)
-            return
-        }
-
-        let containerView = transitionContext.containerView
-        destinationView.frame = transitionContext.finalFrame(for: destinationController)
-        containerView.addSubview(destinationView)
-        destinationView.layoutIfNeeded()
-
-        guard let sourceView = controller.stableTransitionSourceView(
-            in: sourceController
-        ),
-        let image = sourceView.image,
-        let sourceFrame = ImagePreviewTransitionGeometry.validSourceFrame(
-            sourceView.convert(sourceView.bounds, to: containerView)
-        ) else {
-            animateCrossDissolve(
-                appearingView: destinationView,
-                disappearingView: nil,
-                appearingViewWasInserted: true,
-                transitionContext: transitionContext
-            )
-            return
-        }
-
-        let targetFrame = ImagePreviewTransitionGeometry.aspectFitFrame(
-            imageSize: image.size,
-            in: destinationView.frame
-        )
-        let sourceCornerRadius = sourceView.layer.cornerRadius
-        guard let lease = ImagePreviewHeroSourceLease(
-            sourceView: sourceView,
-            image: image,
-            sourceIdentity: controller.session.sourceIdentity,
-            containerView: containerView,
-            imageFrame: sourceFrame,
-            cornerRadius: sourceCornerRadius
-        ) else {
-            animateCrossDissolve(
-                appearingView: destinationView,
-                disappearingView: nil,
-                appearingViewWasInserted: true,
-                transitionContext: transitionContext
-            )
-            return
-        }
-
-        let dimmingView = UIView(frame: containerView.bounds)
-        dimmingView.backgroundColor = .black
-        dimmingView.alpha = 0
-        containerView.insertSubview(dimmingView, belowSubview: lease.proxyView)
-        destinationView.alpha = 0
-        let interactionGate = Self.makeInteractionGate(in: containerView)
-        installActiveCleanup { completed in
-            Self.removeInteractionGate(interactionGate)
-            dimmingView.removeFromSuperview()
-            lease.finish()
-            destinationView.alpha = 1
-            if completed == false {
-                destinationView.removeFromSuperview()
-            }
-        }
-
-        let duration = transitionDuration(using: transitionContext)
-        var didCompleteTransition = false
-        let completeTransition = {
-            guard didCompleteTransition == false,
-                  self.didEndTransition == false else {
-                return
-            }
-            didCompleteTransition = true
-            let completed = transitionContext.transitionWasCancelled == false
-            self.commitCleanupBeforeCompletion {
-                self.runActiveCleanup(completed: completed)
-            } completion: {
-                self.reportOutcome(completed: completed)
-                transitionContext.completeTransition(completed)
-            }
-        }
-
-        // One committed transaction owns both the outer geometry and the crop:
-        // the model layers land on the exact endpoint and the render server
-        // replays the motion, so main-thread work during the 0.32s window can
-        // no longer drop hero frames. Every edge still moves only toward its
-        // final value.
-        runHeroAnimations(
-            lease: lease,
-            dimmingView: dimmingView,
-            image: image,
-            startFrame: sourceFrame,
-            endFrame: targetFrame,
-            startCornerRadius: sourceCornerRadius,
-            endCornerRadius: 0,
-            startDimmingOpacity: 0,
-            endDimmingOpacity: 1,
-            duration: duration,
-            completion: {
-                completeTransition()
-            }
-        )
-    }
-
-    private func animateDismissal(
-        controller: ImagePreviewHostingController,
-        transitionContext: UIViewControllerContextTransitioning
-    ) {
-        guard let sourceController = transitionContext.viewController(forKey: .to),
-              let dismissedView = transitionContext.view(forKey: .from) else {
-            transitionContext.completeTransition(false)
-            return
-        }
-
-        let containerView = transitionContext.containerView
-        // Under .overFullScreen the presenting hierarchy was never removed and
-        // the context vends no destination view: the live source page already
-        // sits below the container, so nothing is re-inserted or re-laid-out
-        // before the first frame. The insertion branch remains for contexts
-        // that do manage the destination view.
-        let destinationView = transitionContext.view(forKey: .to)
-        let destinationWasInserted: Bool
-        if let destinationView, destinationView.superview == nil {
-            destinationView.frame = transitionContext.finalFrame(for: sourceController)
-            containerView.insertSubview(destinationView, belowSubview: dismissedView)
-            destinationView.layoutIfNeeded()
-            destinationWasInserted = true
-        } else {
-            destinationWasInserted = false
-        }
-
-        let currentIndex = controller.transitionState.currentIndex
-        guard currentIndex == controller.session.initialIndex,
-              controller.transitionState.allowsInteractiveDismissal,
-              let sourceView = controller.stableTransitionSourceView(
-                  in: sourceController
-              ),
-              let image = controller.transitionContent.image(at: currentIndex)
-                  ?? sourceView.image,
-              let sourceFrame = ImagePreviewTransitionGeometry.validSourceFrame(
-                  sourceView.convert(sourceView.bounds, to: containerView)
-              ) else {
-            animateCrossDissolve(
-                appearingView: destinationView,
-                disappearingView: dismissedView,
-                appearingViewWasInserted: destinationWasInserted,
-                transitionContext: transitionContext
-            )
-            return
-        }
-
-        let fullScreenFrame = controller.transitionContent.frame(
-            at: currentIndex,
-            convertedTo: containerView
-        ) ?? ImagePreviewTransitionGeometry.aspectFitFrame(
-            imageSize: image.size,
-            in: dismissedView.frame
-        )
-        let sourceCornerRadius = sourceView.layer.cornerRadius
-        guard let lease = ImagePreviewHeroSourceLease(
-            sourceView: sourceView,
-            image: image,
-            sourceIdentity: controller.session.sourceIdentity,
-            containerView: containerView,
-            imageFrame: fullScreenFrame,
-            cornerRadius: 0
-        ) else {
-            animateCrossDissolve(
-                appearingView: destinationView,
-                disappearingView: dismissedView,
-                appearingViewWasInserted: destinationWasInserted,
-                transitionContext: transitionContext
-            )
-            return
-        }
-
-        let dimmingView = UIView(frame: containerView.bounds)
-        dimmingView.backgroundColor = .black
-        dimmingView.alpha = 1
-        containerView.insertSubview(dimmingView, belowSubview: lease.proxyView)
-        containerView.insertSubview(dismissedView, belowSubview: lease.proxyView)
-        let interactionGate = Self.makeInteractionGate(in: containerView)
-        // The app-owned layer starts on the exact viewer frame, so the real
-        // hierarchy can disappear atomically without a page-wide wipe.
-        dismissedView.alpha = 0
-        installActiveCleanup { completed in
-            Self.removeInteractionGate(interactionGate)
-            dimmingView.removeFromSuperview()
-            lease.finish()
-            dismissedView.alpha = 1
-            if completed {
-                dismissedView.removeFromSuperview()
-            } else if destinationWasInserted {
-                destinationView?.removeFromSuperview()
-            }
-        }
-
-        let duration = transitionDuration(using: transitionContext)
-        var didCompleteTransition = false
-        let completeTransition = {
-            guard didCompleteTransition == false,
-                  self.didEndTransition == false else {
-                return
-            }
-            didCompleteTransition = true
-            let completed = transitionContext.transitionWasCancelled == false
-            self.commitCleanupBeforeCompletion {
-                self.runActiveCleanup(completed: completed)
-            } completion: {
-                self.reportOutcome(completed: completed)
-                transitionContext.completeTransition(completed)
-            }
-        }
-
-        runHeroAnimations(
-            lease: lease,
-            dimmingView: dimmingView,
-            image: image,
-            startFrame: fullScreenFrame,
-            endFrame: sourceFrame,
-            startCornerRadius: 0,
-            endCornerRadius: sourceCornerRadius,
-            startDimmingOpacity: 1,
-            endDimmingOpacity: 0,
-            duration: duration,
-            completion: {
-                completeTransition()
-            }
-        )
-    }
-
-    /// Commits the endpoint model values in one transaction and hands the
-    /// whole hero window to the render server as explicit animations. The
-    /// transaction's completion block runs after the animations' final
-    /// presentation frame while the model layers already hold the exact
-    /// endpoint, so removing the animations (default `isRemovedOnCompletion`
-    /// and fill mode) cannot flash before the atomic proxy/real-view handoff.
-    private func runHeroAnimations(
-        lease: ImagePreviewHeroSourceLease,
-        dimmingView: UIView,
-        image: UIImage,
-        startFrame: CGRect,
-        endFrame: CGRect,
-        startCornerRadius: CGFloat,
-        endCornerRadius: CGFloat,
-        startDimmingOpacity: Float,
-        endDimmingOpacity: Float,
-        duration: TimeInterval,
-        completion: @escaping () -> Void
-    ) {
-        let imageLayer = lease.proxyView.imageView.layer
-        let startContentsRect = ImagePreviewTransitionGeometry.aspectFillContentsRect(
-            imageSize: image.size,
-            displaySize: startFrame.size
-        )
-        let endContentsRect = ImagePreviewTransitionGeometry.aspectFillContentsRect(
-            imageSize: image.size,
-            displaySize: endFrame.size
-        )
-
-        func heroAnimation(
-            _ keyPath: String,
-            from fromValue: NSValue,
-            to toValue: NSValue
-        ) -> CABasicAnimation {
-            let animation = CABasicAnimation(keyPath: keyPath)
-            animation.fromValue = fromValue
-            animation.toValue = toValue
-            animation.duration = duration
-            animation.timingFunction = Self.heroTimingFunction
-            let maximumFramesPerSecond = Float(UIScreen.main.maximumFramesPerSecond)
-            animation.preferredFrameRateRange = CAFrameRateRange(
-                minimum: min(80, maximumFramesPerSecond),
-                maximum: maximumFramesPerSecond,
-                preferred: maximumFramesPerSecond
-            )
-            return animation
-        }
-
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        CATransaction.setCompletionBlock(completion)
-
-        lease.proxyView.render(
-            frame: endFrame,
-            imageSize: image.size,
-            cornerRadius: endCornerRadius
-        )
-        dimmingView.layer.opacity = endDimmingOpacity
-
-        imageLayer.add(
-            heroAnimation(
-                "bounds",
-                from: NSValue(cgRect: CGRect(origin: .zero, size: startFrame.size)),
-                to: NSValue(cgRect: CGRect(origin: .zero, size: endFrame.size))
-            ),
-            forKey: "hero-bounds"
-        )
-        imageLayer.add(
-            heroAnimation(
-                "position",
-                from: NSValue(cgPoint: CGPoint(x: startFrame.midX, y: startFrame.midY)),
-                to: NSValue(cgPoint: CGPoint(x: endFrame.midX, y: endFrame.midY))
-            ),
-            forKey: "hero-position"
-        )
-        imageLayer.add(
-            heroAnimation(
-                "cornerRadius",
-                from: NSNumber(value: Double(startCornerRadius)),
-                to: NSNumber(value: Double(endCornerRadius))
-            ),
-            forKey: "hero-corner-radius"
-        )
-        imageLayer.add(
-            heroAnimation(
-                "contentsRect",
-                from: NSValue(cgRect: startContentsRect),
-                to: NSValue(cgRect: endContentsRect)
-            ),
-            forKey: "hero-contents-rect"
-        )
-        dimmingView.layer.add(
-            heroAnimation(
-                "opacity",
-                from: NSNumber(value: startDimmingOpacity),
-                to: NSNumber(value: endDimmingOpacity)
-            ),
-            forKey: "hero-opacity"
-        )
-
-        CATransaction.commit()
-    }
-
-    /// `appearingView` is nil for an `.overFullScreen` dismissal: the live
-    /// presenting page already sits below the container, so only the
-    /// disappearing view fades.
-    private func animateCrossDissolve(
-        appearingView: UIView?,
-        disappearingView: UIView?,
-        appearingViewWasInserted: Bool,
-        transitionContext: UIViewControllerContextTransitioning
-    ) {
-        appearingView?.alpha = disappearingView == nil ? 0 : 1
-        let interactionGate = Self.makeInteractionGate(
-            in: transitionContext.containerView
-        )
-        installActiveCleanup { completed in
-            Self.removeInteractionGate(interactionGate)
-            appearingView?.alpha = 1
-            if completed {
-                disappearingView?.removeFromSuperview()
-            } else {
-                disappearingView?.alpha = 1
-                if appearingViewWasInserted {
-                    appearingView?.removeFromSuperview()
-                }
-            }
-        }
-        UIView.animate(
-            withDuration: transitionDuration(using: transitionContext) * 0.7,
-            delay: 0,
-            options: [.beginFromCurrentState, .curveEaseInOut],
-            animations: {
-                appearingView?.alpha = 1
-                disappearingView?.alpha = 0
-            },
-            completion: { _ in
-                let completed = transitionContext.transitionWasCancelled == false
-                self.runActiveCleanup(completed: completed)
-                self.reportOutcome(completed: completed)
-                transitionContext.completeTransition(completed)
-            }
-        )
-    }
-
-    private func commitCleanupBeforeCompletion(
-        _ cleanup: @escaping () -> Void,
-        completion: @escaping () -> Void
-    ) {
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        CATransaction.setCompletionBlock(completion)
-        cleanup()
-        CATransaction.commit()
-    }
-
-    private func installActiveCleanup(_ cleanup: @escaping (Bool) -> Void) {
-        runActiveCleanup(completed: false)
-        activeCleanup = cleanup
-    }
-
-    private func runActiveCleanup(completed: Bool) {
-        let cleanup = activeCleanup
-        activeCleanup = nil
-        cleanup?(completed)
-    }
-
-    private func reportOutcome(completed: Bool) {
-        guard didReportOutcome == false else { return }
-        didReportOutcome = true
-        guard completed == false else { return }
-        switch operation {
-        case .presentation:
-            controller?.heroPresentationDidCancel()
-        case .dismissal:
-            controller?.heroDismissalDidCancel()
-        }
-    }
-
-    private static func makeInteractionGate(in containerView: UIView) -> UIView {
-        let gate = UIView(frame: containerView.bounds)
-        gate.backgroundColor = .clear
-        gate.alpha = 1
-        gate.isUserInteractionEnabled = true
-        gate.accessibilityElementsHidden = true
-        containerView.addSubview(gate)
-        return gate
-    }
-
-    private static func removeInteractionGate(_ gate: UIView) {
-        gate.removeFromSuperview()
-    }
-}
-
 /// Observes the first touch after UIKit has completed the modal dismissal.
 /// The transition-container gate continues to freeze the source hierarchy
 /// while the hero is active. UIKit intentionally does not deliver new input
@@ -2135,7 +1649,7 @@ private final class ImagePreviewHeroAnimator: NSObject,
 /// recognizer provides a one-touch fallback for a temporarily stale SwiftUI
 /// button without delaying or cancelling normal scrolling.
 @MainActor
-private final class ImagePreviewDismissalInteractionGate: UIGestureRecognizer,
+final class MediaPreviewDismissalInteractionGate: UIGestureRecognizer,
     UIGestureRecognizerDelegate {
     private let onTapAtWindowPoint: (CGPoint, UIWindow) -> Void
     private var initialWindowPoint: CGPoint?
@@ -2160,7 +1674,7 @@ private final class ImagePreviewDismissalInteractionGate: UIGestureRecognizer,
         fatalError("init(coder:) has not been implemented")
     }
 
-    func installed(in window: UIWindow) -> ImagePreviewDismissalInteractionGate {
+    func installed(in window: UIWindow) -> MediaPreviewDismissalInteractionGate {
         window.addGestureRecognizer(self)
         return self
     }
@@ -2397,7 +1911,8 @@ private final class ImagePreviewDismissRelay {
 @MainActor
 private final class ImagePreviewHostingController: UIHostingController<FullScreenImageView>,
     UIAdaptivePresentationControllerDelegate,
-    UIViewControllerTransitioningDelegate {
+    UIViewControllerTransitioningDelegate,
+    MediaPreviewHeroTransitionParticipant {
     let session: ImagePreviewSession
     let transitionState: ImagePreviewPresentationState
     let transitionContent: ImagePreviewTransitionContentState
@@ -2405,9 +1920,10 @@ private final class ImagePreviewHostingController: UIHostingController<FullScree
     private let onDismissalFinished: (UUID) -> Void
     private let onPresentationCancelled: (UUID) -> Void
     private let onDismissalCancelled: (UUID) -> Void
+    private var didCancelPresentation = false
     private var didBeginDismissal = false
     private var didFinishDismissal = false
-    private var dismissalInteractionGate: ImagePreviewDismissalInteractionGate?
+    private var dismissalInteractionGate: MediaPreviewDismissalInteractionGate?
 
     init(
         session: ImagePreviewSession,
@@ -2461,13 +1977,56 @@ private final class ImagePreviewHostingController: UIHostingController<FullScree
         presenting: UIViewController,
         source: UIViewController
     ) -> UIViewControllerAnimatedTransitioning? {
-        ImagePreviewHeroAnimator(operation: .presentation, controller: self)
+        MediaPreviewHeroAnimator(operation: .presentation, participant: self)
     }
 
     func animationController(
         forDismissed dismissed: UIViewController
     ) -> UIViewControllerAnimatedTransitioning? {
-        ImagePreviewHeroAnimator(operation: .dismissal, controller: self)
+        MediaPreviewHeroAnimator(operation: .dismissal, participant: self)
+    }
+
+    var mediaPreviewHeroSourceIdentity: String? {
+        session.sourceIdentity
+    }
+
+    func mediaPreviewStableSourceView(
+        in sourceViewController: UIViewController
+    ) -> ImagePreviewSourceView? {
+        stableTransitionSourceView(in: sourceViewController)
+    }
+
+    func mediaPreviewHeroDismissalContent(
+        sourceView: ImagePreviewSourceView,
+        dismissedView: UIView,
+        containerView: UIView
+    ) -> MediaPreviewHeroDismissalContent? {
+        let currentIndex = transitionState.currentIndex
+        guard currentIndex == session.initialIndex,
+              transitionState.allowsInteractiveDismissal,
+              let image = transitionContent.image(at: currentIndex)
+                ?? sourceView.image else {
+            return nil
+        }
+        let frame = transitionContent.frame(
+            at: currentIndex,
+            convertedTo: containerView
+        ) ?? ImagePreviewTransitionGeometry.aspectFitFrame(
+            imageSize: image.size,
+            in: dismissedView.frame
+        )
+        return MediaPreviewHeroDismissalContent(image: image, frame: frame)
+    }
+
+    func mediaPreviewHeroTransitionDidCancel(
+        _ operation: MediaPreviewHeroOperation
+    ) {
+        switch operation {
+        case .presentation:
+            heroPresentationDidCancel()
+        case .dismissal:
+            heroDismissalDidCancel()
+        }
     }
 
     @discardableResult
@@ -2505,7 +2064,7 @@ private final class ImagePreviewHostingController: UIHostingController<FullScree
         didBeginDismissal = true
         onDismissalBegan(session.id)
         if let window = view.window {
-            dismissalInteractionGate = ImagePreviewDismissalInteractionGate(
+            dismissalInteractionGate = MediaPreviewDismissalInteractionGate(
                 onTapAtWindowPoint: { point, window in
                     ImagePreviewSourceRegistry.shared.activateSource(
                         at: point,
@@ -2533,6 +2092,8 @@ private final class ImagePreviewHostingController: UIHostingController<FullScree
     }
 
     func heroPresentationDidCancel() {
+        guard didCancelPresentation == false else { return }
+        didCancelPresentation = true
         onPresentationCancelled(session.id)
     }
 
@@ -2549,9 +2110,8 @@ private final class ImagePreviewHostingController: UIHostingController<FullScree
 final class ImagePreviewCoordinator {
     static let shared = ImagePreviewCoordinator()
 
-    private var lifecycle = ImagePreviewLifecycle()
+    private let arbiter = MediaPreviewPresentationArbiter.shared
     private var activeController: ImagePreviewHostingController?
-    private var pendingPresentation: (() -> Void)?
 
     private init() {}
 
@@ -2560,26 +2120,31 @@ final class ImagePreviewCoordinator {
         _ session: ImagePreviewSession,
         saveAction: @escaping (URL) async throws -> Void = FullScreenImageView.liveSave
     ) -> Bool {
-        reconcileActiveSession()
-        // A previous viewer whose zoom dismissal is still animating keeps its
-        // session id until the transition completes. Presenting during that
-        // window is silently dropped by UIKit, which reads as a dead ~0.5s
-        // where tapping another image does nothing. Queue the request instead
-        // and run it the moment the dismissal finishes.
-        if case .dismissing = lifecycle.phase {
-            pendingPresentation = { [weak self] in
-                self?.present(session, saveAction: saveAction)
-            }
-            return false
+        let initialImage = session.images.indices.contains(session.initialIndex)
+            ? session.images[session.initialIndex]
+            : nil
+        let request = MediaPreviewPresentationRequest(
+            id: session.id,
+            kind: .image,
+            sourceKey: session.sourceIdentity
+                ?? initialImage?.originalURL?.absoluteString
+                ?? initialImage?.thumbnailURL?.absoluteString
+        )
+        return arbiter.submit(request) { [weak self] in
+            self?.startPresentation(
+                session,
+                request: request,
+                saveAction: saveAction
+            ) ?? false
         }
-        guard lifecycle.phase == .idle else { return false }
-        pendingPresentation = nil
-        guard let presenter = Self.topPresenter() else {
-            return false
-        }
-        guard lifecycle.beginPresentation(sessionID: session.id) else {
-            return false
-        }
+    }
+
+    private func startPresentation(
+        _ session: ImagePreviewSession,
+        request: MediaPreviewPresentationRequest,
+        saveAction: @escaping (URL) async throws -> Void
+    ) -> Bool {
+        guard let presenter = Self.topPresenter() else { return false }
 #if DEBUG
         ImageDismissScrollRaceProbe.shared.prepare(session: session)
 #endif
@@ -2617,91 +2182,95 @@ final class ImagePreviewCoordinator {
             transitionContent: transitionContent,
             rootView: viewer,
             onDismissalBegan: { [weak self] sessionID in
-                self?.beginDismissal(sessionID: sessionID)
+                self?.beginDismissal(sessionID: sessionID, request: request)
             },
             onDismissalFinished: { [weak self] sessionID in
-                self?.finishDismissal(sessionID: sessionID)
+                self?.finishDismissal(sessionID: sessionID, request: request)
             },
             onPresentationCancelled: { [weak self] sessionID in
-                self?.cancelPresentation(sessionID: sessionID)
+                self?.cancelPresentation(sessionID: sessionID, request: request)
             },
             onDismissalCancelled: { [weak self] sessionID in
-                self?.cancelDismissal(sessionID: sessionID)
+                self?.cancelDismissal(sessionID: sessionID, request: request)
             }
         )
         dismissRelay.controller = controller
-        // .overFullScreen keeps the presenting page alive underneath the
-        // viewer, so dismissal never re-inserts and re-lays-out the whole
-        // source hierarchy before its first frame.
         controller.modalPresentationStyle = .overFullScreen
         controller.modalPresentationCapturesStatusBarAppearance = true
         controller.isModalInPresentation = true
         controller.transitioningDelegate = controller
-
-        // Materialize the destination hierarchy before the app-owned hero
-        // animator captures geometry. No UIKit zoom portal participates in
-        // this transition.
         controller.loadViewIfNeeded()
         controller.view.layoutIfNeeded()
         activeController = controller
+
         presenter.present(
             controller,
             animated: ImagePreviewTransitionMotionPolicy.animationsEnabled
         ) { [weak self, weak controller] in
             guard let self,
-                  self.lifecycle.finishPresentation(sessionID: session.id) else {
+                  self.arbiter.presentationDidFinish(request) else {
                 return
             }
             controller?.finishPresentationIfNeeded()
         }
+        MediaPreviewPresentationAttachmentVerifier.verify(
+            controller: controller,
+            presenter: presenter
+        ) { [weak controller] in
+            controller?.heroPresentationDidCancel()
+        }
         return true
     }
 
-    private func reconcileActiveSession() {
-        guard let sessionID = lifecycle.phase.sessionID else { return }
-        // A controller in `isBeingDismissed` remains active until UIKit's real
-        // dismissal completion. Inferring lifecycle from transient UIKit flags
-        // caused the coordinator to present a new viewer into a dismissal and
-        // lose the tap.
-        guard activeController == nil else { return }
-        finishDismissal(sessionID: sessionID)
-    }
-
-    private func beginDismissal(sessionID: UUID) {
-        guard lifecycle.beginDismissal(sessionID: sessionID) else { return }
+    private func beginDismissal(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id,
+              arbiter.dismissalWillBegin(request) else {
+            return
+        }
 #if DEBUG
         ImageDismissScrollRaceProbe.shared.dismissalDidBegin(sessionID: sessionID)
 #endif
     }
 
-    private func finishDismissal(sessionID: UUID) {
-        guard lifecycle.finish(sessionID: sessionID) else { return }
+    private func finishDismissal(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id else { return }
+        if activeController?.session.id == sessionID {
+            activeController = nil
+        }
 #if DEBUG
         ImageDismissScrollRaceProbe.shared.dismissalDidFinish(sessionID: sessionID)
 #endif
-        activeController = nil
-        // Flush a tap that arrived while the dismissal was still animating.
-        // Defer to the next runloop so UIKit fully tears down the previous
-        // presentation before the queued present begins.
-        if let pendingPresentation {
-            self.pendingPresentation = nil
-            Task { @MainActor in
-                await Task.yield()
-                pendingPresentation()
-            }
+        _ = arbiter.dismissalDidFinish(request)
+    }
+
+    private func cancelPresentation(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id,
+              arbiter.presentationDidCancel(request) else {
+            return
+        }
+        if activeController?.session.id == sessionID {
+            activeController = nil
         }
     }
 
-    private func cancelPresentation(sessionID: UUID) {
-        guard lifecycle.cancelPresentation(sessionID: sessionID) else { return }
-        activeController = nil
+    private func cancelDismissal(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id else { return }
+        _ = arbiter.dismissalDidCancel(request)
     }
 
-    private func cancelDismissal(sessionID: UUID) {
-        _ = lifecycle.cancelDismissal(sessionID: sessionID)
-    }
-
-    private static func topPresenter() -> UIViewController? {
+    static func topPresenter() -> UIViewController? {
         let scenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
         let scene = scenes.first(where: { $0.activationState == .foregroundActive })
@@ -2712,7 +2281,7 @@ final class ImagePreviewCoordinator {
         return topViewController(from: root)
     }
 
-    private static func topViewController(from controller: UIViewController) -> UIViewController {
+    static func topViewController(from controller: UIViewController) -> UIViewController {
         if let presented = controller.presentedViewController,
            presented.isBeingDismissed == false {
             return topViewController(from: presented)
@@ -2733,6 +2302,7 @@ final class ImagePreviewCoordinator {
         return controller
     }
 }
+
 enum FullScreenOriginalImageLoadState: Equatable {
     case unavailable
     case available
@@ -4667,14 +4237,21 @@ struct ReaderMediaPolicyUITestHost: View {
         height: 400,
         showOriginalButton: true
     )
-    private let video = VideoContent(
-        videoURL: URL(string: "https://fixture-success.invalid/media-policy-video.mp4"),
-        coverURL: URL(string: "https://fixture.invalid/media-policy-video-cover.png"),
-        webURL: nil,
-        width: 640,
-        height: 360,
-        duration: 12
-    )
+    private var video: VideoContent {
+        let successfulCover = ProcessInfo.processInfo.arguments.contains(
+            "UITEST_VIDEO_PREVIEW_HERO"
+        )
+        return VideoContent(
+            videoURL: URL(string: "https://fixture-success.invalid/media-policy-video.mp4"),
+            coverURL: URL(string: successfulCover
+                ? "https://fixture-success.invalid/media-policy-video-cover.png"
+                : "https://fixture.invalid/media-policy-video-cover.png"),
+            webURL: nil,
+            width: 640,
+            height: 360,
+            duration: 12
+        )
+    }
 
     private var mediaGridVideoItem: ReaderMediaItem {
         ReaderMediaItem(

--- a/TiebaPure/Features/Media/MediaPreviewHeroAnimator.swift
+++ b/TiebaPure/Features/Media/MediaPreviewHeroAnimator.swift
@@ -1,0 +1,507 @@
+import UIKit
+
+enum MediaPreviewHeroOperation {
+    case presentation
+    case dismissal
+}
+
+struct MediaPreviewHeroDismissalContent {
+    let image: UIImage
+    let frame: CGRect
+}
+
+@MainActor
+protocol MediaPreviewHeroTransitionParticipant: AnyObject {
+    var mediaPreviewHeroSourceIdentity: String? { get }
+
+    func mediaPreviewStableSourceView(
+        in sourceViewController: UIViewController
+    ) -> ImagePreviewSourceView?
+
+    /// Returns nil when dismissal must cross-dissolve instead of returning a
+    /// bitmap to the source thumbnail.
+    func mediaPreviewHeroDismissalContent(
+        sourceView: ImagePreviewSourceView,
+        dismissedView: UIView,
+        containerView: UIView
+    ) -> MediaPreviewHeroDismissalContent?
+
+    func mediaPreviewHeroTransitionDidCancel(
+        _ operation: MediaPreviewHeroOperation
+    )
+}
+
+/// Shared, render-server-driven hero transition for image and video previews.
+/// Cleanup is committed before UIKit receives `completeTransition`, which
+/// keeps the proxy-to-live-view handoff atomic during fast scroll/reopen paths.
+@MainActor
+final class MediaPreviewHeroAnimator: NSObject,
+    UIViewControllerAnimatedTransitioning {
+    private weak var participant: MediaPreviewHeroTransitionParticipant?
+    private let operation: MediaPreviewHeroOperation
+    private var activeCleanup: ((Bool) -> Void)?
+    private var didReportOutcome = false
+    private var didEndTransition = false
+
+    private static let heroTimingFunction = CAMediaTimingFunction(
+        controlPoints: 0.37, 0, 0.63, 1
+    )
+
+    init(
+        operation: MediaPreviewHeroOperation,
+        participant: MediaPreviewHeroTransitionParticipant
+    ) {
+        self.operation = operation
+        self.participant = participant
+        super.init()
+    }
+
+    func transitionDuration(
+        using transitionContext: UIViewControllerContextTransitioning?
+    ) -> TimeInterval {
+        0.32
+    }
+
+    func animateTransition(
+        using transitionContext: UIViewControllerContextTransitioning
+    ) {
+        guard let participant else {
+            transitionContext.completeTransition(false)
+            return
+        }
+        switch operation {
+        case .presentation:
+            animatePresentation(
+                participant: participant,
+                transitionContext: transitionContext
+            )
+        case .dismissal:
+            animateDismissal(
+                participant: participant,
+                transitionContext: transitionContext
+            )
+        }
+    }
+
+    func animationEnded(_ transitionCompleted: Bool) {
+        didEndTransition = true
+        runActiveCleanup(completed: transitionCompleted)
+        reportOutcome(completed: transitionCompleted)
+    }
+
+    private func animatePresentation(
+        participant: MediaPreviewHeroTransitionParticipant,
+        transitionContext: UIViewControllerContextTransitioning
+    ) {
+        guard let sourceController = transitionContext.viewController(forKey: .from),
+              let destinationController = transitionContext.viewController(forKey: .to),
+              let destinationView = transitionContext.view(forKey: .to) else {
+            transitionContext.completeTransition(false)
+            return
+        }
+
+        let containerView = transitionContext.containerView
+        destinationView.frame = transitionContext.finalFrame(for: destinationController)
+        containerView.addSubview(destinationView)
+        destinationView.layoutIfNeeded()
+
+        guard let sourceView = participant.mediaPreviewStableSourceView(
+            in: sourceController
+        ),
+        let image = sourceView.image,
+        let sourceFrame = ImagePreviewTransitionGeometry.validSourceFrame(
+            sourceView.convert(sourceView.bounds, to: containerView)
+        ) else {
+            animateCrossDissolve(
+                appearingView: destinationView,
+                disappearingView: nil,
+                appearingViewWasInserted: true,
+                transitionContext: transitionContext
+            )
+            return
+        }
+
+        let targetFrame = ImagePreviewTransitionGeometry.aspectFitFrame(
+            imageSize: image.size,
+            in: destinationView.frame
+        )
+        let sourceCornerRadius = sourceView.layer.cornerRadius
+        guard let lease = ImagePreviewHeroSourceLease(
+            sourceView: sourceView,
+            image: image,
+            sourceIdentity: participant.mediaPreviewHeroSourceIdentity,
+            containerView: containerView,
+            imageFrame: sourceFrame,
+            cornerRadius: sourceCornerRadius
+        ) else {
+            animateCrossDissolve(
+                appearingView: destinationView,
+                disappearingView: nil,
+                appearingViewWasInserted: true,
+                transitionContext: transitionContext
+            )
+            return
+        }
+
+        let dimmingView = UIView(frame: containerView.bounds)
+        dimmingView.backgroundColor = .black
+        dimmingView.alpha = 0
+        containerView.insertSubview(dimmingView, belowSubview: lease.proxyView)
+        destinationView.alpha = 0
+        let interactionGate = Self.makeInteractionGate(in: containerView)
+        installActiveCleanup { completed in
+            Self.removeInteractionGate(interactionGate)
+            dimmingView.removeFromSuperview()
+            lease.finish()
+            destinationView.alpha = 1
+            if completed == false {
+                destinationView.removeFromSuperview()
+            }
+        }
+
+        completeWithHeroAnimation(
+            lease: lease,
+            dimmingView: dimmingView,
+            image: image,
+            startFrame: sourceFrame,
+            endFrame: targetFrame,
+            startCornerRadius: sourceCornerRadius,
+            endCornerRadius: 0,
+            startDimmingOpacity: 0,
+            endDimmingOpacity: 1,
+            transitionContext: transitionContext
+        )
+    }
+
+    private func animateDismissal(
+        participant: MediaPreviewHeroTransitionParticipant,
+        transitionContext: UIViewControllerContextTransitioning
+    ) {
+        guard let sourceController = transitionContext.viewController(forKey: .to),
+              let dismissedView = transitionContext.view(forKey: .from) else {
+            transitionContext.completeTransition(false)
+            return
+        }
+
+        let containerView = transitionContext.containerView
+        let destinationView = transitionContext.view(forKey: .to)
+        let destinationWasInserted: Bool
+        if let destinationView, destinationView.superview == nil {
+            destinationView.frame = transitionContext.finalFrame(for: sourceController)
+            containerView.insertSubview(destinationView, belowSubview: dismissedView)
+            destinationView.layoutIfNeeded()
+            destinationWasInserted = true
+        } else {
+            destinationWasInserted = false
+        }
+
+        guard let sourceView = participant.mediaPreviewStableSourceView(
+            in: sourceController
+        ),
+        let content = participant.mediaPreviewHeroDismissalContent(
+            sourceView: sourceView,
+            dismissedView: dismissedView,
+            containerView: containerView
+        ),
+        let fullScreenFrame = ImagePreviewTransitionGeometry.validSourceFrame(
+            content.frame
+        ),
+        let sourceFrame = ImagePreviewTransitionGeometry.validSourceFrame(
+            sourceView.convert(sourceView.bounds, to: containerView)
+        ) else {
+            animateCrossDissolve(
+                appearingView: destinationView,
+                disappearingView: dismissedView,
+                appearingViewWasInserted: destinationWasInserted,
+                transitionContext: transitionContext
+            )
+            return
+        }
+
+        let sourceCornerRadius = sourceView.layer.cornerRadius
+        guard let lease = ImagePreviewHeroSourceLease(
+            sourceView: sourceView,
+            image: content.image,
+            sourceIdentity: participant.mediaPreviewHeroSourceIdentity,
+            containerView: containerView,
+            imageFrame: fullScreenFrame,
+            cornerRadius: 0
+        ) else {
+            animateCrossDissolve(
+                appearingView: destinationView,
+                disappearingView: dismissedView,
+                appearingViewWasInserted: destinationWasInserted,
+                transitionContext: transitionContext
+            )
+            return
+        }
+
+        let dimmingView = UIView(frame: containerView.bounds)
+        dimmingView.backgroundColor = .black
+        dimmingView.alpha = 1
+        containerView.insertSubview(dimmingView, belowSubview: lease.proxyView)
+        containerView.insertSubview(dismissedView, belowSubview: lease.proxyView)
+        dismissedView.alpha = 0
+        let interactionGate = Self.makeInteractionGate(in: containerView)
+        installActiveCleanup { completed in
+            Self.removeInteractionGate(interactionGate)
+            dimmingView.removeFromSuperview()
+            lease.finish()
+            dismissedView.alpha = 1
+            if completed {
+                dismissedView.removeFromSuperview()
+            } else if destinationWasInserted {
+                destinationView?.removeFromSuperview()
+            }
+        }
+
+        completeWithHeroAnimation(
+            lease: lease,
+            dimmingView: dimmingView,
+            image: content.image,
+            startFrame: fullScreenFrame,
+            endFrame: sourceFrame,
+            startCornerRadius: 0,
+            endCornerRadius: sourceCornerRadius,
+            startDimmingOpacity: 1,
+            endDimmingOpacity: 0,
+            transitionContext: transitionContext
+        )
+    }
+
+    private func completeWithHeroAnimation(
+        lease: ImagePreviewHeroSourceLease,
+        dimmingView: UIView,
+        image: UIImage,
+        startFrame: CGRect,
+        endFrame: CGRect,
+        startCornerRadius: CGFloat,
+        endCornerRadius: CGFloat,
+        startDimmingOpacity: Float,
+        endDimmingOpacity: Float,
+        transitionContext: UIViewControllerContextTransitioning
+    ) {
+        var didCompleteTransition = false
+        let completeTransition = {
+            guard didCompleteTransition == false,
+                  self.didEndTransition == false else {
+                return
+            }
+            didCompleteTransition = true
+            let completed = transitionContext.transitionWasCancelled == false
+            self.commitCleanupBeforeCompletion {
+                self.runActiveCleanup(completed: completed)
+            } completion: {
+                self.reportOutcome(completed: completed)
+                transitionContext.completeTransition(completed)
+            }
+        }
+
+        runHeroAnimations(
+            lease: lease,
+            dimmingView: dimmingView,
+            image: image,
+            startFrame: startFrame,
+            endFrame: endFrame,
+            startCornerRadius: startCornerRadius,
+            endCornerRadius: endCornerRadius,
+            startDimmingOpacity: startDimmingOpacity,
+            endDimmingOpacity: endDimmingOpacity,
+            duration: transitionDuration(using: transitionContext),
+            completion: completeTransition
+        )
+    }
+
+    private func runHeroAnimations(
+        lease: ImagePreviewHeroSourceLease,
+        dimmingView: UIView,
+        image: UIImage,
+        startFrame: CGRect,
+        endFrame: CGRect,
+        startCornerRadius: CGFloat,
+        endCornerRadius: CGFloat,
+        startDimmingOpacity: Float,
+        endDimmingOpacity: Float,
+        duration: TimeInterval,
+        completion: @escaping () -> Void
+    ) {
+        let imageLayer = lease.proxyView.imageView.layer
+        let startContentsRect = ImagePreviewTransitionGeometry.aspectFillContentsRect(
+            imageSize: image.size,
+            displaySize: startFrame.size
+        )
+        let endContentsRect = ImagePreviewTransitionGeometry.aspectFillContentsRect(
+            imageSize: image.size,
+            displaySize: endFrame.size
+        )
+
+        func heroAnimation(
+            _ keyPath: String,
+            from fromValue: NSValue,
+            to toValue: NSValue
+        ) -> CABasicAnimation {
+            let animation = CABasicAnimation(keyPath: keyPath)
+            animation.fromValue = fromValue
+            animation.toValue = toValue
+            animation.duration = duration
+            animation.timingFunction = Self.heroTimingFunction
+            let maximumFramesPerSecond = Float(UIScreen.main.maximumFramesPerSecond)
+            animation.preferredFrameRateRange = CAFrameRateRange(
+                minimum: min(80, maximumFramesPerSecond),
+                maximum: maximumFramesPerSecond,
+                preferred: maximumFramesPerSecond
+            )
+            return animation
+        }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        CATransaction.setCompletionBlock(completion)
+
+        lease.proxyView.render(
+            frame: endFrame,
+            imageSize: image.size,
+            cornerRadius: endCornerRadius
+        )
+        dimmingView.layer.opacity = endDimmingOpacity
+
+        imageLayer.add(
+            heroAnimation(
+                "bounds",
+                from: NSValue(cgRect: CGRect(origin: .zero, size: startFrame.size)),
+                to: NSValue(cgRect: CGRect(origin: .zero, size: endFrame.size))
+            ),
+            forKey: "hero-bounds"
+        )
+        imageLayer.add(
+            heroAnimation(
+                "position",
+                from: NSValue(cgPoint: CGPoint(x: startFrame.midX, y: startFrame.midY)),
+                to: NSValue(cgPoint: CGPoint(x: endFrame.midX, y: endFrame.midY))
+            ),
+            forKey: "hero-position"
+        )
+        imageLayer.add(
+            heroAnimation(
+                "cornerRadius",
+                from: NSNumber(value: Double(startCornerRadius)),
+                to: NSNumber(value: Double(endCornerRadius))
+            ),
+            forKey: "hero-corner-radius"
+        )
+        imageLayer.add(
+            heroAnimation(
+                "contentsRect",
+                from: NSValue(cgRect: startContentsRect),
+                to: NSValue(cgRect: endContentsRect)
+            ),
+            forKey: "hero-contents-rect"
+        )
+        dimmingView.layer.add(
+            heroAnimation(
+                "opacity",
+                from: NSNumber(value: startDimmingOpacity),
+                to: NSNumber(value: endDimmingOpacity)
+            ),
+            forKey: "hero-opacity"
+        )
+
+        CATransaction.commit()
+    }
+
+    private func animateCrossDissolve(
+        appearingView: UIView?,
+        disappearingView: UIView?,
+        appearingViewWasInserted: Bool,
+        transitionContext: UIViewControllerContextTransitioning
+    ) {
+        appearingView?.alpha = disappearingView == nil ? 0 : 1
+        let interactionGate = Self.makeInteractionGate(
+            in: transitionContext.containerView
+        )
+        installActiveCleanup { completed in
+            Self.removeInteractionGate(interactionGate)
+            appearingView?.alpha = 1
+            if completed {
+                disappearingView?.removeFromSuperview()
+            } else {
+                disappearingView?.alpha = 1
+                if appearingViewWasInserted {
+                    appearingView?.removeFromSuperview()
+                }
+            }
+        }
+
+        var didCompleteTransition = false
+        let completeTransition = {
+            guard didCompleteTransition == false,
+                  self.didEndTransition == false else {
+                return
+            }
+            didCompleteTransition = true
+            let completed = transitionContext.transitionWasCancelled == false
+            self.commitCleanupBeforeCompletion {
+                self.runActiveCleanup(completed: completed)
+            } completion: {
+                self.reportOutcome(completed: completed)
+                transitionContext.completeTransition(completed)
+            }
+        }
+
+        UIView.animate(
+            withDuration: transitionDuration(using: transitionContext) * 0.7,
+            delay: 0,
+            options: [.beginFromCurrentState, .curveEaseInOut],
+            animations: {
+                appearingView?.alpha = 1
+                disappearingView?.alpha = 0
+            },
+            completion: { _ in
+                completeTransition()
+            }
+        )
+    }
+
+    private func commitCleanupBeforeCompletion(
+        _ cleanup: @escaping () -> Void,
+        completion: @escaping () -> Void
+    ) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        CATransaction.setCompletionBlock(completion)
+        cleanup()
+        CATransaction.commit()
+    }
+
+    private func installActiveCleanup(_ cleanup: @escaping (Bool) -> Void) {
+        runActiveCleanup(completed: false)
+        activeCleanup = cleanup
+    }
+
+    private func runActiveCleanup(completed: Bool) {
+        let cleanup = activeCleanup
+        activeCleanup = nil
+        cleanup?(completed)
+    }
+
+    private func reportOutcome(completed: Bool) {
+        guard didReportOutcome == false else { return }
+        didReportOutcome = true
+        guard completed == false else { return }
+        participant?.mediaPreviewHeroTransitionDidCancel(operation)
+    }
+
+    private static func makeInteractionGate(in containerView: UIView) -> UIView {
+        let gate = UIView(frame: containerView.bounds)
+        gate.backgroundColor = .clear
+        gate.alpha = 1
+        gate.isUserInteractionEnabled = true
+        gate.accessibilityElementsHidden = true
+        containerView.addSubview(gate)
+        return gate
+    }
+
+    private static func removeInteractionGate(_ gate: UIView) {
+        gate.removeFromSuperview()
+    }
+}

--- a/TiebaPure/Features/Media/MediaPreviewPresentationArbiter.swift
+++ b/TiebaPure/Features/Media/MediaPreviewPresentationArbiter.swift
@@ -1,0 +1,325 @@
+import Foundation
+import UIKit
+
+enum MediaPreviewPresentationKind: String, Equatable, Hashable {
+    case image
+    case video
+    case safari
+}
+
+struct MediaPreviewPresentationRequest: Equatable, Hashable {
+    let id: UUID
+    let kind: MediaPreviewPresentationKind
+    let sourceKey: String?
+
+    init(
+        id: UUID,
+        kind: MediaPreviewPresentationKind,
+        sourceKey: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.sourceKey = sourceKey.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    func matchesSource(of other: MediaPreviewPresentationRequest) -> Bool {
+        guard kind == other.kind,
+              let sourceKey,
+              let otherSourceKey = other.sourceKey else {
+            return id == other.id
+        }
+        return sourceKey == otherSourceKey
+    }
+}
+
+enum MediaPreviewPresentationPhase: Equatable {
+    case idle
+    case presenting(MediaPreviewPresentationRequest)
+    case presented(MediaPreviewPresentationRequest)
+    case dismissing(MediaPreviewPresentationRequest)
+    case settling
+
+    var activeRequest: MediaPreviewPresentationRequest? {
+        switch self {
+        case .idle, .settling:
+            return nil
+        case let .presenting(request),
+             let .presented(request),
+             let .dismissing(request):
+            return request
+        }
+    }
+}
+
+enum MediaPreviewSubmissionDisposition: Equatable {
+    case startNow
+    case queued(replacing: MediaPreviewPresentationRequest?)
+    case ignoredActive
+}
+
+enum MediaPreviewPresentationAttachmentPolicy {
+    static func wasAccepted(
+        presenterOwnsController: Bool,
+        controllerHasPresenter: Bool,
+        controllerHasWindow: Bool
+    ) -> Bool {
+        presenterOwnsController || controllerHasPresenter || controllerHasWindow
+    }
+}
+
+/// UIKit can reject `present` asynchronously without invoking its completion
+/// block. Verify the ownership relationship on the next main-runloop turn so
+/// the global arbiter cannot remain stuck in `presenting` after that rejection.
+@MainActor
+enum MediaPreviewPresentationAttachmentVerifier {
+    static func verify(
+        controller: UIViewController,
+        presenter: UIViewController,
+        onRejected: @escaping @MainActor () -> Void
+    ) {
+        DispatchQueue.main.async { [weak controller, weak presenter] in
+            MainActor.assumeIsolated {
+                guard let controller else {
+                    onRejected()
+                    return
+                }
+                let wasAccepted = MediaPreviewPresentationAttachmentPolicy.wasAccepted(
+                    presenterOwnsController: presenter?.presentedViewController === controller,
+                    controllerHasPresenter: controller.presentingViewController != nil,
+                    controllerHasWindow: controller.viewIfLoaded?.window != nil
+                )
+                guard wasAccepted else {
+                    onRejected()
+                    return
+                }
+            }
+        }
+    }
+}
+
+/// Pure state machine behind the app-wide media modal arbiter.
+///
+/// `settling` is intentional: UIKit has completed the old modal dismissal,
+/// but a new presentation is not allowed until the next main-runloop turn.
+struct MediaPreviewPresentationArbiterState {
+    private(set) var phase: MediaPreviewPresentationPhase = .idle
+    private(set) var pendingRequest: MediaPreviewPresentationRequest?
+
+    mutating func submit(
+        _ request: MediaPreviewPresentationRequest
+    ) -> MediaPreviewSubmissionDisposition {
+        switch phase {
+        case .idle:
+            phase = .presenting(request)
+            return .startNow
+        case .presenting, .presented:
+            guard phase.activeRequest?.matchesSource(of: request) != true else {
+                return .ignoredActive
+            }
+            let replaced = pendingRequest
+            pendingRequest = request
+            return .queued(replacing: replaced)
+        case .dismissing:
+            let replaced = pendingRequest
+            pendingRequest = request
+            return .queued(replacing: replaced)
+        case .settling:
+            let replaced = pendingRequest
+            pendingRequest = request
+            return .queued(replacing: replaced)
+        }
+    }
+
+    mutating func presentationDidFinish(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard phase == .presenting(request) else { return false }
+        phase = .presented(request)
+        return true
+    }
+
+    mutating func dismissalWillBegin(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        switch phase {
+        case let .presenting(activeRequest),
+             let .presented(activeRequest):
+            guard activeRequest == request else { return false }
+            phase = .dismissing(request)
+            return true
+        case let .dismissing(activeRequest):
+            return activeRequest == request
+        default:
+            return false
+        }
+    }
+
+    mutating func dismissalDidFinish(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard phase == .dismissing(request) else { return false }
+        phase = .settling
+        return true
+    }
+
+    mutating func presentationDidCancel(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard phase == .presenting(request) else { return false }
+        phase = .settling
+        return true
+    }
+
+    mutating func dismissalDidCancel(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard phase == .dismissing(request) else { return false }
+        phase = .presented(request)
+        return true
+    }
+
+    mutating func cancelPending(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard pendingRequest == request else { return false }
+        pendingRequest = nil
+        return true
+    }
+
+    /// Ends the post-dismissal barrier and reserves the next request for
+    /// presentation. The caller must invoke the matching start closure.
+    mutating func finishSettlement() -> MediaPreviewPresentationRequest? {
+        guard phase == .settling else { return nil }
+        guard let pendingRequest else {
+            phase = .idle
+            return nil
+        }
+        self.pendingRequest = nil
+        phase = .presenting(pendingRequest)
+        return pendingRequest
+    }
+}
+
+/// Serializes image, direct-video, and Safari media presentations app-wide.
+/// Only the newest request is retained while another modal is active.
+@MainActor
+final class MediaPreviewPresentationArbiter {
+    static let shared = MediaPreviewPresentationArbiter()
+
+    typealias StartAction = @MainActor () -> Bool
+
+    private struct PendingPresentation {
+        let request: MediaPreviewPresentationRequest
+        let start: StartAction
+    }
+
+    private var state = MediaPreviewPresentationArbiterState()
+    private var pendingPresentation: PendingPresentation?
+    private var settlementScheduled = false
+
+    private init() {}
+
+    @discardableResult
+    func submit(
+        _ request: MediaPreviewPresentationRequest,
+        start: @escaping StartAction
+    ) -> Bool {
+        let presentation = PendingPresentation(request: request, start: start)
+        switch state.submit(request) {
+        case .startNow:
+            return startPresentation(presentation)
+        case .queued:
+            pendingPresentation = presentation
+            return false
+        case .ignoredActive:
+            return false
+        }
+    }
+
+    @discardableResult
+    func presentationDidFinish(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        state.presentationDidFinish(request)
+    }
+
+    @discardableResult
+    func dismissalWillBegin(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        state.dismissalWillBegin(request)
+    }
+
+    @discardableResult
+    func dismissalDidFinish(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard state.dismissalDidFinish(request) else { return false }
+        scheduleSettlement()
+        return true
+    }
+
+    @discardableResult
+    func presentationDidCancel(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard state.presentationDidCancel(request) else { return false }
+        scheduleSettlement()
+        return true
+    }
+
+    @discardableResult
+    func dismissalDidCancel(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        state.dismissalDidCancel(request)
+    }
+
+    @discardableResult
+    func cancelPending(
+        _ request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard state.cancelPending(request) else { return false }
+        if pendingPresentation?.request == request {
+            pendingPresentation = nil
+        }
+        return true
+    }
+
+    private func startPresentation(
+        _ presentation: PendingPresentation
+    ) -> Bool {
+        guard presentation.start() else {
+            _ = state.presentationDidCancel(presentation.request)
+            scheduleSettlement()
+            return false
+        }
+        return true
+    }
+
+    private func scheduleSettlement() {
+        guard settlementScheduled == false else { return }
+        settlementScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            MainActor.assumeIsolated {
+                self?.finishSettlement()
+            }
+        }
+    }
+
+    private func finishSettlement() {
+        settlementScheduled = false
+        guard let request = state.finishSettlement() else {
+            pendingPresentation = nil
+            return
+        }
+        guard let pendingPresentation,
+              pendingPresentation.request == request else {
+            _ = state.presentationDidCancel(request)
+            scheduleSettlement()
+            return
+        }
+        self.pendingPresentation = nil
+        _ = startPresentation(pendingPresentation)
+    }
+}

--- a/TiebaPure/Features/Media/VideoPlayerView.swift
+++ b/TiebaPure/Features/Media/VideoPlayerView.swift
@@ -1,6 +1,3 @@
-import AVKit
-import Combine
-import SafariServices
 import SwiftUI
 
 enum TiebaVideoSourcePolicy {
@@ -13,35 +10,68 @@ enum TiebaVideoSourcePolicy {
     }
 }
 
+enum VideoPreviewSourceIdentityPolicy {
+    static func identity(for video: VideoContent) -> String {
+        [
+            "video",
+            video.videoURL?.absoluteString ?? "",
+            video.coverURL?.absoluteString ?? "",
+            video.webURL?.absoluteString ?? "",
+            String(video.width),
+            String(video.height),
+            String(video.duration)
+        ].joined(separator: "|")
+    }
+}
+
+enum VideoPreviewReusePolicy {
+    static func effectiveLoadState(
+        storedState: TiebaRemoteImageLoadState,
+        storedIdentity: String?,
+        currentIdentity: String
+    ) -> TiebaRemoteImageLoadState {
+        storedIdentity == currentIdentity ? storedState : .empty
+    }
+
+    static func isManualLoadAuthorized(
+        authorizedIdentity: String?,
+        currentIdentity: String
+    ) -> Bool {
+        authorizedIdentity == currentIdentity
+    }
+
+    static func canUseSourceAnchor(
+        anchorIdentity: String,
+        currentIdentity: String
+    ) -> Bool {
+        anchorIdentity == currentIdentity
+    }
+}
+
 struct VideoPlayerView: View {
     @Environment(\.readingPreferences) private var readingPreferences
 
     let video: VideoContent
 
-    @State private var showsPlayer = false
-    @State private var showsSafari = false
     @State private var coverLoadState: TiebaRemoteImageLoadState = .empty
+    @State private var coverLoadStateIdentity: String?
     @State private var manualCoverAuthorization: String?
+    @StateObject private var previewSource: ImagePreviewSourceAnchor
+    private let previewSourceIdentity: String
+
+    init(video: VideoContent) {
+        self.video = video
+        let identity = VideoPreviewSourceIdentityPolicy.identity(for: video)
+        previewSourceIdentity = identity
+        _previewSource = StateObject(
+            wrappedValue: ImagePreviewSourceAnchor(sourceIdentity: identity)
+        )
+    }
 
     var body: some View {
         Group {
             if resolvedVideoURL != nil || resolvedWebURL != nil {
-                Button {
-                    if coverLoadState == .failure {
-                        openVideo()
-                    } else if coverLoadState == .empty,
-                              isManualCoverMode {
-                        manualCoverAuthorization = coverSourceIdentity
-                        return
-                    } else if coverLoadState == .loading,
-                              ReaderMediaActivationPolicy.blocksWhileLoading(
-                                requestPolicy: mediaRequestPolicy
-                              ) {
-                        return
-                    } else {
-                        openVideo()
-                    }
-                } label: {
+                Button(action: activateVideo) {
                     thumbnail
                 }
                 .buttonStyle(.plain)
@@ -53,26 +83,47 @@ struct VideoPlayerView: View {
                     .accessibilityLabel("视频不可用")
             }
         }
-        .fullScreenCover(isPresented: $showsPlayer) {
-            if let videoURL = resolvedVideoURL {
-                FullScreenVideoPlayer(url: videoURL)
-            }
+        .onChange(of: previewSourceIdentity, initial: true) { _, identity in
+            coverLoadState = .empty
+            coverLoadStateIdentity = identity
+            manualCoverAuthorization = nil
+            previewSource.prepareForReuse(sourceIdentity: identity)
         }
-        .sheet(isPresented: $showsSafari) {
-            if let webURL = resolvedWebURL {
-                SafariView(url: webURL)
-                    .ignoresSafeArea()
-            }
+    }
+
+    private func activateVideo() {
+        if effectiveCoverLoadState == .failure {
+            openVideo()
+        } else if effectiveCoverLoadState == .empty,
+                  isManualCoverMode {
+            manualCoverAuthorization = previewSourceIdentity
+        } else if effectiveCoverLoadState == .loading,
+                  ReaderMediaActivationPolicy.blocksWhileLoading(
+                    requestPolicy: mediaRequestPolicy
+                  ) {
+            return
+        } else {
+            openVideo()
         }
     }
 
     private func openVideo() {
-        VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
-        if resolvedVideoURL != nil {
-            showsPlayer = true
-        } else if resolvedWebURL != nil {
-            showsSafari = true
-        }
+        previewSource.prepareForReuse(sourceIdentity: previewSourceIdentity)
+        let sourceAnchor = VideoPreviewReusePolicy.canUseSourceAnchor(
+            anchorIdentity: previewSource.sourceIdentity,
+            currentIdentity: previewSourceIdentity
+        ) ? previewSource : nil
+        VideoPreviewCoordinator.shared.present(
+            VideoPreviewSession(
+                video: video,
+                sourceFrame: ImagePreviewSourceRegistry.shared
+                    .frameInWindow(for: previewSourceIdentity)
+                    ?? sourceAnchor?.frameInWindow,
+                sourceImage: sourceAnchor?.image,
+                sourceAnchor: sourceAnchor,
+                sourceIdentity: previewSourceIdentity
+            )
+        )
     }
 
     private var resolvedVideoURL: URL? {
@@ -94,14 +145,35 @@ struct VideoPlayerView: View {
                     contentMode: .fill,
                     showsProgress: true,
                     showsRetryButton: false,
+                    showsResolvedImage: false,
                     loadsAutomatically: mediaRequestPolicy.loadsAutomatically || isManualCoverLoadAuthorized,
-                    onLoadStateChange: { coverLoadState = $0 }
+                    onLoadStateChange: {
+                        coverLoadState = $0
+                        coverLoadStateIdentity = previewSourceIdentity
+                        if $0 != .success {
+                            previewSource.clearImage(sourceIdentity: previewSourceIdentity)
+                        }
+                    },
+                    onImageResolved: {
+                        previewSource.store(
+                            image: $0,
+                            sourceIdentity: previewSourceIdentity
+                        )
+                    }
                 )
+
+                ImagePreviewSourceAnchorReader(
+                    anchor: previewSource,
+                    sourceIdentity: previewSourceIdentity,
+                    onTransitionTap: activateVideo
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .allowsHitTesting(false)
             } else {
                 placeholderIcon
             }
 
-            if waitsForManualCoverLoad == false || coverLoadState != .empty {
+            if waitsForManualCoverLoad == false || effectiveCoverLoadState != .empty {
                 Image(systemName: "play.circle.fill")
                     .font(.system(size: TiebaPureTheme.IconSize.play))
                     .foregroundStyle(.white)
@@ -110,7 +182,7 @@ struct VideoPlayerView: View {
             }
 
             if waitsForManualCoverLoad,
-               coverLoadState == .empty {
+               effectiveCoverLoadState == .empty {
                 Image(systemName: "arrow.down.circle")
                     .font(.system(size: 30, weight: .medium))
                     .foregroundStyle(.white)
@@ -151,12 +223,9 @@ struct VideoPlayerView: View {
         guard video.duration > 0 else { return nil }
 
         let seconds = video.duration > 10_000 ? video.duration / 1_000 : video.duration
-        return [
-            seconds / 60,
-            seconds % 60
-        ]
-        .map { String(format: "%02d", $0) }
-        .joined(separator: ":")
+        return [seconds / 60, seconds % 60]
+            .map { String(format: "%02d", $0) }
+            .joined(separator: ":")
     }
 
     private var mediaRequestPolicy: ReaderMediaRequestPolicy {
@@ -171,17 +240,23 @@ struct VideoPlayerView: View {
         video.coverURL != nil && mediaRequestPolicy.loadsAutomatically == false
     }
 
-    private var coverSourceIdentity: String? {
-        video.coverURL?.absoluteString
+    private var isManualCoverLoadAuthorized: Bool {
+        VideoPreviewReusePolicy.isManualLoadAuthorized(
+            authorizedIdentity: manualCoverAuthorization,
+            currentIdentity: previewSourceIdentity
+        )
     }
 
-    private var isManualCoverLoadAuthorized: Bool {
-        guard let coverSourceIdentity else { return false }
-        return manualCoverAuthorization == coverSourceIdentity
+    private var effectiveCoverLoadState: TiebaRemoteImageLoadState {
+        VideoPreviewReusePolicy.effectiveLoadState(
+            storedState: coverLoadState,
+            storedIdentity: coverLoadStateIdentity,
+            currentIdentity: previewSourceIdentity
+        )
     }
 
     private var videoAccessibilityLabel: String {
-        switch coverLoadState {
+        switch effectiveCoverLoadState {
         case .empty where waitsForManualCoverLoad:
             return "加载视频封面"
         case .loading:
@@ -194,7 +269,7 @@ struct VideoPlayerView: View {
     }
 
     private var videoAccessibilityHint: String {
-        switch coverLoadState {
+        switch effectiveCoverLoadState {
         case .empty where waitsForManualCoverLoad:
             return "加载当前视频封面"
         case .loading:
@@ -202,111 +277,7 @@ struct VideoPlayerView: View {
         case .failure:
             return "封面不可用，仍可打开视频播放器"
         case .empty, .success:
-            return "打开视频播放器"
+            return "打开全屏视频播放器"
         }
     }
-}
-
-struct DirectVideoPlaybackView: View {
-    let video: VideoContent
-
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        Group {
-            if let videoURL = TiebaVideoSourcePolicy.videoURL(video.videoURL) {
-                FullScreenVideoPlayer(url: videoURL)
-            } else if let webURL = TiebaVideoSourcePolicy.webpageURL(video.webURL) {
-                SafariView(url: webURL)
-                    .ignoresSafeArea()
-            } else {
-                unavailableView
-            }
-        }
-        .onAppear {
-            VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
-        }
-    }
-
-    private var unavailableView: some View {
-        ZStack(alignment: .topTrailing) {
-            Color.black
-                .ignoresSafeArea()
-
-            Text("视频不可用")
-                .font(.body.weight(.medium))
-                .foregroundStyle(.white)
-
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: TiebaPureTheme.IconSize.toolbar, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
-                    .background(.black.opacity(0.45), in: Circle())
-            }
-            .accessibilityLabel("关闭视频")
-            .padding(TiebaPureTheme.Spacing.md)
-        }
-    }
-}
-
-private struct FullScreenVideoPlayer: View {
-    let url: URL
-
-    @Environment(\.dismiss) private var dismiss
-    @State private var player: AVPlayer
-
-    init(url: URL) {
-        self.url = url
-        _player = State(initialValue: AVPlayer(url: url))
-    }
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            Color.black
-                .ignoresSafeArea()
-
-            VideoPlayer(player: player)
-                .ignoresSafeArea()
-
-            Button {
-                player.pause()
-                dismiss()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: TiebaPureTheme.IconSize.toolbar, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
-                    .background(.black.opacity(0.45), in: Circle())
-            }
-            .accessibilityLabel("关闭视频")
-            .padding(TiebaPureTheme.Spacing.md)
-        }
-        .onAppear {
-            VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
-            player.play()
-        }
-        .onReceive(player.publisher(for: \.timeControlStatus)) { status in
-            guard status == .playing else { return }
-            VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .tiebaVoicePlaybackWillStart)) { _ in
-            player.pause()
-        }
-        .onDisappear {
-            player.pause()
-        }
-    }
-}
-
-private struct SafariView: UIViewControllerRepresentable {
-    let url: URL
-
-    func makeUIViewController(context: Context) -> SFSafariViewController {
-        SFSafariViewController(url: url)
-    }
-
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
 }

--- a/TiebaPure/Features/Media/VideoPreviewTransition.swift
+++ b/TiebaPure/Features/Media/VideoPreviewTransition.swift
@@ -1,0 +1,842 @@
+import AVKit
+import SafariServices
+import UIKit
+
+enum VideoPreviewPlaybackPolicy {
+    static func shouldPlay(
+        presentationFinished: Bool,
+        dismissalStarted: Bool
+    ) -> Bool {
+        presentationFinished && dismissalStarted == false
+    }
+
+    static func keepsPosterVisible(
+        firstFrameReady: Bool,
+        dismissalStarted: Bool
+    ) -> Bool {
+        _ = dismissalStarted
+        return firstFrameReady == false
+    }
+}
+
+struct VideoPreviewSession: Identifiable {
+    let id = UUID()
+    let video: VideoContent
+    let sourceFrame: CGRect?
+    let sourceImage: UIImage?
+    let sourceAnchor: ImagePreviewSourceAnchor?
+    let sourceToken: ImagePreviewSourceToken?
+    let sourceIdentity: String?
+
+    @MainActor
+    init(
+        video: VideoContent,
+        sourceFrame: CGRect? = nil,
+        sourceImage: UIImage? = nil,
+        sourceAnchor: ImagePreviewSourceAnchor? = nil,
+        sourceIdentity: String? = nil
+    ) {
+        self.video = video
+        self.sourceFrame = ImagePreviewTransitionGeometry.validSourceFrame(sourceFrame)
+        self.sourceImage = sourceImage
+        self.sourceAnchor = sourceAnchor
+        sourceToken = sourceAnchor?.transitionToken
+        self.sourceIdentity = sourceIdentity ?? sourceAnchor?.sourceIdentity
+    }
+}
+
+@MainActor
+final class VideoPreviewCoordinator {
+    static let shared = VideoPreviewCoordinator()
+
+    private let arbiter = MediaPreviewPresentationArbiter.shared
+    private var activeController: VideoPreviewController?
+    private var activeSafariDriver: MediaPreviewSafariDriver?
+
+    private init() {}
+
+    @discardableResult
+    func present(_ session: VideoPreviewSession) -> Bool {
+        if let videoURL = TiebaVideoSourcePolicy.videoURL(session.video.videoURL) {
+            let request = MediaPreviewPresentationRequest(
+                id: session.id,
+                kind: .video,
+                sourceKey: session.sourceIdentity ?? videoURL.absoluteString
+            )
+            return arbiter.submit(request) { [weak self] in
+                self?.startVideo(
+                    session,
+                    videoURL: videoURL,
+                    request: request
+                ) ?? false
+            }
+        }
+
+        guard let webURL = TiebaVideoSourcePolicy.webpageURL(session.video.webURL) else {
+            return false
+        }
+        let request = MediaPreviewPresentationRequest(
+            id: session.id,
+            kind: .safari,
+            sourceKey: webURL.absoluteString
+        )
+        return arbiter.submit(request) { [weak self] in
+            self?.startSafari(webURL: webURL, request: request) ?? false
+        }
+    }
+
+    private func startVideo(
+        _ session: VideoPreviewSession,
+        videoURL: URL,
+        request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard let presenter = ImagePreviewCoordinator.topPresenter() else {
+            return false
+        }
+        let controller = VideoPreviewController(
+            session: session,
+            videoURL: videoURL,
+            onDismissalBegan: { [weak self] sessionID in
+                self?.beginDismissal(sessionID: sessionID, request: request)
+            },
+            onDismissalFinished: { [weak self] sessionID in
+                self?.finishVideoDismissal(sessionID: sessionID, request: request)
+            },
+            onPresentationCancelled: { [weak self] sessionID in
+                self?.cancelVideoPresentation(sessionID: sessionID, request: request)
+            },
+            onDismissalCancelled: { [weak self] sessionID in
+                self?.cancelDismissal(sessionID: sessionID, request: request)
+            }
+        )
+        controller.modalPresentationStyle = .overFullScreen
+        controller.modalPresentationCapturesStatusBarAppearance = true
+        controller.isModalInPresentation = true
+        controller.transitioningDelegate = controller
+        controller.loadViewIfNeeded()
+        controller.view.layoutIfNeeded()
+        activeController = controller
+
+        presenter.present(
+            controller,
+            animated: ImagePreviewTransitionMotionPolicy.animationsEnabled
+        ) { [weak self, weak controller] in
+            guard let self,
+                  self.arbiter.presentationDidFinish(request) else {
+                return
+            }
+            controller?.finishPresentationIfNeeded()
+        }
+        MediaPreviewPresentationAttachmentVerifier.verify(
+            controller: controller,
+            presenter: presenter
+        ) { [weak controller] in
+            controller?.heroPresentationDidCancel()
+        }
+        return true
+    }
+
+    private func startSafari(
+        webURL: URL,
+        request: MediaPreviewPresentationRequest
+    ) -> Bool {
+        guard let presenter = ImagePreviewCoordinator.topPresenter() else {
+            return false
+        }
+        let controller = SFSafariViewController(url: webURL)
+        let driver = MediaPreviewSafariDriver(
+            request: request,
+            controller: controller,
+            onDismissalBegan: { [weak self] request in
+                _ = self?.arbiter.dismissalWillBegin(request)
+            },
+            onDismissalFinished: { [weak self] request in
+                self?.finishSafariDismissal(request)
+            },
+            onDismissalCancelled: { [weak self] request in
+                _ = self?.arbiter.dismissalDidCancel(request)
+            }
+        )
+        controller.delegate = driver
+        activeSafariDriver = driver
+        presenter.present(controller, animated: true) { [weak self, weak driver] in
+            guard let self, let driver else { return }
+            driver.installPresentationDelegate()
+            _ = self.arbiter.presentationDidFinish(request)
+        }
+        MediaPreviewPresentationAttachmentVerifier.verify(
+            controller: controller,
+            presenter: presenter
+        ) { [weak self] in
+            self?.cancelSafariPresentation(request)
+        }
+        return true
+    }
+
+    private func beginDismissal(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id else { return }
+        _ = arbiter.dismissalWillBegin(request)
+    }
+
+    private func finishVideoDismissal(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id else { return }
+        if activeController?.session.id == sessionID {
+            activeController = nil
+        }
+        _ = arbiter.dismissalDidFinish(request)
+    }
+
+    private func cancelVideoPresentation(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id,
+              arbiter.presentationDidCancel(request) else {
+            return
+        }
+        if activeController?.session.id == sessionID {
+            activeController = nil
+        }
+    }
+
+    private func cancelDismissal(
+        sessionID: UUID,
+        request: MediaPreviewPresentationRequest
+    ) {
+        guard sessionID == request.id else { return }
+        _ = arbiter.dismissalDidCancel(request)
+    }
+
+    private func finishSafariDismissal(
+        _ request: MediaPreviewPresentationRequest
+    ) {
+        if activeSafariDriver?.request == request {
+            activeSafariDriver = nil
+        }
+        _ = arbiter.dismissalDidFinish(request)
+    }
+
+    private func cancelSafariPresentation(
+        _ request: MediaPreviewPresentationRequest
+    ) {
+        guard arbiter.presentationDidCancel(request) else { return }
+        if activeSafariDriver?.request == request {
+            activeSafariDriver = nil
+        }
+    }
+}
+
+@MainActor
+private final class MediaPreviewSafariDriver: NSObject,
+    @preconcurrency SFSafariViewControllerDelegate,
+    UIAdaptivePresentationControllerDelegate {
+    let request: MediaPreviewPresentationRequest
+
+    private weak var controller: SFSafariViewController?
+    private let onDismissalBegan: (MediaPreviewPresentationRequest) -> Void
+    private let onDismissalFinished: (MediaPreviewPresentationRequest) -> Void
+    private let onDismissalCancelled: (MediaPreviewPresentationRequest) -> Void
+    private var dismissalInteractionGate: MediaPreviewDismissalInteractionGate?
+    private var didBeginDismissal = false
+    private var didFinishDismissal = false
+
+    init(
+        request: MediaPreviewPresentationRequest,
+        controller: SFSafariViewController,
+        onDismissalBegan: @escaping (MediaPreviewPresentationRequest) -> Void,
+        onDismissalFinished: @escaping (MediaPreviewPresentationRequest) -> Void,
+        onDismissalCancelled: @escaping (MediaPreviewPresentationRequest) -> Void
+    ) {
+        self.request = request
+        self.controller = controller
+        self.onDismissalBegan = onDismissalBegan
+        self.onDismissalFinished = onDismissalFinished
+        self.onDismissalCancelled = onDismissalCancelled
+        super.init()
+    }
+
+    func installPresentationDelegate() {
+        controller?.presentationController?.delegate = self
+    }
+
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        beginDismissalIfNeeded()
+        controller.dismiss(animated: true) { [weak self] in
+            self?.finishDismissalIfNeeded()
+        }
+    }
+
+    func presentationControllerWillDismiss(
+        _ presentationController: UIPresentationController
+    ) {
+        beginDismissalIfNeeded()
+        presentationController.presentedViewController.transitionCoordinator?
+            .notifyWhenInteractionChanges { [weak self] context in
+                guard context.isCancelled else { return }
+                DispatchQueue.main.async {
+                    self?.cancelDismissalIfNeeded()
+                }
+            }
+    }
+
+    func presentationControllerDidDismiss(
+        _ presentationController: UIPresentationController
+    ) {
+        finishDismissalIfNeeded()
+    }
+
+    private func beginDismissalIfNeeded() {
+        guard didBeginDismissal == false else { return }
+        didBeginDismissal = true
+        onDismissalBegan(request)
+        if let window = controller?.view.window {
+            dismissalInteractionGate = MediaPreviewDismissalInteractionGate(
+                onTapAtWindowPoint: { point, window in
+                    ImagePreviewSourceRegistry.shared.activateSource(
+                        at: point,
+                        in: window
+                    )
+                }
+            )
+            .installed(in: window)
+        }
+    }
+
+    private func finishDismissalIfNeeded() {
+        guard didFinishDismissal == false else { return }
+        didFinishDismissal = true
+        guard let dismissalInteractionGate else {
+            onDismissalFinished(request)
+            return
+        }
+        self.dismissalInteractionGate = nil
+        dismissalInteractionGate.transitionDidComplete { [request, onDismissalFinished] in
+            onDismissalFinished(request)
+        }
+    }
+
+    private func cancelDismissalIfNeeded() {
+        guard didBeginDismissal, didFinishDismissal == false else { return }
+        didBeginDismissal = false
+        dismissalInteractionGate?.cancel()
+        dismissalInteractionGate = nil
+        onDismissalCancelled(request)
+    }
+}
+
+@MainActor
+private final class VideoPreviewController: UIViewController,
+    UIAdaptivePresentationControllerDelegate,
+    UIViewControllerTransitioningDelegate,
+    MediaPreviewHeroTransitionParticipant {
+    let session: VideoPreviewSession
+
+    private let videoURL: URL
+    private let player = AVPlayer()
+    private let playerController = AVPlayerViewController()
+    private let posterView = UIImageView()
+    private let failureView = UIView()
+    private let failureLabel = UILabel()
+    private let retryButton = UIButton(type: .system)
+    private let closeButton = UIButton(type: .system)
+    private let onDismissalBegan: (UUID) -> Void
+    private let onDismissalFinished: (UUID) -> Void
+    private let onPresentationCancelled: (UUID) -> Void
+    private let onDismissalCancelled: (UUID) -> Void
+
+    private var readyObservation: NSKeyValueObservation?
+    private var timeControlObservation: NSKeyValueObservation?
+    private var itemStatusObservation: NSKeyValueObservation?
+    private var failedToPlayObserver: NSObjectProtocol?
+    private var voicePlaybackObserver: NSObjectProtocol?
+    private var backgroundObserver: NSObjectProtocol?
+    private var posterAnimator: UIViewPropertyAnimator?
+    private var dismissalInteractionGate: MediaPreviewDismissalInteractionGate?
+    private var didCancelPresentation = false
+    private var didFinishPresentation = false
+    private var didBeginDismissal = false
+    private var didFinishDismissal = false
+    private var didReleasePlayer = false
+    private var firstFrameReady = false
+
+    init(
+        session: VideoPreviewSession,
+        videoURL: URL,
+        onDismissalBegan: @escaping (UUID) -> Void,
+        onDismissalFinished: @escaping (UUID) -> Void,
+        onPresentationCancelled: @escaping (UUID) -> Void,
+        onDismissalCancelled: @escaping (UUID) -> Void
+    ) {
+        self.session = session
+        self.videoURL = videoURL
+        self.onDismissalBegan = onDismissalBegan
+        self.onDismissalFinished = onDismissalFinished
+        self.onPresentationCancelled = onPresentationCancelled
+        self.onDismissalCancelled = onDismissalCancelled
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        playerController.player = player
+        playerController.showsPlaybackControls = true
+        playerController.videoGravity = .resizeAspect
+        playerController.view.accessibilityIdentifier = "full-screen-video-player"
+        addChild(playerController)
+        view.addSubview(playerController.view)
+        playerController.didMove(toParent: self)
+
+        configureContentOverlay()
+        configureCloseButton()
+        installPlayerItem()
+        observePlayback()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        playerController.view.frame = view.bounds
+        closeButton.frame = CGRect(
+            x: view.bounds.maxX - view.safeAreaInsets.right - 60,
+            y: view.safeAreaInsets.top + 16,
+            width: 44,
+            height: 44
+        )
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        presentationController?.delegate = self
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .lightContent
+    }
+
+    override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        .fade
+    }
+
+    func animationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
+        source: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        MediaPreviewHeroAnimator(operation: .presentation, participant: self)
+    }
+
+    func animationController(
+        forDismissed dismissed: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        MediaPreviewHeroAnimator(operation: .dismissal, participant: self)
+    }
+
+    func presentationControllerWillDismiss(
+        _ presentationController: UIPresentationController
+    ) {
+        beginDismissalIfNeeded()
+    }
+
+    func presentationControllerDidDismiss(
+        _ presentationController: UIPresentationController
+    ) {
+        finishDismissalIfNeeded()
+    }
+
+    var mediaPreviewHeroSourceIdentity: String? {
+        session.sourceIdentity
+    }
+
+    func mediaPreviewStableSourceView(
+        in sourceViewController: UIViewController
+    ) -> ImagePreviewSourceView? {
+        guard let sourceView = ImagePreviewSourceResolver.view(
+            exactAnchor: session.sourceAnchor,
+            token: session.sourceToken,
+            sourceIdentity: session.sourceIdentity
+        ) as? ImagePreviewSourceView,
+        let sourceWindow = sourceView.window else {
+            return nil
+        }
+        sourceViewController.loadViewIfNeeded()
+        let container = sourceViewController.view!
+        guard container.window === sourceWindow,
+              sourceView.isDescendant(of: container),
+              ImagePreviewTransitionGeometry.fullyVisibleFrame(
+                of: sourceView,
+                in: sourceWindow
+              ) != nil else {
+            return nil
+        }
+        return sourceView
+    }
+
+    func mediaPreviewHeroDismissalContent(
+        sourceView: ImagePreviewSourceView,
+        dismissedView: UIView,
+        containerView: UIView
+    ) -> MediaPreviewHeroDismissalContent? {
+        _ = containerView
+        guard firstFrameReady == false,
+              let image = session.sourceImage ?? sourceView.image else {
+            return nil
+        }
+        return MediaPreviewHeroDismissalContent(
+            image: image,
+            frame: ImagePreviewTransitionGeometry.aspectFitFrame(
+                imageSize: image.size,
+                in: dismissedView.frame
+            )
+        )
+    }
+
+    func mediaPreviewHeroTransitionDidCancel(
+        _ operation: MediaPreviewHeroOperation
+    ) {
+        switch operation {
+        case .presentation:
+            heroPresentationDidCancel()
+        case .dismissal:
+            heroDismissalDidCancel()
+        }
+    }
+
+    func finishPresentationIfNeeded() {
+        guard didFinishPresentation == false else { return }
+        didFinishPresentation = true
+        updatePlaybackState()
+    }
+
+    func beginDismissalIfNeeded() {
+        guard didBeginDismissal == false else { return }
+        didBeginDismissal = true
+        prepareForDismissal()
+        onDismissalBegan(session.id)
+        if let window = view.window {
+            dismissalInteractionGate = MediaPreviewDismissalInteractionGate(
+                onTapAtWindowPoint: { point, window in
+                    ImagePreviewSourceRegistry.shared.activateSource(
+                        at: point,
+                        in: window
+                    )
+                }
+            )
+            .installed(in: window)
+        }
+    }
+
+    func finishDismissalIfNeeded() {
+        guard didFinishDismissal == false else { return }
+        didFinishDismissal = true
+        releasePlayer()
+        let finish = onDismissalFinished
+        let sessionID = session.id
+        guard let dismissalInteractionGate else {
+            finish(sessionID)
+            return
+        }
+        self.dismissalInteractionGate = nil
+        dismissalInteractionGate.transitionDidComplete {
+            finish(sessionID)
+        }
+    }
+
+    func heroPresentationDidCancel() {
+        guard didCancelPresentation == false else { return }
+        didCancelPresentation = true
+        releasePlayer()
+        onPresentationCancelled(session.id)
+    }
+
+    func heroDismissalDidCancel() {
+        didBeginDismissal = false
+        didFinishDismissal = false
+        dismissalInteractionGate?.cancel()
+        dismissalInteractionGate = nil
+        playerController.showsPlaybackControls = true
+        updatePosterVisibility(animated: false)
+        updatePlaybackState()
+        onDismissalCancelled(session.id)
+    }
+
+    @objc
+    private func close() {
+        guard presentingViewController != nil,
+              isBeingDismissed == false else {
+            return
+        }
+        beginDismissalIfNeeded()
+        dismiss(animated: ImagePreviewTransitionMotionPolicy.animationsEnabled) { [weak self] in
+            self?.finishDismissalIfNeeded()
+        }
+    }
+
+    @objc
+    private func retryPlayback() {
+        guard didReleasePlayer == false,
+              didBeginDismissal == false else {
+            return
+        }
+        failureView.isHidden = true
+        installPlayerItem()
+        updatePlaybackState()
+    }
+
+    private func configureContentOverlay() {
+        let overlay = playerController.contentOverlayView ?? playerController.view!
+
+        posterView.image = session.sourceImage
+        posterView.contentMode = .scaleAspectFit
+        posterView.backgroundColor = .black
+        posterView.isUserInteractionEnabled = false
+        posterView.accessibilityElementsHidden = true
+        posterView.alpha = session.sourceImage == nil ? 0 : 1
+        posterView.translatesAutoresizingMaskIntoConstraints = false
+        overlay.addSubview(posterView)
+
+        failureView.backgroundColor = UIColor.black.withAlphaComponent(0.72)
+        failureView.layer.cornerRadius = 8
+        failureView.isHidden = true
+        failureView.accessibilityIdentifier = "video-playback-failure"
+        failureView.translatesAutoresizingMaskIntoConstraints = false
+        overlay.addSubview(failureView)
+
+        failureLabel.text = "视频加载失败\n请检查网络后重试"
+        failureLabel.font = .preferredFont(forTextStyle: .body)
+        failureLabel.textColor = .white
+        failureLabel.textAlignment = .center
+        failureLabel.numberOfLines = 0
+        failureLabel.translatesAutoresizingMaskIntoConstraints = false
+        failureView.addSubview(failureLabel)
+
+        var retryConfiguration = UIButton.Configuration.filled()
+        retryConfiguration.title = "重试"
+        retryConfiguration.baseForegroundColor = .white
+        retryConfiguration.baseBackgroundColor = .systemBlue
+        retryConfiguration.cornerStyle = .medium
+        retryButton.configuration = retryConfiguration
+        retryButton.addTarget(self, action: #selector(retryPlayback), for: .touchUpInside)
+        retryButton.accessibilityLabel = "重试播放视频"
+        retryButton.translatesAutoresizingMaskIntoConstraints = false
+        failureView.addSubview(retryButton)
+
+        NSLayoutConstraint.activate([
+            posterView.leadingAnchor.constraint(equalTo: overlay.leadingAnchor),
+            posterView.trailingAnchor.constraint(equalTo: overlay.trailingAnchor),
+            posterView.topAnchor.constraint(equalTo: overlay.topAnchor),
+            posterView.bottomAnchor.constraint(equalTo: overlay.bottomAnchor),
+            failureView.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            failureView.centerYAnchor.constraint(equalTo: overlay.centerYAnchor),
+            failureView.leadingAnchor.constraint(
+                greaterThanOrEqualTo: overlay.leadingAnchor,
+                constant: 24
+            ),
+            failureView.trailingAnchor.constraint(
+                lessThanOrEqualTo: overlay.trailingAnchor,
+                constant: -24
+            ),
+            failureLabel.leadingAnchor.constraint(equalTo: failureView.leadingAnchor, constant: 20),
+            failureLabel.trailingAnchor.constraint(equalTo: failureView.trailingAnchor, constant: -20),
+            failureLabel.topAnchor.constraint(equalTo: failureView.topAnchor, constant: 18),
+            retryButton.topAnchor.constraint(equalTo: failureLabel.bottomAnchor, constant: 14),
+            retryButton.centerXAnchor.constraint(equalTo: failureView.centerXAnchor),
+            retryButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 88),
+            retryButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 44),
+            retryButton.bottomAnchor.constraint(equalTo: failureView.bottomAnchor, constant: -18)
+        ])
+    }
+
+    private func configureCloseButton() {
+        var configuration = UIButton.Configuration.filled()
+        configuration.image = UIImage(systemName: "xmark")
+        configuration.baseForegroundColor = .white
+        configuration.baseBackgroundColor = UIColor.black.withAlphaComponent(0.45)
+        configuration.cornerStyle = .capsule
+        closeButton.configuration = configuration
+        closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
+        closeButton.accessibilityLabel = "关闭视频"
+        view.addSubview(closeButton)
+    }
+
+    private func installPlayerItem() {
+        itemStatusObservation?.invalidate()
+        itemStatusObservation = nil
+        if let failedToPlayObserver {
+            NotificationCenter.default.removeObserver(failedToPlayObserver)
+            self.failedToPlayObserver = nil
+        }
+
+        let item = AVPlayerItem(url: videoURL)
+        player.replaceCurrentItem(with: item)
+        itemStatusObservation = item.observe(
+            \.status,
+            options: [.initial, .new]
+        ) { [weak self, weak item] _, _ in
+            DispatchQueue.main.async {
+                guard let self, let item,
+                      self.player.currentItem === item else {
+                    return
+                }
+                self.handlePlayerItemStatus(item.status)
+            }
+        }
+        failedToPlayObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemFailedToPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self, weak item] _ in
+            Task { @MainActor in
+                guard let self, let item,
+                      self.player.currentItem === item else {
+                    return
+                }
+                self.showPlaybackFailure()
+            }
+        }
+    }
+
+    private func observePlayback() {
+        readyObservation = playerController.observe(
+            \.isReadyForDisplay,
+            options: [.initial, .new]
+        ) { [weak self] controller, _ in
+            guard controller.isReadyForDisplay else { return }
+            DispatchQueue.main.async {
+                self?.receiveFirstFrameReady()
+            }
+        }
+        timeControlObservation = player.observe(
+            \.timeControlStatus,
+            options: [.new]
+        ) { _, change in
+            guard change.newValue == .playing else { return }
+            DispatchQueue.main.async {
+                VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
+            }
+        }
+        voicePlaybackObserver = NotificationCenter.default.addObserver(
+            forName: .tiebaVoicePlaybackWillStart,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.player.pause()
+        }
+        backgroundObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.player.pause()
+        }
+    }
+
+    private func handlePlayerItemStatus(_ status: AVPlayerItem.Status) {
+        guard didReleasePlayer == false else { return }
+        switch status {
+        case .readyToPlay:
+            failureView.isHidden = true
+            if playerController.isReadyForDisplay {
+                receiveFirstFrameReady()
+            }
+        case .failed:
+            showPlaybackFailure()
+        case .unknown:
+            break
+        @unknown default:
+            break
+        }
+    }
+
+    private func showPlaybackFailure() {
+        guard didReleasePlayer == false else { return }
+        player.pause()
+        failureView.isHidden = false
+    }
+
+    private func receiveFirstFrameReady() {
+        guard didReleasePlayer == false else { return }
+        firstFrameReady = true
+        failureView.isHidden = true
+        updatePosterVisibility(animated: didFinishPresentation)
+    }
+
+    private func updatePlaybackState() {
+        guard VideoPreviewPlaybackPolicy.shouldPlay(
+            presentationFinished: didFinishPresentation,
+            dismissalStarted: didBeginDismissal
+        ), didReleasePlayer == false else {
+            player.pause()
+            return
+        }
+        VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
+        player.play()
+    }
+
+    private func updatePosterVisibility(animated: Bool) {
+        let keepsPoster = VideoPreviewPlaybackPolicy.keepsPosterVisible(
+            firstFrameReady: firstFrameReady,
+            dismissalStarted: didBeginDismissal
+        )
+        let targetAlpha: CGFloat = keepsPoster && posterView.image != nil ? 1 : 0
+        guard posterView.alpha != targetAlpha else { return }
+
+        posterAnimator?.stopAnimation(true)
+        guard animated, UIAccessibility.isReduceMotionEnabled == false else {
+            posterView.alpha = targetAlpha
+            return
+        }
+        let animator = UIViewPropertyAnimator(duration: 0.16, curve: .easeInOut) {
+            self.posterView.alpha = targetAlpha
+        }
+        posterAnimator = animator
+        animator.startAnimation()
+    }
+
+    private func prepareForDismissal() {
+        posterAnimator?.stopAnimation(true)
+        posterAnimator = nil
+        player.pause()
+        playerController.showsPlaybackControls = false
+        updatePosterVisibility(animated: false)
+    }
+
+    private func releasePlayer() {
+        guard didReleasePlayer == false else { return }
+        didReleasePlayer = true
+        posterAnimator?.stopAnimation(true)
+        posterAnimator = nil
+        readyObservation?.invalidate()
+        readyObservation = nil
+        timeControlObservation?.invalidate()
+        timeControlObservation = nil
+        itemStatusObservation?.invalidate()
+        itemStatusObservation = nil
+        if let failedToPlayObserver {
+            NotificationCenter.default.removeObserver(failedToPlayObserver)
+            self.failedToPlayObserver = nil
+        }
+        if let voicePlaybackObserver {
+            NotificationCenter.default.removeObserver(voicePlaybackObserver)
+            self.voicePlaybackObserver = nil
+        }
+        if let backgroundObserver {
+            NotificationCenter.default.removeObserver(backgroundObserver)
+            self.backgroundObserver = nil
+        }
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        playerController.player = nil
+    }
+}

--- a/TiebaPure/Features/Messages/MessagesView.swift
+++ b/TiebaPure/Features/Messages/MessagesView.swift
@@ -171,6 +171,7 @@ struct MessagesView: View {
         .accessibilityIdentifier("messages-list")
         .shortPullRefresh(
             isEnabled: didLoad && isLoading == false,
+            surface: .grouped,
             accessibilityIdentifier: "messages-refresh-animation"
         ) {
             await reload()

--- a/TiebaPure/Features/Profile/FollowedUsersView.swift
+++ b/TiebaPure/Features/Profile/FollowedUsersView.swift
@@ -128,6 +128,7 @@ struct UserRelationshipsView: View {
                 .listStyle(.plain)
                 .shortPullRefresh(
                     isEnabled: didLoad && isLoading == false,
+                    surface: .plain,
                     accessibilityIdentifier: "user-relationships-refresh-animation"
                 ) {
                     await reload()

--- a/TiebaPure/Features/Profile/MeView.swift
+++ b/TiebaPure/Features/Profile/MeView.swift
@@ -83,12 +83,12 @@ struct MeView: View {
                         Button {
                             showsFollowedForums = true
                         } label: {
-                            Label("我的关注吧", systemImage: "star")
+                            Label("关注的吧", systemImage: "star")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
-                        .accessibilityLabel("我的关注吧")
+                        .accessibilityLabel("关注的吧")
                         .accessibilityHint("打开已关注的贴吧列表")
                     }
                 } else {

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -59,7 +59,6 @@ struct UserProfileView: View {
     @State private var selectedThread: UserProfileThreadRoute?
     @State private var selectedForum: Forum?
     @State private var selectedRelationshipKind: UserRelationshipKind?
-    @State private var selectedVideoPreview: HomeVideoPreview?
 
     var body: some View {
         Group {
@@ -194,9 +193,6 @@ struct UserProfileView: View {
             isLoadingProfile = false
             isLoadingThreads = false
         }
-        .fullScreenCover(item: $selectedVideoPreview) { preview in
-            DirectVideoPlaybackView(video: preview.video)
-        }
         .accessibilityIdentifier("user-profile-screen")
         .fullScreenInteractiveNavigationPop()
     }
@@ -228,6 +224,7 @@ struct UserProfileView: View {
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
         .shortPullRefresh(
             isEnabled: isLoadingProfile == false && isLoadingThreads == false,
+            surface: .grouped,
             accessibilityIdentifier: "user-profile-refresh-animation"
         ) {
             await reload()
@@ -298,7 +295,14 @@ struct UserProfileView: View {
                                 )
                                 )
                             case let .playVideo(video):
-                                selectedVideoPreview = HomeVideoPreview(video: video)
+                                VideoPreviewCoordinator.shared.present(
+                                    VideoPreviewSession(
+                                        video: video,
+                                        sourceFrame: sourceFrame,
+                                        sourceImage: sourceImage,
+                                        sourceAnchor: sourceAnchor
+                                    )
+                                )
                             case .openThread:
                                 openThread(thread)
                             }

--- a/TiebaPure/Features/Search/SearchResultsView.swift
+++ b/TiebaPure/Features/Search/SearchResultsView.swift
@@ -57,7 +57,6 @@ struct SearchResultsView: View {
     @State private var activeThread: SearchThreadRoute?
     @State private var activeForum: Forum?
     @State private var selectedUser: UserSummary?
-    @State private var selectedVideoPreview: HomeVideoPreview?
     @State private var requestGeneration = 0
     @State private var loadTask: Task<SearchResultsPage, Error>?
     @State private var showsHistoryPersistenceError = false
@@ -153,9 +152,6 @@ struct SearchResultsView: View {
             loadTask?.cancel()
             requestGeneration += 1
             isLoading = false
-        }
-        .fullScreenCover(item: $selectedVideoPreview) { preview in
-            DirectVideoPlaybackView(video: preview.video)
         }
         .alert("操作失败", isPresented: $showsHistoryPersistenceError) {
             Button("好", role: .cancel) {}
@@ -347,7 +343,14 @@ struct SearchResultsView: View {
                                                 )
                                             )
                                         case let .playVideo(video):
-                                            selectedVideoPreview = HomeVideoPreview(video: video)
+                                            VideoPreviewCoordinator.shared.present(
+                                                VideoPreviewSession(
+                                                    video: video,
+                                                    sourceFrame: sourceFrame,
+                                                    sourceImage: sourceImage,
+                                                    sourceAnchor: sourceAnchor
+                                                )
+                                            )
                                         case .openThread:
                                             openThread(
                                                 SearchThreadRoute(
@@ -405,6 +408,7 @@ struct SearchResultsView: View {
                     }
                     .shortPullRefresh(
                         isEnabled: didLoad && isLoading == false,
+                        surface: .grouped,
                         accessibilityIdentifier: "search-refresh-animation"
                     ) {
                         await reload()

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -784,6 +784,7 @@ struct ThreadDetailView: View {
             .accessibilityIdentifier("thread-detail-scroll-view")
             .shortPullRefresh(
                 isEnabled: didLoad && isLoading == false,
+                surface: .grouped,
                 accessibilityIdentifier: "thread-refresh-animation"
             ) {
                 guard isLoading == false else { return }

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -2460,6 +2460,20 @@ final class TiebaPureSmokeTests: XCTestCase {
         )
     }
 
+    func testShortPullRefreshSurfacesResolveToSemanticSystemBackgrounds() {
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            let traits = UITraitCollection(userInterfaceStyle: style)
+            XCTAssertEqual(
+                UIColor(ShortPullRefreshSurface.grouped.color).resolvedColor(with: traits),
+                UIColor.systemGroupedBackground.resolvedColor(with: traits)
+            )
+            XCTAssertEqual(
+                UIColor(ShortPullRefreshSurface.plain.color).resolvedColor(with: traits),
+                UIColor.systemBackground.resolvedColor(with: traits)
+            )
+        }
+    }
+
     func testShortPullRefreshUsesSixHundredMillisecondMinimumVisibility() {
         XCTAssertEqual(
             ShortPullRefreshPolicy.minimumVisibleDurationNanoseconds,

--- a/TiebaPureTests/VideoPreviewTests.swift
+++ b/TiebaPureTests/VideoPreviewTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+import UIKit
+@testable import TiebaPure
+
+final class VideoPreviewTests: XCTestCase {
+    func testPlaybackStartsOnlyAfterPresentationAndStopsForDismissal() {
+        XCTAssertFalse(VideoPreviewPlaybackPolicy.shouldPlay(
+            presentationFinished: false,
+            dismissalStarted: false
+        ))
+        XCTAssertTrue(VideoPreviewPlaybackPolicy.shouldPlay(
+            presentationFinished: true,
+            dismissalStarted: false
+        ))
+        XCTAssertFalse(VideoPreviewPlaybackPolicy.shouldPlay(
+            presentationFinished: true,
+            dismissalStarted: true
+        ))
+    }
+
+    func testPosterStaysVisibleUntilFirstFrameAndDoesNotReturnAfterPlayback() {
+        XCTAssertTrue(VideoPreviewPlaybackPolicy.keepsPosterVisible(
+            firstFrameReady: false,
+            dismissalStarted: false
+        ))
+        XCTAssertFalse(VideoPreviewPlaybackPolicy.keepsPosterVisible(
+            firstFrameReady: true,
+            dismissalStarted: false
+        ))
+        XCTAssertFalse(VideoPreviewPlaybackPolicy.keepsPosterVisible(
+            firstFrameReady: true,
+            dismissalStarted: true
+        ))
+    }
+
+    func testVideoSourceIdentityIsStableAndContentSpecific() {
+        let first = makeVideo(url: "https://video.example/first.mp4")
+        let matching = makeVideo(url: "https://video.example/first.mp4")
+        let second = makeVideo(url: "https://video.example/second.mp4")
+
+        XCTAssertEqual(
+            VideoPreviewSourceIdentityPolicy.identity(for: first),
+            VideoPreviewSourceIdentityPolicy.identity(for: matching)
+        )
+        XCTAssertNotEqual(
+            VideoPreviewSourceIdentityPolicy.identity(for: first),
+            VideoPreviewSourceIdentityPolicy.identity(for: second)
+        )
+    }
+
+    func testVideoReuseRejectsLoadStateAuthorizationAndAnchorFromPreviousVideo() {
+        let oldIdentity = "video|old"
+        let newIdentity = "video|new"
+
+        XCTAssertEqual(
+            VideoPreviewReusePolicy.effectiveLoadState(
+                storedState: .success,
+                storedIdentity: oldIdentity,
+                currentIdentity: newIdentity
+            ),
+            .empty
+        )
+        XCTAssertFalse(VideoPreviewReusePolicy.isManualLoadAuthorized(
+            authorizedIdentity: oldIdentity,
+            currentIdentity: newIdentity
+        ))
+        XCTAssertFalse(VideoPreviewReusePolicy.canUseSourceAnchor(
+            anchorIdentity: oldIdentity,
+            currentIdentity: newIdentity
+        ))
+    }
+
+    func testVideoReusePreservesStateOnlyForTheSameVideoIdentity() {
+        let identity = "video|same"
+
+        XCTAssertEqual(
+            VideoPreviewReusePolicy.effectiveLoadState(
+                storedState: .failure,
+                storedIdentity: identity,
+                currentIdentity: identity
+            ),
+            .failure
+        )
+        XCTAssertTrue(VideoPreviewReusePolicy.isManualLoadAuthorized(
+            authorizedIdentity: identity,
+            currentIdentity: identity
+        ))
+        XCTAssertTrue(VideoPreviewReusePolicy.canUseSourceAnchor(
+            anchorIdentity: identity,
+            currentIdentity: identity
+        ))
+    }
+
+    func testPresentationAttachmentRequiresEitherUIKitOwnershipRelationship() {
+        XCTAssertFalse(MediaPreviewPresentationAttachmentPolicy.wasAccepted(
+            presenterOwnsController: false,
+            controllerHasPresenter: false,
+            controllerHasWindow: false
+        ))
+        XCTAssertTrue(MediaPreviewPresentationAttachmentPolicy.wasAccepted(
+            presenterOwnsController: true,
+            controllerHasPresenter: false,
+            controllerHasWindow: false
+        ))
+        XCTAssertTrue(MediaPreviewPresentationAttachmentPolicy.wasAccepted(
+            presenterOwnsController: false,
+            controllerHasPresenter: true,
+            controllerHasWindow: false
+        ))
+        XCTAssertTrue(MediaPreviewPresentationAttachmentPolicy.wasAccepted(
+            presenterOwnsController: false,
+            controllerHasPresenter: false,
+            controllerHasWindow: true
+        ))
+    }
+
+    func testMediaArbiterQueuesOnlyLatestCrossMediaRequestUntilSettlement() {
+        let image = request(.image)
+        let video = request(.video)
+        let safari = request(.safari)
+        var state = MediaPreviewPresentationArbiterState()
+
+        XCTAssertEqual(state.submit(image), .startNow)
+        XCTAssertTrue(state.presentationDidFinish(image))
+        XCTAssertTrue(state.dismissalWillBegin(image))
+        XCTAssertEqual(state.submit(video), .queued(replacing: nil))
+        XCTAssertEqual(state.submit(safari), .queued(replacing: video))
+        XCTAssertEqual(state.phase, .dismissing(image))
+
+        XCTAssertTrue(state.dismissalDidFinish(image))
+        XCTAssertEqual(state.phase, .settling)
+        XCTAssertEqual(state.finishSettlement(), safari)
+        XCTAssertEqual(state.phase, .presenting(safari))
+    }
+
+    func testMediaArbiterCancelledDismissalKeepsQueuedRequestBehindActiveModal() {
+        let image = request(.image)
+        let video = request(.video)
+        var state = MediaPreviewPresentationArbiterState()
+
+        XCTAssertEqual(state.submit(image), .startNow)
+        XCTAssertTrue(state.presentationDidFinish(image))
+        XCTAssertTrue(state.dismissalWillBegin(image))
+        XCTAssertEqual(state.submit(video), .queued(replacing: nil))
+
+        XCTAssertTrue(state.dismissalDidCancel(image))
+        XCTAssertEqual(state.phase, .presented(image))
+        XCTAssertEqual(state.pendingRequest, video)
+        XCTAssertFalse(state.dismissalDidFinish(image))
+
+        XCTAssertTrue(state.dismissalWillBegin(image))
+        XCTAssertTrue(state.dismissalDidFinish(image))
+        XCTAssertEqual(state.finishSettlement(), video)
+    }
+
+    func testMediaArbiterCanCancelQueuedCrossMediaRequest() {
+        let image = request(.image)
+        let video = request(.video)
+        var state = MediaPreviewPresentationArbiterState()
+
+        XCTAssertEqual(state.submit(image), .startNow)
+        XCTAssertTrue(state.presentationDidFinish(image))
+        XCTAssertTrue(state.dismissalWillBegin(image))
+        XCTAssertEqual(state.submit(video), .queued(replacing: nil))
+        XCTAssertTrue(state.cancelPending(video))
+        XCTAssertNil(state.pendingRequest)
+        XCTAssertTrue(state.dismissalDidFinish(image))
+        XCTAssertNil(state.finishSettlement())
+        XCTAssertEqual(state.phase, .idle)
+    }
+
+    func testMediaArbiterCoalescesRelayAndSwiftUITapForSameSource() {
+        let sourceKey = "thread-1-video-1"
+        let first = MediaPreviewPresentationRequest(
+            id: UUID(),
+            kind: .video,
+            sourceKey: sourceKey
+        )
+        let duplicate = MediaPreviewPresentationRequest(
+            id: UUID(),
+            kind: .video,
+            sourceKey: sourceKey
+        )
+        var state = MediaPreviewPresentationArbiterState()
+
+        XCTAssertEqual(state.submit(first), .startNow)
+        XCTAssertEqual(state.submit(duplicate), .ignoredActive)
+        XCTAssertNil(state.pendingRequest)
+    }
+
+    func testMediaArbiterPresentationCancellationStartsQueuedRequestAfterBarrier() {
+        let image = request(.image)
+        let video = request(.video)
+        var state = MediaPreviewPresentationArbiterState()
+
+        XCTAssertEqual(state.submit(image), .startNow)
+        XCTAssertEqual(state.submit(video), .queued(replacing: nil))
+        XCTAssertTrue(state.presentationDidCancel(image))
+        XCTAssertEqual(state.phase, .settling)
+        XCTAssertEqual(state.finishSettlement(), video)
+        XCTAssertEqual(state.phase, .presenting(video))
+    }
+
+    func testMediaArbiterRejectedPresentationWithoutPendingRequestReturnsToIdle() {
+        let video = request(.video)
+        var state = MediaPreviewPresentationArbiterState()
+
+        XCTAssertEqual(state.submit(video), .startNow)
+        XCTAssertTrue(state.presentationDidCancel(video))
+        XCTAssertNil(state.finishSettlement())
+        XCTAssertEqual(state.phase, .idle)
+    }
+
+    @MainActor
+    func testVideoSessionCapturesExactSourceTokenAndRejectsInvalidFrame() {
+        let identity = "fixture-video-source"
+        let anchor = ImagePreviewSourceAnchor(sourceIdentity: identity)
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 16, height: 9)).image {
+            UIColor.systemBlue.setFill()
+            $0.fill(CGRect(x: 0, y: 0, width: 16, height: 9))
+        }
+        anchor.store(image: image, sourceIdentity: identity)
+
+        let session = VideoPreviewSession(
+            video: makeVideo(url: "https://video.example/fixture.mp4"),
+            sourceFrame: .zero,
+            sourceImage: image,
+            sourceAnchor: anchor
+        )
+
+        XCTAssertEqual(session.sourceIdentity, identity)
+        XCTAssertEqual(session.sourceToken, anchor.transitionToken)
+        XCTAssertTrue(session.sourceImage === image)
+        XCTAssertNil(session.sourceFrame)
+    }
+
+    private func makeVideo(url: String) -> VideoContent {
+        VideoContent(
+            videoURL: URL(string: url),
+            coverURL: URL(string: "https://video.example/cover.jpg"),
+            webURL: URL(string: "https://tieba.baidu.com/p/1"),
+            width: 1920,
+            height: 1080,
+            duration: 120
+        )
+    }
+
+    private func request(
+        _ kind: MediaPreviewPresentationKind
+    ) -> MediaPreviewPresentationRequest {
+        MediaPreviewPresentationRequest(id: UUID(), kind: kind)
+    }
+}

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -380,10 +380,10 @@ final class TiebaPureUITests: XCTestCase {
 
         middleSwipeRight(in: app)
         rootTab("我的", in: app).tap()
-        let forumListEntry = app.buttons["我的关注吧"]
+        let forumListEntry = app.buttons["关注的吧"]
         XCTAssertTrue(forumListEntry.waitForExistence(timeout: 8))
         forumListEntry.tap()
-        XCTAssertTrue(app.navigationBars["我的关注吧"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.navigationBars["关注的吧"].waitForExistence(timeout: 8))
         XCTAssertFalse(
             app.buttons.matching(NSPredicate(format: "label == %@", "进入测试吧")).firstMatch.exists,
             "取消关注后，关注吧列表不能继续显示旧条目"
@@ -414,7 +414,7 @@ final class TiebaPureUITests: XCTestCase {
         rootTab("我的", in: app).tap()
 
         let followedUsers = app.buttons["followed-users-entry"]
-        let followedForums = app.buttons["我的关注吧"]
+        let followedForums = app.buttons["关注的吧"]
         let favorites = app.buttons["thread-favorites-entry"]
         let history = app.buttons["browsing-history-entry"]
         XCTAssertTrue(followedUsers.waitForExistence(timeout: 8))
@@ -808,21 +808,39 @@ final class TiebaPureUITests: XCTestCase {
             additionalArguments: ["UITEST_EXTENDED_REFRESH_ANIMATION"]
         )
         XCTAssertTrue(threadRows(in: app).firstMatch.waitForExistence(timeout: 45))
+        let homeScrollView = app.scrollViews["home-feed-scroll-view"]
+        XCTAssertTrue(homeScrollView.waitForExistence(timeout: 5))
 
         let homeStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.20))
         let homeEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.34))
         homeStart.press(forDuration: 0.1, thenDragTo: homeEnd)
+        let homeRefresh = app.descendants(matching: .any)["home-refresh-animation"]
         XCTAssertTrue(
-            app.descendants(matching: .any)["home-refresh-animation"].waitForExistence(timeout: 2)
+            homeRefresh.waitForExistence(timeout: 2)
+        )
+        assertRefreshRevealMatchesGroupedBackground(
+            in: app,
+            scrollContainer: homeScrollView,
+            refreshIndicator: homeRefresh,
+            context: "首页刷新保持态"
         )
         attachScreenshot(named: "fixture-home-refresh-indicator")
 
         openFirstThread(in: app)
+        let threadScrollView = app.scrollViews["thread-detail-scroll-view"]
+        XCTAssertTrue(threadScrollView.waitForExistence(timeout: 5))
         let threadStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.20))
         let threadEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.34))
         threadStart.press(forDuration: 0.1, thenDragTo: threadEnd)
+        let threadRefresh = app.descendants(matching: .any)["thread-refresh-animation"]
         XCTAssertTrue(
-            app.descendants(matching: .any)["thread-refresh-animation"].waitForExistence(timeout: 2)
+            threadRefresh.waitForExistence(timeout: 2)
+        )
+        assertRefreshRevealMatchesGroupedBackground(
+            in: app,
+            scrollContainer: threadScrollView,
+            refreshIndicator: threadRefresh,
+            context: "帖子页刷新保持态"
         )
         attachScreenshot(named: "fixture-thread-refresh-indicator")
     }
@@ -1093,7 +1111,7 @@ final class TiebaPureUITests: XCTestCase {
         rootTab("我的", in: app).tap()
         XCTAssertTrue(app.navigationBars["我的"].waitForExistence(timeout: 10))
         let loginButton = app.buttons["手机号验证码登录"]
-        let followedForumsButton = app.buttons["我的关注吧"]
+        let followedForumsButton = app.buttons["关注的吧"]
         XCTAssertTrue(
             loginButton.waitForExistence(timeout: 5) || followedForumsButton.waitForExistence(timeout: 5)
         )
@@ -1125,9 +1143,9 @@ final class TiebaPureUITests: XCTestCase {
         )
 
         let initialFrame = title.frame
-        assertForumHubTitle(title, staysInside: navigationBar)
+        assertNavigationTitle(title, staysInside: navigationBar)
 
-        let pullDelta = min(96 / max(forumList.frame.height, 1), 0.20)
+        let pullDelta = min(96 / max(forumList.frame.height, 1), 0.70)
         let refreshStart = forumList.coordinate(
             withNormalizedOffset: CGVector(dx: 0.5, dy: 0.20)
         )
@@ -1139,18 +1157,24 @@ final class TiebaPureUITests: XCTestCase {
             "forum-hub-refresh-animation"
         ]
         XCTAssertTrue(refreshAnimation.waitForExistence(timeout: 2))
-        assertForumHubTitle(title, staysInside: navigationBar)
+        assertNavigationTitle(title, staysInside: navigationBar)
+        assertRefreshRevealMatchesGroupedBackground(
+            in: app,
+            scrollContainer: forumList,
+            refreshIndicator: refreshAnimation,
+            context: "进吧刷新保持态"
+        )
         XCTAssertTrue(refreshAnimation.waitForNonExistence(timeout: 8))
-        assertForumHubTitle(title, staysInside: navigationBar)
+        assertNavigationTitle(title, staysInside: navigationBar)
 
         for _ in 0..<6 {
             forumList.swipeUp()
-            assertForumHubTitle(title, staysInside: navigationBar)
+            assertNavigationTitle(title, staysInside: navigationBar)
         }
         XCTAssertFalse(forumField.isHittable, "测试必须先让进吧列表明确离开顶部")
         for _ in 0..<12 where forumField.isHittable == false {
             forumList.swipeDown()
-            assertForumHubTitle(title, staysInside: navigationBar)
+            assertNavigationTitle(title, staysInside: navigationBar)
         }
         XCTAssertTrue(forumField.isHittable, "滚动验证结束后必须回到进吧页顶部")
         RunLoop.current.run(until: Date().addingTimeInterval(0.3))
@@ -1158,6 +1182,187 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertEqual(title.frame.midX, initialFrame.midX, accuracy: 1)
         XCTAssertEqual(title.frame.midY, initialFrame.midY, accuracy: 1)
         attachScreenshot(named: "fixture-forum-hub-inline-title-after-scroll")
+    }
+
+    func testFollowedForumTitleAndFirstRowStayVisibleWhileRefreshing() {
+        let app = launchApp(
+            account: "loggedIn",
+            additionalArguments: [
+                "UITEST_EXTENDED_REFRESH_ANIMATION",
+                "-UIPreferredContentSizeCategoryName",
+                "UICTContentSizeCategoryAccessibilityXXXL"
+            ]
+        )
+
+        rootTab("我的", in: app).tap()
+        let entry = app.buttons["关注的吧"]
+        XCTAssertTrue(entry.waitForExistence(timeout: 8))
+        entry.tap()
+
+        let navigationBar = app.navigationBars["关注的吧"]
+        let title = navigationBar.staticTexts["关注的吧"]
+        let searchField = app.textFields["followed-forum-search-field"]
+        let list = app.scrollViews["followed-forum-list"]
+        let firstRow = app.buttons.matching(identifier: "followed-forum-row").firstMatch
+        XCTAssertTrue(navigationBar.waitForExistence(timeout: 8))
+        XCTAssertTrue(title.waitForExistence(timeout: 5))
+        XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+        XCTAssertTrue(list.waitForExistence(timeout: 5))
+        XCTAssertTrue(firstRow.waitForExistence(timeout: 8))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+
+        let initialTitleFrame = title.frame
+        let initialSearchFrame = searchField.frame
+        let initialListFrame = list.frame
+        assertNavigationTitle(title, staysInside: navigationBar)
+        assertVisible(firstRow, inside: list, context: "关注的吧首行刷新前")
+
+        let appFrame = app.frame
+        let firstRowFrame = firstRow.frame
+        let startPoint = CGPoint(
+            x: firstRowFrame.midX,
+            y: firstRowFrame.minY + min(max(firstRowFrame.height * 0.35, 24), 60)
+        )
+        // Start inside visible row content. On iOS 26 the scroll view's
+        // accessibility frame can extend behind fixed navigation/header chrome,
+        // where a synthetic drag would not reach the list pan recognizer.
+        let endPoint = CGPoint(
+            x: startPoint.x,
+            y: min(startPoint.y + 120, appFrame.maxY - 32)
+        )
+        let start = app.coordinate(withNormalizedOffset: CGVector(
+            dx: startPoint.x / max(appFrame.width, 1),
+            dy: startPoint.y / max(appFrame.height, 1)
+        ))
+        let end = app.coordinate(withNormalizedOffset: CGVector(
+            dx: endPoint.x / max(appFrame.width, 1),
+            dy: endPoint.y / max(appFrame.height, 1)
+        ))
+        start.press(forDuration: 0.1, thenDragTo: end)
+
+        let refresh = app.descendants(matching: .any)["forum-list-refresh-animation"]
+        XCTAssertTrue(refresh.waitForExistence(timeout: 2))
+        assertNavigationTitle(title, staysInside: navigationBar)
+        XCTAssertEqual(searchField.frame.minY, initialSearchFrame.minY, accuracy: 1)
+        XCTAssertEqual(searchField.frame.height, initialSearchFrame.height, accuracy: 1)
+        let heldRefreshDistance: CGFloat = 44
+        XCTAssertEqual(
+            list.frame.minY,
+            initialListFrame.minY + heldRefreshDistance,
+            accuracy: 2,
+            "列表只应保留统一的 44pt 刷新空间，不得发生搜索抽屉重排"
+        )
+        assertVisible(firstRow, inside: list, context: "关注的吧首行刷新保持态")
+        assertRefreshRevealMatchesGroupedBackground(
+            in: app,
+            scrollContainer: list,
+            refreshIndicator: refresh,
+            context: "关注的吧刷新保持态"
+        )
+        attachScreenshot(named: "fixture-followed-forums-refresh-stable-title")
+
+        XCTAssertTrue(refresh.waitForNonExistence(timeout: 8))
+        assertNavigationTitle(title, staysInside: navigationBar)
+        XCTAssertEqual(title.frame.midX, initialTitleFrame.midX, accuracy: 1)
+        XCTAssertEqual(title.frame.midY, initialTitleFrame.midY, accuracy: 1)
+    }
+
+    private func assertVisible(
+        _ element: XCUIElement,
+        inside container: XCUIElement,
+        context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(element.exists, "\(context)：元素不存在", file: file, line: line)
+        let intersection = container.frame.intersection(element.frame)
+        XCTAssertFalse(intersection.isNull, "\(context)：元素不在可视区域", file: file, line: line)
+        XCTAssertGreaterThan(
+            intersection.height,
+            min(20, element.frame.height * 0.5),
+            "\(context)：元素被顶部或底部明显裁切",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertRefreshRevealMatchesGroupedBackground(
+        in app: XCUIApplication,
+        scrollContainer: XCUIElement,
+        refreshIndicator: XCUIElement,
+        context: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let capturedScreenshot = XCUIScreen.main.screenshot()
+        let screenshot = capturedScreenshot.image
+        let point = CGPoint(
+            x: scrollContainer.frame.minX + 8,
+            // Anchor the sample to the real refresh overlay. On iOS 26 a
+            // scroll view's accessibility frame can extend behind navigation
+            // chrome and is not a reliable visible-surface origin.
+            y: refreshIndicator.frame.midY
+        )
+        guard let actual = screenshotRGB(screenshot, atScreenPoint: point, screenFrame: app.frame) else {
+            XCTFail("\(context)：无法读取刷新暴露区像素", file: file, line: line)
+            return
+        }
+        let expectedColor = UIColor.systemGroupedBackground.resolvedColor(
+            with: UITraitCollection(userInterfaceStyle: UITraitCollection.current.userInterfaceStyle)
+        )
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard expectedColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            XCTFail("\(context)：无法解析语义背景色", file: file, line: line)
+            return
+        }
+        let expected = (
+            red: Int((red * 255).rounded()),
+            green: Int((green * 255).rounded()),
+            blue: Int((blue * 255).rounded())
+        )
+        let difference = abs(actual.red - expected.red)
+            + abs(actual.green - expected.green)
+            + abs(actual.blue - expected.blue)
+        if difference > 30 {
+            let attachment = XCTAttachment(screenshot: capturedScreenshot)
+            attachment.name = "\(context)-background-mismatch"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+            print(
+                "\(context): scrollFrame=\(scrollContainer.frame), "
+                    + "samplePoint=\(point), actual=\(actual), expected=\(expected)"
+            )
+        }
+        XCTAssertLessThanOrEqual(
+            difference,
+            30,
+            "\(context)：刷新暴露区与分组背景不连续，实际 \(actual)，预期 \(expected)",
+            file: file,
+            line: line
+        )
+    }
+
+    private func screenshotRGB(
+        _ image: UIImage,
+        atScreenPoint point: CGPoint,
+        screenFrame: CGRect
+    ) -> (red: Int, green: Int, blue: Int)? {
+        guard let cgImage = image.cgImage,
+              screenFrame.width > 0,
+              screenFrame.height > 0,
+              let data = cgImage.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(data) else {
+            return nil
+        }
+        let x = min(max(Int(point.x / screenFrame.width * CGFloat(cgImage.width)), 0), cgImage.width - 1)
+        let y = min(max(Int(point.y / screenFrame.height * CGFloat(cgImage.height)), 0), cgImage.height - 1)
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        guard bytesPerPixel >= 3 else { return nil }
+        let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
+        return (Int(bytes[offset]), Int(bytes[offset + 1]), Int(bytes[offset + 2]))
     }
 
     func testViewingThreadAddsBrowsingHistoryInMeAndReopensIt() {
@@ -3187,6 +3392,42 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
+    func testVideoPreviewReturnsToItsCoverAndCanReopenImmediately() {
+        let app = launchApp(additionalArguments: [
+            "UITEST_READER_MEDIA_POLICY",
+            "UITEST_VIDEO_PREVIEW_HERO"
+        ])
+        let video = app.buttons["播放视频"]
+        XCTAssertTrue(video.waitForExistence(timeout: 8))
+        XCTAssertTrue(waitForHittable(video, expected: true, timeout: 5))
+        guard let initialFrame = waitForStableFrame(of: video) else {
+            return XCTFail("视频封面初始布局没有稳定")
+        }
+
+        for cycle in 1...2 {
+            video.tap()
+            let player = app.descendants(matching: .any)["full-screen-video-player"]
+            let close = app.buttons["关闭视频"]
+            XCTAssertTrue(
+                player.waitForExistence(timeout: 5),
+                "第\(cycle)次没有打开全屏视频"
+            )
+            XCTAssertTrue(close.waitForExistence(timeout: 5))
+            close.tap()
+            XCTAssertTrue(
+                waitForHittable(video, expected: true, timeout: 5),
+                "第\(cycle)次关闭后视频封面没有恢复交互"
+            )
+            guard let restoredFrame = waitForStableFrame(of: video) else {
+                return XCTFail("第\(cycle)次关闭后视频封面布局没有稳定")
+            }
+            XCTAssertEqual(restoredFrame.minX, initialFrame.minX, accuracy: 1)
+            XCTAssertEqual(restoredFrame.minY, initialFrame.minY, accuracy: 1)
+            XCTAssertEqual(restoredFrame.width, initialFrame.width, accuracy: 1)
+            XCTAssertEqual(restoredFrame.height, initialFrame.height, accuracy: 1)
+        }
+    }
+
     func testFullScreenImageTransitionHandlesCroppedThumbnailAndOriginalRatio() {
         let arguments = [
             "UITEST_IMAGE_VIEWER",
@@ -3273,9 +3514,9 @@ final class TiebaPureUITests: XCTestCase {
     func testFollowedForumWholeRowNavigatesWithoutGestureConflict() {
         let app = launchApp(account: "loggedIn")
         rootTab("我的", in: app).tap()
-        XCTAssertTrue(app.buttons["我的关注吧"].waitForExistence(timeout: 8))
-        app.buttons["我的关注吧"].tap()
-        XCTAssertTrue(app.navigationBars["我的关注吧"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.buttons["关注的吧"].waitForExistence(timeout: 8))
+        app.buttons["关注的吧"].tap()
+        XCTAssertTrue(app.navigationBars["关注的吧"].waitForExistence(timeout: 8))
 
         let row = app.buttons.matching(identifier: "followed-forum-row").firstMatch
         XCTAssertTrue(row.waitForExistence(timeout: 8))
@@ -3286,7 +3527,7 @@ final class TiebaPureUITests: XCTestCase {
 
         middleSwipeRight(in: app)
         XCTAssertTrue(
-            app.navigationBars["我的关注吧"].waitForExistence(timeout: 5),
+            app.navigationBars["关注的吧"].waitForExistence(timeout: 5),
             "关注吧进入贴吧后右划只能返回关注吧列表"
         )
         middleSwipeRight(in: app)
@@ -4228,7 +4469,7 @@ final class TiebaPureUITests: XCTestCase {
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
-    private func assertForumHubTitle(
+    private func assertNavigationTitle(
         _ title: XCUIElement,
         staysInside navigationBar: XCUIElement,
         file: StaticString = #filePath,
@@ -4236,10 +4477,10 @@ final class TiebaPureUITests: XCTestCase {
     ) {
         let titleFrame = title.frame
         let navigationFrame = navigationBar.frame.insetBy(dx: -1, dy: -1)
-        XCTAssertFalse(titleFrame.isEmpty, "进吧标题必须保持可见", file: file, line: line)
+        XCTAssertFalse(titleFrame.isEmpty, "导航标题必须保持可见", file: file, line: line)
         XCTAssertTrue(
             navigationFrame.contains(titleFrame),
-            "进吧标题必须完整位于导航栏内，不能在滚动后错位或被裁切",
+            "导航标题必须完整位于导航栏内，不能在滚动或刷新后错位或被裁切",
             file: file,
             line: line
         )

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.3.6
-        CURRENT_PROJECT_VERSION: 25
+        MARKETING_VERSION: 1.3.7
+        CURRENT_PROJECT_VERSION: 26
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.3.6
-        CURRENT_PROJECT_VERSION: 25
+        MARKETING_VERSION: 1.3.7
+        CURRENT_PROJECT_VERSION: 26
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容
- 将“我的关注吧”统一改为“关注的吧”，固定搜索栏与导航标题，刷新时不再随内容消失
- 统一首页、进吧、关注列表、帖子等刷新容器的语义背景，修复白色与灰色区域断层
- 重构图片与视频共用的全屏转场和展示仲裁，支持视频封面 Hero 动画、稳定返回与立即重开
- 修复视频列表复用时旧封面、旧加载状态及展示失败后的资源残留
- 版本更新为 1.3.7 (26)

## 验证
- 完整单元测试：497/497
- 刷新与视频 UI 回归：11/11
- 图片共享转场回归：8/8
- 最终视频复用定向测试：15/15
- xcodebuild analyze 通过
- Release unsigned IPA 打包及结构校验通过