### PR TITLE
新增回帖开关、个人资料管理与本人主题删除

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1243,13 +1243,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1260,14 +1260,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1313,14 +1313,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1333,13 +1333,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		523FCD7E0AC8E40A81BA0C03 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6443B9D2D0368D0B870565A7 /* Assets.xcassets */; };
 		53044332B9EB096132A2E15F /* LocalThreadLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B097E875FE8B825D77AD05F /* LocalThreadLibrary.swift */; };
 		53DEA982CB662F838F26F9BC /* ThreadAuthorBadgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7B54C9EC311DDB57FEBB4F /* ThreadAuthorBadgeTests.swift */; };
+		55E47240CEE0819290FB3D4B /* UserProfileManagementUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368AC27310A17EE4C0B40D24 /* UserProfileManagementUITests.swift */; };
 		560E7C25470B13349BE24055 /* ContentBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD67FF51E0529813111A68A /* ContentBlock.swift */; };
 		568856E8203C6DDBCBD7F027 /* PbFloor_PbFloorRequest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532EEE9965373A3008560F53 /* PbFloor_PbFloorRequest.pb.swift */; };
 		5A56CE0B756E52E025521190 /* Error.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221856558BEBEBF7F21F19A9 /* Error.pb.swift */; };
@@ -67,6 +68,7 @@
 		5DF9D42AF53D712C923B9A3D /* TiebaSearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8606C99A4A56953BB1FA0ED /* TiebaSearchAPI.swift */; };
 		5FE25FDC40B4F42C42A3787C /* CommonRequest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374582F532CC1815B25EC4EB /* CommonRequest.pb.swift */; };
 		61AC96A8DF8D9A6671239F30 /* TiebaURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3321457BFA9611243ABF93 /* TiebaURL.swift */; };
+		63731BB53CEC877F1A7F871A /* ContentReplyFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622845B4F081A6D04395156C /* ContentReplyFeatureTests.swift */; };
 		66CB3F6B00C11572EF7276D1 /* TiebaUserProfileAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55649E6AEA1AD2EF4813452 /* TiebaUserProfileAPI.swift */; };
 		691639A3C4F64DE3F892A98D /* ContentBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B4550B620AEBC6B7EA4F46 /* ContentBlockView.swift */; };
 		6A3F2F36CE6C23941BD07F7E /* MediaPreviewPresentationArbiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A89193F661C5F61F3470AC /* MediaPreviewPresentationArbiter.swift */; };
@@ -91,6 +93,7 @@
 		96E558670B2758520F748005 /* ContentComposerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C0F8A37BD6F0E4EA09BFCD /* ContentComposerPolicyTests.swift */; };
 		9B869CC8E0EE590D0B003B40 /* FollowedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBDB720D1FCC2A3138B0CC /* FollowedUsersView.swift */; };
 		9E782527D741226479B50A92 /* TiebaContentSubmissionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C158046155BBD6748519CF /* TiebaContentSubmissionAPI.swift */; };
+		9FCC42B360A1683D6696808F /* ContentSubmissionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A4C581F09C568D7DFC25D8 /* ContentSubmissionSettings.swift */; };
 		A4FCD6601BAA005BF0F264D0 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11227FF243EF6E0046E5C4A1 /* RootView.swift */; };
 		A5757E03976CA021ADE696FB /* Personalized.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6711EB46FB5BE95EF86ACB6 /* Personalized.pb.swift */; };
 		A6537596454795C265B252AD /* TiebaRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9A3625B3F19C2F07165809 /* TiebaRequestBuilder.swift */; };
@@ -107,6 +110,7 @@
 		B1EC4ECCDB577E77B8026BE6 /* TiebaEmoticon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF25E73F880C6AD77740631 /* TiebaEmoticon.swift */; };
 		B4A335E483F17819940BE505 /* Voice.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E70E625263EC96961F9D8D7 /* Voice.pb.swift */; };
 		B5EC9216076BE5E4C2EF8721 /* TiebaPureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F406332470AF7C30B532A5 /* TiebaPureApp.swift */; };
+		B673FC1D9439E3D10DF147C0 /* UserProfileMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F1C4599FA7188B0D810AE19 /* UserProfileMutationTests.swift */; };
 		B744513E4012208DC9BA3056 /* ContentSubmissionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B9F1DB7C284253E1A90DCA /* ContentSubmissionCoordinatorTests.swift */; };
 		BB1C38F18849E8E8287BCCA7 /* SocialMutationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5B4C5570D72B5D840721B1 /* SocialMutationCoordinator.swift */; };
 		BE171315B6CB8B7FCA968A65 /* PbFloor_PbFloorResponse.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A967D18B7F1F21562A66FCA /* PbFloor_PbFloorResponse.pb.swift */; };
@@ -165,6 +169,7 @@
 		FA74FB79B01F1BE9C5A98873 /* ContentSubmissionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FC3906D642656961F9DAE4 /* ContentSubmissionCoordinator.swift */; };
 		FA8DDBB0C4B9772070886AEB /* ContentComposerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E72CA28607562B62AC8C5CD /* ContentComposerPresentation.swift */; };
 		FAA35A6197A3F9ADA6A58599 /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BD3F2D04164FFE41606F0C /* AccountStore.swift */; };
+		FB6002A8AEF7E1213AC7EA87 /* OwnThreadMutationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703A3E007139EC93BECB057F /* OwnThreadMutationState.swift */; };
 		FFA0818B86B2CCB9CDB7539F /* VoicePlaybackControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BABD44302879D665A9AC3 /* VoicePlaybackControl.swift */; };
 /* End PBXBuildFile section */
 
@@ -247,6 +252,7 @@
 		356FA7F667F83C07E1845A80 /* ContentComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentComposerView.swift; sourceTree = "<group>"; };
 		35CD0BAA4D26A1DBC8367F53 /* ImageDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadService.swift; sourceTree = "<group>"; };
 		36421D36A7372F3886F8A1FA /* FixtureTiebaAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureTiebaAPI.swift; sourceTree = "<group>"; };
+		368AC27310A17EE4C0B40D24 /* UserProfileManagementUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileManagementUITests.swift; sourceTree = "<group>"; };
 		36B7B87BD4A9EB32A9F340FC /* ContentFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentFilterTests.swift; sourceTree = "<group>"; };
 		374582F532CC1815B25EC4EB /* CommonRequest.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonRequest.pb.swift; sourceTree = "<group>"; };
 		3797B6083214EC5E9FF58648 /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
@@ -279,6 +285,7 @@
 		5E2FAEA095A18F41BED60B8D /* EmoticonResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoticonResourceTests.swift; sourceTree = "<group>"; };
 		5E7B54C9EC311DDB57FEBB4F /* ThreadAuthorBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadAuthorBadgeTests.swift; sourceTree = "<group>"; };
 		5E92E90BB801373B85685DDD /* Forum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Forum.swift; sourceTree = "<group>"; };
+		622845B4F081A6D04395156C /* ContentReplyFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentReplyFeatureTests.swift; sourceTree = "<group>"; };
 		62D2754EBACAEEB97F2E3E7E /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		638DEF254549D0D4DE625487 /* ReadingPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPreferences.swift; sourceTree = "<group>"; };
 		63DFA01B546626F59DF261F1 /* ExternalRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalRoute.swift; sourceTree = "<group>"; };
@@ -290,6 +297,7 @@
 		6AD842C2F8EBE015B4F98443 /* Abstract.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Abstract.pb.swift; sourceTree = "<group>"; };
 		6B9769DFBF55471E036C585C /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		6E308EC64EE7E7737CA03AE5 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		703A3E007139EC93BECB057F /* OwnThreadMutationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnThreadMutationState.swift; sourceTree = "<group>"; };
 		7294F83ED412C768AFA77BCB /* LICENSE */ = {isa = PBXFileReference; path = LICENSE; sourceTree = "<group>"; };
 		72A829A6D2ABD0F1D55D90E6 /* SocialRelationshipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialRelationshipStateTests.swift; sourceTree = "<group>"; };
 		78FABF04E476AC1533EBDFA2 /* InteractiveNavigationPop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveNavigationPop.swift; sourceTree = "<group>"; };
@@ -316,6 +324,7 @@
 		994E9D3128F82A0683DA39E0 /* CapsuleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleLabel.swift; sourceTree = "<group>"; };
 		9CE43843ABF0E6FE36F6A7BD /* TiebaURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaURLTests.swift; sourceTree = "<group>"; };
 		9D3DFA01DD01FD4EA295E006 /* ForumHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumHubView.swift; sourceTree = "<group>"; };
+		9F1C4599FA7188B0D810AE19 /* UserProfileMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileMutationTests.swift; sourceTree = "<group>"; };
 		A87CD00DD298F86614F66AAD /* Lbs.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lbs.pb.swift; sourceTree = "<group>"; };
 		A8FC3906D642656961F9DAE4 /* ContentSubmissionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSubmissionCoordinator.swift; sourceTree = "<group>"; };
 		AABE9716DCC2C5720A003041 /* VideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerView.swift; sourceTree = "<group>"; };
@@ -352,6 +361,7 @@
 		E442EEBED99D57F019D339D0 /* VoiceAudioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioClient.swift; sourceTree = "<group>"; };
 		E65F7C671CDA66E5F18CEC24 /* UserProfileMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileMapper.swift; sourceTree = "<group>"; };
 		E6FB0DE22872019BC145C2AF /* ContentSubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSubmission.swift; sourceTree = "<group>"; };
+		E7A4C581F09C568D7DFC25D8 /* ContentSubmissionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSubmissionSettings.swift; sourceTree = "<group>"; };
 		E7D98C38DD4DF0A6BBAEE14B /* User.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.pb.swift; sourceTree = "<group>"; };
 		EA31C128D796A3D90D001643 /* ContentMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMappingTests.swift; sourceTree = "<group>"; };
 		ED135C7D7263C882A3B2FF09 /* ForumMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumMapper.swift; sourceTree = "<group>"; };
@@ -510,6 +520,7 @@
 				EDD67FF51E0529813111A68A /* ContentBlock.swift */,
 				B5A1C1C285AED2131947564A /* ContentDraft.swift */,
 				E6FB0DE22872019BC145C2AF /* ContentSubmission.swift */,
+				E7A4C581F09C568D7DFC25D8 /* ContentSubmissionSettings.swift */,
 				5E92E90BB801373B85685DDD /* Forum.swift */,
 				93E0B943190782C7374C3690 /* ForumThreadCategory.swift */,
 				8B097E875FE8B825D77AD05F /* LocalThreadLibrary.swift */,
@@ -598,6 +609,7 @@
 			isa = PBXGroup;
 			children = (
 				A8FC3906D642656961F9DAE4 /* ContentSubmissionCoordinator.swift */,
+				703A3E007139EC93BECB057F /* OwnThreadMutationState.swift */,
 				2E5B4C5570D72B5D840721B1 /* SocialMutationCoordinator.swift */,
 				B9718D80CC5DA7EC934BCFEB /* SocialRelationshipState.swift */,
 			);
@@ -613,6 +625,7 @@
 				0CE52F261111609A3D8E1D30 /* ContentDraftTests.swift */,
 				36B7B87BD4A9EB32A9F340FC /* ContentFilterTests.swift */,
 				EA31C128D796A3D90D001643 /* ContentMappingTests.swift */,
+				622845B4F081A6D04395156C /* ContentReplyFeatureTests.swift */,
 				C3B9F1DB7C284253E1A90DCA /* ContentSubmissionCoordinatorTests.swift */,
 				83A586DD3DD949672854FF9E /* ContentSubmissionNetworkTests.swift */,
 				5E2FAEA095A18F41BED60B8D /* EmoticonResourceTests.swift */,
@@ -628,6 +641,7 @@
 				2792F6DFB423B6000542ADFB /* TiebaPostingBootstrapTests.swift */,
 				53A22DDA746D43724E44B7D2 /* TiebaPureSmokeTests.swift */,
 				9CE43843ABF0E6FE36F6A7BD /* TiebaURLTests.swift */,
+				9F1C4599FA7188B0D810AE19 /* UserProfileMutationTests.swift */,
 				3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */,
 				DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */,
 				3ABAA8240FEE5D60D5C61349 /* VoicePlaybackControlTests.swift */,
@@ -684,6 +698,7 @@
 			isa = PBXGroup;
 			children = (
 				FB433765723C53B6E8A6CA9B /* TiebaPureUITests.swift */,
+				368AC27310A17EE4C0B40D24 /* UserProfileManagementUITests.swift */,
 			);
 			path = TiebaPureUITests;
 			sourceTree = "<group>";
@@ -993,6 +1008,7 @@
 				50AA54B8BA6EAAD96FE7E609 /* ContentSubmission.pb.swift in Sources */,
 				76335BCC2EF12774CA12ACC1 /* ContentSubmission.swift in Sources */,
 				FA74FB79B01F1BE9C5A98873 /* ContentSubmissionCoordinator.swift in Sources */,
+				9FCC42B360A1683D6696808F /* ContentSubmissionSettings.swift in Sources */,
 				5A56CE0B756E52E025521190 /* Error.pb.swift in Sources */,
 				ECDE960EDA7E9E0E186B2D3C /* ExternalRoute.swift in Sources */,
 				4ED79FF1DB72B276E756EBF2 /* FixtureTiebaAPI.swift in Sources */,
@@ -1022,6 +1038,7 @@
 				F60F13E9F3CF7AA790EE1C4A /* MessagesView.swift in Sources */,
 				D3F2C72D1BAA5E6241C68B52 /* MetadataLine.swift in Sources */,
 				4A8E23945EF79EAEFE3019DC /* MultipartFormData.swift in Sources */,
+				FB6002A8AEF7E1213AC7EA87 /* OwnThreadMutationState.swift in Sources */,
 				5C55104E13B0C728DDDAD257 /* Page.pb.swift in Sources */,
 				2382AFD769C00913BCF7C713 /* PbContent.pb.swift in Sources */,
 				568856E8203C6DDBCBD7F027 /* PbFloor_PbFloorRequest.pb.swift in Sources */,
@@ -1101,6 +1118,7 @@
 				116B9F91820A3F111B4D0150 /* ContentDraftTests.swift in Sources */,
 				AC68D0057C4A48786599AB69 /* ContentFilterTests.swift in Sources */,
 				CF454E1295D97B7FE03A3DDA /* ContentMappingTests.swift in Sources */,
+				63731BB53CEC877F1A7F871A /* ContentReplyFeatureTests.swift in Sources */,
 				B744513E4012208DC9BA3056 /* ContentSubmissionCoordinatorTests.swift in Sources */,
 				2E614B406807B5BAFBCA4918 /* ContentSubmissionNetworkTests.swift in Sources */,
 				7670D2DD682E7DA328CABB62 /* EmoticonResourceTests.swift in Sources */,
@@ -1116,6 +1134,7 @@
 				85EFBF3494B6DBAE4707E464 /* TiebaPostingBootstrapTests.swift in Sources */,
 				C0E5134C9E23DDD474D84DDA /* TiebaPureSmokeTests.swift in Sources */,
 				450F423517B8D1DEFD51B15B /* TiebaURLTests.swift in Sources */,
+				B673FC1D9439E3D10DF147C0 /* UserProfileMutationTests.swift in Sources */,
 				DE64CDA4FA60F57188F7BC53 /* UserProfileTests.swift in Sources */,
 				3E9872C838729BB48E4DD67A /* VideoPreviewTests.swift in Sources */,
 				8013F79EDBAB28236D574DAD /* VoicePlaybackControlTests.swift in Sources */,
@@ -1138,6 +1157,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80239D3CC75F3B5A44A8BEDA /* TiebaPureUITests.swift in Sources */,
+				55E47240CEE0819290FB3D4B /* UserProfileManagementUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1223,13 +1243,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.7;
+				MARKETING_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1240,14 +1260,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.7;
+				MARKETING_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1293,14 +1313,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.7;
+				MARKETING_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1313,13 +1333,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.7;
+				MARKETING_VERSION = 1.3.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -26,15 +26,19 @@ final class AppEnvironment: ObservableObject {
         self.accountStore = accountStore
         self.api = api
         self.logoutCoordinator = logoutCoordinator
-        let resolvedSocialState = socialRelationshipState ?? SocialRelationshipState()
-        self.socialRelationshipState = resolvedSocialState
-        self.socialMutationCoordinator = socialMutationCoordinator
-            ?? SocialMutationCoordinator(api: api, state: resolvedSocialState)
-        self.ownThreadMutationState = ownThreadMutationState ?? OwnThreadMutationState()
-        self.contentDraftStore = contentDraftStore ?? ContentDraftStore()
         let resolvedSubmissionSettings = contentSubmissionSettingsStore
             ?? ContentSubmissionSettingsStore()
         self.contentSubmissionSettingsStore = resolvedSubmissionSettings
+        let resolvedSocialState = socialRelationshipState ?? SocialRelationshipState()
+        self.socialRelationshipState = resolvedSocialState
+        self.socialMutationCoordinator = socialMutationCoordinator
+            ?? SocialMutationCoordinator(
+                api: api,
+                state: resolvedSocialState,
+                allowsLikes: { resolvedSubmissionSettings.likesEnabled }
+            )
+        self.ownThreadMutationState = ownThreadMutationState ?? OwnThreadMutationState()
+        self.contentDraftStore = contentDraftStore ?? ContentDraftStore()
         self.contentSubmissionCoordinator = contentSubmissionCoordinator
             ?? ContentSubmissionCoordinator(
                 api: api,
@@ -163,7 +167,8 @@ final class AppEnvironment: ObservableObject {
         let socialRelationshipState = SocialRelationshipState()
         let socialMutationCoordinator = SocialMutationCoordinator(
             api: api,
-            state: socialRelationshipState
+            state: socialRelationshipState,
+            allowsLikes: { contentSubmissionSettingsStore.likesEnabled }
         )
         return AppEnvironment(
             accountStore: accountStore,
@@ -248,7 +253,8 @@ final class AppEnvironment: ObservableObject {
         let socialRelationshipState = SocialRelationshipState()
         let socialMutationCoordinator = SocialMutationCoordinator(
             api: api,
-            state: socialRelationshipState
+            state: socialRelationshipState,
+            allowsLikes: { contentSubmissionSettingsStore.likesEnabled }
         )
         let draftStore = ContentDraftStore()
         if ProcessInfo.processInfo.arguments.contains("UITEST_RESET_CONTENT_SUBMISSION") {

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -7,7 +7,9 @@ final class AppEnvironment: ObservableObject {
     let logoutCoordinator: LogoutCoordinator
     let socialRelationshipState: SocialRelationshipState
     let socialMutationCoordinator: SocialMutationCoordinator
+    let ownThreadMutationState: OwnThreadMutationState
     let contentDraftStore: ContentDraftStore
+    let contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     let contentSubmissionCoordinator: ContentSubmissionCoordinator
 
     init(
@@ -15,7 +17,10 @@ final class AppEnvironment: ObservableObject {
         api: any TiebaAPIService,
         logoutCoordinator: LogoutCoordinator,
         socialRelationshipState: SocialRelationshipState? = nil,
+        socialMutationCoordinator: SocialMutationCoordinator? = nil,
+        ownThreadMutationState: OwnThreadMutationState? = nil,
         contentDraftStore: ContentDraftStore? = nil,
+        contentSubmissionSettingsStore: ContentSubmissionSettingsStore? = nil,
         contentSubmissionCoordinator: ContentSubmissionCoordinator? = nil
     ) {
         self.accountStore = accountStore
@@ -23,10 +28,18 @@ final class AppEnvironment: ObservableObject {
         self.logoutCoordinator = logoutCoordinator
         let resolvedSocialState = socialRelationshipState ?? SocialRelationshipState()
         self.socialRelationshipState = resolvedSocialState
-        socialMutationCoordinator = SocialMutationCoordinator(api: api, state: resolvedSocialState)
+        self.socialMutationCoordinator = socialMutationCoordinator
+            ?? SocialMutationCoordinator(api: api, state: resolvedSocialState)
+        self.ownThreadMutationState = ownThreadMutationState ?? OwnThreadMutationState()
         self.contentDraftStore = contentDraftStore ?? ContentDraftStore()
+        let resolvedSubmissionSettings = contentSubmissionSettingsStore
+            ?? ContentSubmissionSettingsStore()
+        self.contentSubmissionSettingsStore = resolvedSubmissionSettings
         self.contentSubmissionCoordinator = contentSubmissionCoordinator
-            ?? ContentSubmissionCoordinator(api: api)
+            ?? ContentSubmissionCoordinator(
+                api: api,
+                allowsSubmission: { resolvedSubmissionSettings.allowsSubmission(kind: $0) }
+            )
     }
 
     static func live() -> AppEnvironment {
@@ -44,6 +57,12 @@ final class AppEnvironment: ObservableObject {
                 operation: "清空浏览历史"
             )
         }
+        if arguments.contains("UITEST_RESET_RECENT_FORUMS") {
+            requireUIFixturePersistence(
+                RecentForumStore.shared.clear(),
+                operation: "清空最近浏览贴吧"
+            )
+        }
         if arguments.contains("UITEST_RESET_LOCAL_THREAD_LIBRARY") {
             requireUIFixturePersistence(
                 LocalThreadLibraryStore.shared.clearAll(),
@@ -58,7 +77,8 @@ final class AppEnvironment: ObservableObject {
         if arguments.contains("UITEST_RESET_FORUM_THREAD_SORT") {
             ForumThreadSortPreferenceStore().reset()
         }
-        if arguments.contains("UITEST_RESET_CONTENT_SUBMISSION") {
+        if arguments.contains("UITEST_RESET_CONTENT_SUBMISSION")
+            || arguments.contains("UITEST_RESET_CONTENT_SUBMISSION_RISK") {
             ContentSubmissionRiskPolicy.reset()
         }
         if arguments.contains("UITEST_SEED_LOCAL_THREAD_LIBRARY") {
@@ -135,19 +155,41 @@ final class AppEnvironment: ObservableObject {
             configuration: configuration,
             redirectScope: .baiduHTTPS
         )))
-        let contentSubmissionCoordinator = ContentSubmissionCoordinator(api: api)
+        let contentSubmissionSettingsStore = ContentSubmissionSettingsStore()
+        let contentSubmissionCoordinator = ContentSubmissionCoordinator(
+            api: api,
+            allowsSubmission: { contentSubmissionSettingsStore.allowsSubmission(kind: $0) }
+        )
+        let socialRelationshipState = SocialRelationshipState()
+        let socialMutationCoordinator = SocialMutationCoordinator(
+            api: api,
+            state: socialRelationshipState
+        )
         return AppEnvironment(
             accountStore: accountStore,
             api: api,
             logoutCoordinator: LogoutCoordinator(
                 accountStore: accountStore,
                 beginWriteInvalidation: {
-                    await contentSubmissionCoordinator.beginInvalidation()
+                    socialMutationCoordinator.establishInvalidationBarrier()
+                    contentSubmissionCoordinator.establishInvalidationBarrier()
+                    let socialDrain = Task { @MainActor in
+                        await socialMutationCoordinator.drainInvalidatedOperations()
+                    }
+                    let contentDrain = Task { @MainActor in
+                        await contentSubmissionCoordinator.drainInvalidatedOperations()
+                    }
+                    await socialDrain.value
+                    await contentDrain.value
                 },
                 endWriteInvalidation: {
                     contentSubmissionCoordinator.endInvalidation()
+                    socialMutationCoordinator.endInvalidation()
                 }
             ),
+            socialRelationshipState: socialRelationshipState,
+            socialMutationCoordinator: socialMutationCoordinator,
+            contentSubmissionSettingsStore: contentSubmissionSettingsStore,
             contentSubmissionCoordinator: contentSubmissionCoordinator
         )
     }
@@ -185,7 +227,29 @@ final class AppEnvironment: ObservableObject {
         let service = MemoryAccountStoreService(data: accountData)
         let store = AccountStore(service: service)
         let api = FixtureTiebaAPI(scenario: scenario, delayMilliseconds: delay)
-        let contentSubmissionCoordinator = ContentSubmissionCoordinator(api: api)
+        let settingsSuite = "dev.infinityf4p.tiebapure.uitest.content-submission"
+        let settingsDefaults = UserDefaults(suiteName: settingsSuite) ?? .standard
+        if ProcessInfo.processInfo.arguments.contains(
+            "UITEST_PRESERVE_CONTENT_SUBMISSION_SETTINGS"
+        ) == false {
+            settingsDefaults.removePersistentDomain(forName: settingsSuite)
+        }
+        let contentSubmissionSettingsStore = ContentSubmissionSettingsStore(
+            defaults: settingsDefaults,
+            key: "replies-enabled"
+        )
+        if ProcessInfo.processInfo.arguments.contains("UITEST_RESET_CONTENT_SUBMISSION") {
+            contentSubmissionSettingsStore.setRepliesEnabled(true)
+        }
+        let contentSubmissionCoordinator = ContentSubmissionCoordinator(
+            api: api,
+            allowsSubmission: { contentSubmissionSettingsStore.allowsSubmission(kind: $0) }
+        )
+        let socialRelationshipState = SocialRelationshipState()
+        let socialMutationCoordinator = SocialMutationCoordinator(
+            api: api,
+            state: socialRelationshipState
+        )
         let draftStore = ContentDraftStore()
         if ProcessInfo.processInfo.arguments.contains("UITEST_RESET_CONTENT_SUBMISSION") {
             _ = draftStore.clear(accountID: FixtureTiebaAPI.account.id)
@@ -197,13 +261,26 @@ final class AppEnvironment: ObservableObject {
                 accountStore: store,
                 artifactCleaner: FixtureSessionArtifactCleaner(),
                 beginWriteInvalidation: {
-                    await contentSubmissionCoordinator.beginInvalidation()
+                    socialMutationCoordinator.establishInvalidationBarrier()
+                    contentSubmissionCoordinator.establishInvalidationBarrier()
+                    let socialDrain = Task { @MainActor in
+                        await socialMutationCoordinator.drainInvalidatedOperations()
+                    }
+                    let contentDrain = Task { @MainActor in
+                        await contentSubmissionCoordinator.drainInvalidatedOperations()
+                    }
+                    await socialDrain.value
+                    await contentDrain.value
                 },
                 endWriteInvalidation: {
                     contentSubmissionCoordinator.endInvalidation()
+                    socialMutationCoordinator.endInvalidation()
                 }
             ),
+            socialRelationshipState: socialRelationshipState,
+            socialMutationCoordinator: socialMutationCoordinator,
             contentDraftStore: draftStore,
+            contentSubmissionSettingsStore: contentSubmissionSettingsStore,
             contentSubmissionCoordinator: contentSubmissionCoordinator
         )
     }

--- a/TiebaPure/App/RootView.swift
+++ b/TiebaPure/App/RootView.swift
@@ -51,13 +51,45 @@ struct RootView: View {
     @MainActor
     private func updateAccount(_ newAccount: Account?, generation: Int) async {
         let previousAccount = account
-        let invalidatedAccountID = previousAccount.flatMap { previous in
-            previous != newAccount ? previous.id : nil
+        let invalidatedAccountID = AccountTransitionPolicy.invalidatedAccountID(
+            previous: previousAccount,
+            next: newAccount
+        )
+        let invalidatedSession = AccountTransitionPolicy.invalidatedSession(
+            previous: previousAccount,
+            next: newAccount
+        )
+        if let invalidatedSession {
+            environment.socialMutationCoordinator.establishInvalidationBarrier(
+                session: invalidatedSession
+            )
         }
         if let invalidatedAccountID {
-            await environment.contentSubmissionCoordinator.beginInvalidation(
+            environment.contentSubmissionCoordinator.establishInvalidationBarrier(
                 accountID: invalidatedAccountID
             )
+        }
+        var socialDrain: Task<Void, Never>?
+        if let invalidatedSession {
+            socialDrain = Task { @MainActor in
+                await environment.socialMutationCoordinator.drainInvalidatedOperations(
+                    session: invalidatedSession
+                )
+            }
+        }
+        var contentDrain: Task<Void, Never>?
+        if let invalidatedAccountID {
+            contentDrain = Task { @MainActor in
+                await environment.contentSubmissionCoordinator.drainInvalidatedOperations(
+                    accountID: invalidatedAccountID
+                )
+            }
+        }
+        if let socialDrain {
+            await socialDrain.value
+        }
+        if let contentDrain {
+            await contentDrain.value
         }
         defer {
             if let invalidatedAccountID {
@@ -65,22 +97,50 @@ struct RootView: View {
                     accountID: invalidatedAccountID
                 )
             }
+            if let invalidatedSession {
+                environment.socialMutationCoordinator.endInvalidation(
+                    session: invalidatedSession
+                )
+            }
         }
 
-        if let previousAccount, previousAccount != newAccount {
-            if previousAccount.id != newAccount?.id {
-                environment.socialRelationshipState.reset(accountID: previousAccount.id)
-            }
+        if let previousAccount, invalidatedSession != nil {
+            environment.socialRelationshipState.reset(accountID: previousAccount.id)
         }
         guard Task.isCancelled == false,
               generation == accountTransitionGeneration else { return }
         account = newAccount
-        if newAccount != nil {
+        if AccountTransitionPolicy.shouldReleaseGlobalInvalidation(
+            previous: previousAccount,
+            next: newAccount
+        ) {
             // A successful logout deliberately leaves the global submission
             // barrier active. Release it only after the replacement account is
             // the session visible to the application.
             environment.contentSubmissionCoordinator.endInvalidation()
+            environment.socialMutationCoordinator.endInvalidation()
         }
+    }
+}
+
+enum AccountTransitionPolicy {
+    static func invalidatedSession(
+        previous: Account?,
+        next: Account?
+    ) -> AccountSessionIdentity? {
+        guard let previous else { return nil }
+        guard next?.sessionIdentity == previous.sessionIdentity else {
+            return previous.sessionIdentity
+        }
+        return nil
+    }
+
+    static func invalidatedAccountID(previous: Account?, next: Account?) -> String? {
+        invalidatedSession(previous: previous, next: next)?.accountID
+    }
+
+    static func shouldReleaseGlobalInvalidation(previous: Account?, next: Account?) -> Bool {
+        previous == nil && next != nil
     }
 }
 

--- a/TiebaPure/App/TiebaPureApp.swift
+++ b/TiebaPure/App/TiebaPureApp.swift
@@ -25,6 +25,7 @@ struct TiebaPureApp: App {
 #endif
             }
             .environmentObject(environment)
+            .environmentObject(environment.contentSubmissionSettingsStore)
             .environmentObject(appearanceStore)
             .environmentObject(readingPreferencesStore)
             .environment(\.readingPreferences, readingPreferencesStore.preferences)

--- a/TiebaPure/Core/Auth/AccountStore.swift
+++ b/TiebaPure/Core/Auth/AccountStore.swift
@@ -20,6 +20,7 @@ final class AccountStore: ObservableObject {
     private let service: AccountStoreService
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    private let operationLock = AccountStoreOperationLock()
     let accountDidChange = PassthroughSubject<Account?, Never>()
 
     init(service: AccountStoreService) {
@@ -27,6 +28,12 @@ final class AccountStore: ObservableObject {
     }
 
     func load() async throws -> Account? {
+        try await withExclusiveOperation {
+            try await loadUnlocked()
+        }
+    }
+
+    private func loadUnlocked() async throws -> Account? {
         guard let data = try await service.loadData() else { return nil }
         do {
             let account = try decoder.decode(Account.self, from: data)
@@ -41,6 +48,28 @@ final class AccountStore: ObservableObject {
     }
 
     func save(_ account: Account) async throws {
+        try await withExclusiveOperation {
+            try await saveUnlocked(account)
+        }
+    }
+
+    /// Updates non-secret metadata on the active account without allowing a
+    /// stale view to recreate credentials or overwrite refreshed cookies.
+    func updateDisplayName(
+        _ displayName: String,
+        forSession expectedSession: AccountSessionIdentity
+    ) async throws {
+        try await withExclusiveOperation {
+            guard var current = try await loadUnlocked(),
+                  current.sessionIdentity == expectedSession else {
+                throw AccountStoreError.sessionChanged
+            }
+            current.displayName = displayName
+            try await saveUnlocked(current)
+        }
+    }
+
+    private func saveUnlocked(_ account: Account) async throws {
         try Task.checkCancellation()
         guard BaiduCredentialPolicy.isValid(account) else {
             throw AccountStoreError.invalidCredentials
@@ -83,10 +112,49 @@ final class AccountStore: ObservableObject {
     }
 
     func clear() async throws {
-        try await service.clearData()
-        await MainActor.run {
-            accountDidChange.send(nil)
+        try await withExclusiveOperation {
+            try await service.clearData()
+            await MainActor.run {
+                accountDidChange.send(nil)
+            }
         }
+    }
+
+    private func withExclusiveOperation<T>(
+        _ operation: () async throws -> T
+    ) async throws -> T {
+        await operationLock.acquire()
+        do {
+            let result = try await operation()
+            await operationLock.release()
+            return result
+        } catch {
+            await operationLock.release()
+            throw error
+        }
+    }
+}
+
+private actor AccountStoreOperationLock {
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if isLocked == false {
+            isLocked = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        guard waiters.isEmpty == false else {
+            isLocked = false
+            return
+        }
+        waiters.removeFirst().resume()
     }
 }
 
@@ -251,13 +319,50 @@ actor FileAccountStoreService: LegacyAccountStoreService {
     }
 }
 
+protocol KeychainSecurityOperating: Sendable {
+    func copyMatching(
+        _ query: CFDictionary,
+        result: UnsafeMutablePointer<CFTypeRef?>?
+    ) -> OSStatus
+    func update(_ query: CFDictionary, attributes: CFDictionary) -> OSStatus
+    func add(_ attributes: CFDictionary) -> OSStatus
+    func delete(_ query: CFDictionary) -> OSStatus
+}
+
+struct SystemKeychainSecurityOperations: KeychainSecurityOperating {
+    func copyMatching(
+        _ query: CFDictionary,
+        result: UnsafeMutablePointer<CFTypeRef?>?
+    ) -> OSStatus {
+        SecItemCopyMatching(query, result)
+    }
+
+    func update(_ query: CFDictionary, attributes: CFDictionary) -> OSStatus {
+        SecItemUpdate(query, attributes)
+    }
+
+    func add(_ attributes: CFDictionary) -> OSStatus {
+        SecItemAdd(attributes, nil)
+    }
+
+    func delete(_ query: CFDictionary) -> OSStatus {
+        SecItemDelete(query)
+    }
+}
+
 struct KeychainAccountStoreService: AccountStoreService {
     private let service: String
     private let account: String
+    private let securityOperations: any KeychainSecurityOperating
 
-    init(service: String = "dev.infinityf4p.tiebapure.account", account: String = "single") {
+    init(
+        service: String = "dev.infinityf4p.tiebapure.account",
+        account: String = "single",
+        securityOperations: any KeychainSecurityOperating = SystemKeychainSecurityOperations()
+    ) {
         self.service = service
         self.account = account
+        self.securityOperations = securityOperations
     }
 
     func loadData() async throws -> Data? {
@@ -269,7 +374,7 @@ struct KeychainAccountStoreService: AccountStoreService {
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
         var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = securityOperations.copyMatching(query as CFDictionary, result: &result)
         if status == errSecItemNotFound { return nil }
         guard status == errSecSuccess else { throw KeychainError.status(status) }
         return result as? Data
@@ -285,13 +390,16 @@ struct KeychainAccountStoreService: AccountStoreService {
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
-        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        let updateStatus = securityOperations.update(
+            query as CFDictionary,
+            attributes: attributes as CFDictionary
+        )
         if updateStatus == errSecSuccess { return }
         guard updateStatus == errSecItemNotFound else { throw KeychainError.status(updateStatus) }
 
         var addQuery = query
         attributes.forEach { addQuery[$0.key] = $0.value }
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        let addStatus = securityOperations.add(addQuery as CFDictionary)
         guard addStatus == errSecSuccess else { throw KeychainError.status(addStatus) }
     }
 
@@ -311,7 +419,7 @@ struct KeychainAccountStoreService: AccountStoreService {
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
         var result: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+        guard securityOperations.copyMatching(query as CFDictionary, result: &result) == errSecSuccess,
               let attributes = result as? [String: Any] else {
             return nil
         }
@@ -326,7 +434,7 @@ struct KeychainAccountStoreService: AccountStoreService {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
-        let status = SecItemDelete(query as CFDictionary)
+        let status = securityOperations.delete(query as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw KeychainError.status(status)
         }
@@ -371,4 +479,5 @@ enum KeychainError: Error, Equatable {
 enum AccountStoreError: Error, Equatable {
     case cancellationRollbackFailed
     case invalidCredentials
+    case sessionChanged
 }

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -17,6 +17,7 @@ enum FixtureScenario: String {
     case subpostReference
     case imageGesture
     case privateProfile
+    case profileManagement
     case forumPinned
     case forumIDOnly
     case forumCategories
@@ -204,9 +205,12 @@ struct FixtureTiebaAPI: TiebaAPIService {
         sortType: ThreadReplySort
     ) async throws -> ThreadPage {
         try await prepare(page: page)
-        let thread = await state.submittedThread(threadID: threadID)
+        var thread = await state.submittedThread(threadID: threadID)
             ?? Self.threads.first(where: { $0.id == threadID })
             ?? Self.threads[0]
+        if scenario == .profileManagement {
+            thread.author = Self.accountUser
+        }
         let submittedMainPost = await state.submittedMainPost(threadID: threadID)
         let usesLongContent = scenario == .longContent
         let usesLargeLikeCount = scenario == .largeLikeCount
@@ -248,7 +252,7 @@ struct FixtureTiebaAPI: TiebaAPIService {
             id: 2001,
             threadID: threadID,
             floor: 1,
-            author: Self.author,
+            author: scenario == .profileManagement ? Self.accountUser : Self.author,
             ipAddress: "北京",
             createdAt: Date(timeIntervalSince1970: 1_700_000_000),
             blocks: mainBlocks,
@@ -341,6 +345,12 @@ struct FixtureTiebaAPI: TiebaAPIService {
 
     func userProfile(account: Account?, user: UserSummary) async throws -> UserProfile {
         try await prepare()
+        let profileEdit: UserProfileEditRequest?
+        if let account {
+            profileEdit = await state.profileEdit(accountID: account.id)
+        } else {
+            profileEdit = nil
+        }
         let isFollowed = await state.userFollowed(
             accountID: account?.id ?? "guest",
             userID: user.id,
@@ -353,7 +363,8 @@ struct FixtureTiebaAPI: TiebaAPIService {
         let resolvedUser = UserSummary(
             id: user.id == 0 ? Self.author.id : user.id,
             name: user.name.isEmpty ? Self.author.name : user.name,
-            displayName: user.displayName.isEmpty ? Self.author.displayName : user.displayName,
+            displayName: profileEdit?.normalizedNickname
+                ?? (user.displayName.isEmpty ? Self.author.displayName : user.displayName),
             portrait: user.portrait,
             level: user.level ?? 9,
             levelName: user.levelName ?? "九级",
@@ -366,9 +377,10 @@ struct FixtureTiebaAPI: TiebaAPIService {
             isFollowed: isFollowed,
             tiebaID: "100000001",
             tiebaAge: "12.5年",
-            sex: .unspecified,
+            sex: profileEdit?.sex ?? .unspecified,
             location: "北京",
-            intro: "这是用于验证用户主页布局、隐私状态和深色模式的合成资料。",
+            intro: profileEdit?.introduction
+                ?? "这是用于验证用户主页布局、隐私状态和深色模式的合成资料。",
             backgroundURL: URL(string: "https://fixture-success.invalid/profile-background.png"),
             agreeCount: 4_639,
             followingCount: 74,
@@ -378,6 +390,21 @@ struct FixtureTiebaAPI: TiebaAPIService {
             followedForums: hidesForums ? [] : [Self.forum, Self.forumTwo],
             followedForumsVisibility: hidesForums ? .privateContent : .visible
         )
+    }
+
+    func updateOwnProfile(account: Account, request: UserProfileEditRequest) async throws {
+        guard request.normalizedNickname.isEmpty == false else {
+            throw UserProfileMutationError.missingNickname
+        }
+        try await prepare()
+        await state.setProfileEdit(request, accountID: account.id)
+    }
+
+    func deleteOwnThread(account: Account, target: OwnThreadDeletionTarget) async throws {
+        _ = account
+        try UserProfileRequestFactory.validateDeletionTarget(target)
+        try await prepare()
+        await state.deleteThread(target.threadID)
     }
 
     func setUserFollowed(account: Account, user: UserSummary, followed: Bool) async throws {
@@ -530,11 +557,39 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 visibility: .privateContent
             )
         }
+        var visibleThreads: [ThreadSummary] = if page == 1 {
+            await state.removingDeletedThreads(from: Self.threads)
+        } else {
+            []
+        }
+        if scenario == .profileManagement {
+            visibleThreads = visibleThreads.map { thread in
+                var ownThread = thread
+                ownThread.author = Self.accountUser
+                return ownThread
+            }
+        }
+        let deletionTargets: [Int64: OwnThreadDeletionTarget] = Dictionary(
+            uniqueKeysWithValues: visibleThreads.compactMap { thread -> (Int64, OwnThreadDeletionTarget)? in
+                guard let forumID = thread.forumID, forumID > 0 else { return nil }
+                let forumName = forumID == Self.forumTwo.id ? Self.forumTwo.name : Self.forum.name
+                return (
+                    thread.id,
+                    OwnThreadDeletionTarget(
+                        forumID: forumID,
+                        forumName: forumName,
+                        threadID: thread.id,
+                        firstPostID: 2_001
+                    )
+                )
+            }
+        )
         return UserThreadsPage(
-            threads: page == 1 ? Self.threads : [],
+            threads: visibleThreads,
             currentPage: page,
             hasMore: page == 1,
-            visibility: .visible
+            visibility: .visible,
+            deletionTargetsByThreadID: deletionTargets
         )
     }
 
@@ -623,6 +678,15 @@ struct FixtureTiebaAPI: TiebaAPIService {
         stoken: "fixture-stoken",
         baiduID: "fixture-baiduid",
         tbs: "fixture-tbs"
+    )
+
+    static let accountUser = UserSummary(
+        id: Int64(account.uid) ?? 42,
+        name: account.name,
+        displayName: account.displayName,
+        portrait: account.portrait,
+        level: 9,
+        levelName: "九级"
     )
 
     static let forum = Forum(id: 101, name: "测试", displayName: "测试吧", avatarURL: nil, memberCount: 12345, threadCount: 678)
@@ -901,6 +965,8 @@ private actor FixtureRequestState {
     private var submittedMainPostValues: [Int64: Post] = [:]
     private var submittedPostValues: [Int64: [Post]] = [:]
     private var submittedSubpostValues: [UInt64: [Subpost]] = [:]
+    private var profileEditsByAccountID: [String: UserProfileEditRequest] = [:]
+    private var deletedThreadIDs = Set<Int64>()
     private var nextThreadID: Int64 = 9_001
     private var nextPostID: UInt64 = 19_001
 
@@ -936,6 +1002,25 @@ private actor FixtureRequestState {
 
     func userFollowed(accountID: String, userID: Int64, defaultValue: Bool) -> Bool {
         userFollowStates["\(accountID)|\(userID)"] ?? defaultValue
+    }
+
+    func setProfileEdit(_ request: UserProfileEditRequest, accountID: String) {
+        profileEditsByAccountID[accountID] = request
+    }
+
+    func profileEdit(accountID: String) -> UserProfileEditRequest? {
+        profileEditsByAccountID[accountID]
+    }
+
+    func deleteThread(_ threadID: Int64) {
+        deletedThreadIDs.insert(threadID)
+        submittedThreadValues[threadID] = nil
+        submittedMainPostValues[threadID] = nil
+        submittedPostValues[threadID] = nil
+    }
+
+    func removingDeletedThreads(from threads: [ThreadSummary]) -> [ThreadSummary] {
+        threads.filter { deletedThreadIDs.contains($0.id) == false }
     }
 
     func setForumFollowed(_ followed: Bool, accountID: String, forumID: Int64) {

--- a/TiebaPure/Core/Network/MultipartFormData.swift
+++ b/TiebaPure/Core/Network/MultipartFormData.swift
@@ -14,10 +14,18 @@ final class MultipartFormData {
         append("\(value)\r\n")
     }
 
-    func addFile(name: String, filename: String, data fileData: Data) {
+    func addFile(
+        name: String,
+        filename: String,
+        contentType: String? = "application/octet-stream",
+        data fileData: Data
+    ) {
         append("--\(boundary)\r\n")
         append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
-        append("Content-Type: application/octet-stream\r\n\r\n")
+        if let contentType {
+            append("Content-Type: \(contentType)\r\n")
+        }
+        append("\r\n")
         data.append(fileData)
         append("\r\n")
     }

--- a/TiebaPure/Core/Network/TiebaAPI.swift
+++ b/TiebaPure/Core/Network/TiebaAPI.swift
@@ -971,7 +971,40 @@ enum TiebaAPIError: Error, Equatable, CustomStringConvertible {
     case sessionExpired(code: Int, message: String)
     case emptyResponse
 
-    static let sessionExpiredCodes: Set<Int> = [4, 110001, 110002, 110003, 110004]
+    private static let unambiguousSessionExpiredCodes: Set<Int> = [
+        110001,
+        110002,
+        110003,
+        110004
+    ]
+
+    static func isSessionExpired(code: Int, message: String) -> Bool {
+        if unambiguousSessionExpiredCodes.contains(code) {
+            return true
+        }
+        guard code == 4 else { return false }
+
+        let normalized = message
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return [
+            "未登录",
+            "未登陆",
+            "请先登录",
+            "请先登陆",
+            "重新登录",
+            "重新登陆",
+            "登录失效",
+            "登陆失效",
+            "登录已失效",
+            "登陆已失效",
+            "登录过期",
+            "登陆过期",
+            "not logged",
+            "login expired",
+            "session expired"
+        ].contains { normalized.contains($0) }
+    }
 
     var description: String {
         switch self {
@@ -988,7 +1021,7 @@ enum TiebaAPIError: Error, Equatable, CustomStringConvertible {
 enum TiebaResponseValidator {
     static func validate(code: Int, message: String) throws {
         guard code != 0 else { return }
-        if TiebaAPIError.sessionExpiredCodes.contains(code) {
+        if TiebaAPIError.isSessionExpired(code: code, message: message) {
             throw TiebaAPIError.sessionExpired(code: code, message: message)
         }
         throw TiebaAPIError.response(code: code, message: message)

--- a/TiebaPure/Core/Network/TiebaAPIService.swift
+++ b/TiebaPure/Core/Network/TiebaAPIService.swift
@@ -38,6 +38,8 @@ protocol TiebaAPIService {
     ) async throws -> [Subpost]
     func userProfile(account: Account?, user: UserSummary) async throws -> UserProfile
     func userThreads(account: Account?, userID: Int64, page: Int) async throws -> UserThreadsPage
+    func updateOwnProfile(account: Account, request: UserProfileEditRequest) async throws
+    func deleteOwnThread(account: Account, target: OwnThreadDeletionTarget) async throws
     func setUserFollowed(account: Account, user: UserSummary, followed: Bool) async throws
     func userRelationships(
         account: Account?,
@@ -62,6 +64,14 @@ protocol TiebaAPIService {
 }
 
 extension TiebaAPIService {
+    func updateOwnProfile(account: Account, request: UserProfileEditRequest) async throws {
+        throw UserProfileMutationError.unsupportedByService
+    }
+
+    func deleteOwnThread(account: Account, target: OwnThreadDeletionTarget) async throws {
+        throw UserProfileMutationError.unsupportedByService
+    }
+
     func followedUsers(account: Account, page: Int) async throws -> FollowedUsersPage {
         guard let userID = Int64(account.uid), userID > 0 else {
             throw TiebaMutationError.invalidUserID

--- a/TiebaPure/Core/Network/TiebaContentSubmissionAPI.swift
+++ b/TiebaPure/Core/Network/TiebaContentSubmissionAPI.swift
@@ -1,7 +1,7 @@
 import CryptoKit
 import Foundation
+import CoreFoundation
 import SwiftProtobuf
-import UIKit
 
 struct TiebaAppUploadedImage: Equatable, Sendable {
     let picID: String
@@ -63,7 +63,7 @@ struct TiebaImageUploadResponseDTO: Decodable, Equatable {
             throw ContentSubmissionError.business(code: -1, message: "图片上传响应缺少状态码。")
         }
         guard errorCode == 0 else {
-            if TiebaAPIError.sessionExpiredCodes.contains(errorCode) {
+            if TiebaAPIError.isSessionExpired(code: errorCode, message: errorMessage) {
                 throw ContentSubmissionError.sessionExpired
             }
             throw ContentSubmissionError.business(
@@ -88,12 +88,438 @@ struct TiebaImageUploadResponseDTO: Decodable, Equatable {
     }
 }
 
+private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
+    private struct DataDTO: Decodable {
+        let result: Int?
+        let hasResult: Bool
+        let errorCode: Int?
+        let hasErrorCode: Bool
+        let legacyErrorCode: Int?
+        let hasLegacyErrorCode: Bool
+        let threadIDs: [String]
+        let postIDs: [String]
+        let hasUnparseableIdentifier: Bool
+        let message: String
+        let verificationMD5: String
+
+        private enum CodingKeys: String, CodingKey {
+            case result
+            case errorCode = "error_code"
+            case legacyErrorCode = "err_code"
+            case threadID = "tid"
+            case postID = "pid"
+            case message = "msg"
+            case verificationMD5 = "vcode_md5"
+        }
+
+        init(from decoder: Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            hasResult = container.contains(.result)
+            result = container.submissionInt(forKey: .result)
+            hasErrorCode = container.contains(.errorCode)
+            errorCode = container.submissionInt(forKey: .errorCode)
+            hasLegacyErrorCode = container.contains(.legacyErrorCode)
+            legacyErrorCode = container.submissionInt(forKey: .legacyErrorCode)
+            let threadID = container.submissionIdentifierString(forKey: .threadID)
+            let postID = container.submissionIdentifierString(forKey: .postID)
+            threadIDs = [threadID].compactMap { $0 }
+            postIDs = [postID].compactMap { $0 }
+            hasUnparseableIdentifier = [CodingKeys.threadID, .postID].contains {
+                container.contains($0)
+                    && container.submissionIdentifierString(forKey: $0)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
+            }
+            message = container.submissionString(forKey: .message) ?? ""
+            verificationMD5 = container.submissionString(forKey: .verificationMD5) ?? ""
+        }
+    }
+
+    let result: Int?
+    let hasResult: Bool
+    let errorCode: Int?
+    let hasErrorCode: Bool
+    let legacyErrorCode: Int?
+    let hasLegacyErrorCode: Bool
+    let errorMessage: String
+    let legacyErrorMessage: String
+    let threadIDs: [String]
+    let postIDs: [String]
+    let hasUnparseableIdentifier: Bool
+    let verificationMD5: String
+    private let data: DataDTO?
+
+    private enum CodingKeys: String, CodingKey {
+        case result
+        case errorCode = "error_code"
+        case legacyErrorCode = "err_code"
+        case errorMessage = "error_msg"
+        case legacyErrorMessage = "err_msg"
+        case threadID = "tid"
+        case postID = "pid"
+        case verificationMD5 = "vcode_md5"
+        case data
+    }
+
+    init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedData = try? container.decodeIfPresent(DataDTO.self, forKey: .data)
+        data = decodedData
+        let topResult = container.submissionInt(forKey: .result)
+        hasResult = container.contains(.result) || (decodedData?.hasResult ?? false)
+        if let topResult, let nestedResult = decodedData?.result, topResult != nestedResult {
+            result = nil
+        } else {
+            result = topResult ?? decodedData?.result
+        }
+        let topErrorCode = container.submissionInt(forKey: .errorCode)
+        hasErrorCode = container.contains(.errorCode) || (decodedData?.hasErrorCode ?? false)
+        if let topErrorCode,
+           let nestedErrorCode = decodedData?.errorCode,
+           topErrorCode != nestedErrorCode {
+            errorCode = nil
+        } else {
+            errorCode = topErrorCode ?? decodedData?.errorCode
+        }
+        let topLegacyErrorCode = container.submissionInt(forKey: .legacyErrorCode)
+        hasLegacyErrorCode = container.contains(.legacyErrorCode)
+            || (decodedData?.hasLegacyErrorCode ?? false)
+        if let topLegacyErrorCode,
+           let nestedLegacyErrorCode = decodedData?.legacyErrorCode,
+           topLegacyErrorCode != nestedLegacyErrorCode {
+            legacyErrorCode = nil
+        } else {
+            legacyErrorCode = topLegacyErrorCode ?? decodedData?.legacyErrorCode
+        }
+        errorMessage = container.submissionString(forKey: .errorMessage) ?? ""
+        legacyErrorMessage = container.submissionString(forKey: .legacyErrorMessage) ?? ""
+        let threadID = container.submissionIdentifierString(forKey: .threadID)
+        let postID = container.submissionIdentifierString(forKey: .postID)
+        threadIDs = [threadID].compactMap { $0 } + (decodedData?.threadIDs ?? [])
+        postIDs = [postID].compactMap { $0 } + (decodedData?.postIDs ?? [])
+        hasUnparseableIdentifier = [CodingKeys.threadID, .postID].contains {
+            container.contains($0)
+                && container.submissionIdentifierString(forKey: $0)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
+        } || (decodedData?.hasUnparseableIdentifier ?? false)
+        verificationMD5 = container.submissionString(forKey: .verificationMD5) ?? ""
+    }
+
+    var submissionReceipt: ContentSubmissionReceipt {
+        get throws {
+            // A present-but-unparseable status is not a trustworthy explicit
+            // success or failure response after a write has been dispatched.
+            guard (hasResult == false || result != nil),
+                  (hasErrorCode == false || errorCode != nil),
+                  (hasLegacyErrorCode == false || legacyErrorCode != nil) else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+
+            let codes = [errorCode, legacyErrorCode].compactMap { $0 }
+            guard Set(codes).count <= 1 else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+            let code = codes.first
+            let resultIsSuccess = result == 1
+            let resultIsFailure = hasResult && resultIsSuccess == false
+            let codeIsSuccess = code == 0
+            let codeIsFailure = code.map { $0 != 0 } ?? false
+            guard (resultIsSuccess && codeIsFailure) == false,
+                  (resultIsFailure && codeIsSuccess) == false else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+
+            let messages = normalizedSubmissionMessages([
+                errorMessage,
+                legacyErrorMessage,
+                data?.message ?? ""
+            ])
+            let message = messages.first ?? ""
+            if let code,
+               code != 0,
+               TiebaAPIError.isSessionExpired(code: code, message: message) {
+                throw ContentSubmissionError.sessionExpired
+            }
+            if verificationMD5.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                || data?.verificationMD5.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                || messages.contains(where: \.requiresSubmissionVerification) {
+                throw ContentSubmissionError.verificationRequired(message: message)
+            }
+            if let code, code != 0 {
+                throw ContentSubmissionError.business(code: code, message: message)
+            }
+            if resultIsFailure {
+                throw ContentSubmissionError.business(code: -1, message: message)
+            }
+            guard resultIsSuccess || codeIsSuccess else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+
+            guard hasUnparseableIdentifier == false else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+            let returnedThreadIDs = try validatedPositiveInt64Values(threadIDs)
+            guard returnedThreadIDs.count == 1,
+                  let resolvedThreadID = returnedThreadIDs.first else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+            let returnedPostIDs = try validatedPositiveUInt64Values(postIDs)
+            guard returnedPostIDs.count <= 1 else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+            return ContentSubmissionReceipt(
+                threadID: resolvedThreadID,
+                postID: returnedPostIDs.first
+            )
+        }
+    }
+}
+
+struct TiebaWebUploadPictureResponseDTO: Decodable, Equatable {
+    let errorCode: Int?
+    private let hasErrorCode: Bool
+    let errorMessage: String
+    let imageInfo: String
+
+    private enum CodingKeys: String, CodingKey {
+        case errorCode = "error_code"
+        case legacyErrorCode = "err_code"
+        case errorMessage = "error_msg"
+        case camelErrorMessage = "errorMsg"
+        case legacyErrorMessage = "err_msg"
+        case legacyCamelErrorMessage = "errMsg"
+        case imageInfo = "image_info"
+        case camelImageInfo = "imageInfo"
+    }
+
+    init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let hasPrimaryCode = container.contains(.errorCode)
+        let hasLegacyCode = container.contains(.legacyErrorCode)
+        hasErrorCode = hasPrimaryCode || hasLegacyCode
+        let primaryCode = container.submissionInt(forKey: .errorCode)
+        let legacyCode = container.submissionInt(forKey: .legacyErrorCode)
+        if let primaryCode, let legacyCode, primaryCode != legacyCode {
+            errorCode = nil
+        } else {
+            errorCode = primaryCode ?? legacyCode
+        }
+        errorMessage = container.submissionString(forKey: .errorMessage)
+            ?? container.submissionString(forKey: .camelErrorMessage)
+            ?? container.submissionString(forKey: .legacyErrorMessage)
+            ?? container.submissionString(forKey: .legacyCamelErrorMessage)
+            ?? ""
+        imageInfo = container.submissionString(forKey: .imageInfo)
+            ?? container.submissionString(forKey: .camelImageInfo)
+            ?? ""
+    }
+
+    func validatedImageInfo() throws -> String {
+        guard hasErrorCode == false || errorCode != nil else {
+            throw ContentSubmissionError.business(code: -1, message: "图片上传响应状态无效。")
+        }
+        if let errorCode, errorCode != 0 {
+            if TiebaAPIError.isSessionExpired(code: errorCode, message: errorMessage) {
+                throw ContentSubmissionError.sessionExpired
+            }
+            throw ContentSubmissionError.business(
+                code: errorCode,
+                message: errorMessage.isEmpty ? "图片上传失败。" : errorMessage
+            )
+        }
+        let normalized = imageInfo.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.isEmpty == false,
+              normalized.utf8.count <= 16_384,
+              containsASCIIControlLineBreak(normalized) == false else {
+            throw ContentSubmissionError.business(code: -1, message: "贴吧没有返回有效的图片信息。")
+        }
+        return normalized
+    }
+}
+
+struct TiebaWebReplySubmissionResponseDTO: Decodable {
+    private struct DataDTO: Decodable {
+        let result: Int?
+        let hasResult: Bool
+        let codes: [Int]
+        let hasUnparseableCode: Bool
+        let messages: [String]
+        let threadIDs: [String]
+        let postIDs: [String]
+        let hasUnparseableIdentifier: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case result
+            case errorCode = "error_code"
+            case legacyErrorCode = "err_code"
+            case no
+            case errno
+            case errorNo = "error_no"
+            case errorMessage = "error_msg"
+            case legacyErrorMessage = "err_msg"
+            case error
+            case message = "msg"
+            case threadID = "tid"
+            case postID = "pid"
+            case alternatePostID = "post_id"
+        }
+
+        init(from decoder: Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            hasResult = container.contains(.result)
+            result = container.submissionInt(forKey: .result)
+            let codeKeys: [CodingKeys] = [.errorCode, .legacyErrorCode, .no, .errno, .errorNo]
+            codes = codeKeys.compactMap { container.submissionInt(forKey: $0) }
+            hasUnparseableCode = codeKeys.contains {
+                container.contains($0) && container.submissionInt(forKey: $0) == nil
+            }
+            messages = [
+                container.submissionString(forKey: .errorMessage),
+                container.submissionString(forKey: .legacyErrorMessage),
+                container.submissionString(forKey: .error),
+                container.submissionString(forKey: .message)
+            ].compactMap { $0 }
+            let threadID = container.submissionIdentifierString(forKey: .threadID)
+            let postID = container.submissionIdentifierString(forKey: .postID)
+            let alternatePostID = container.submissionIdentifierString(forKey: .alternatePostID)
+            threadIDs = [threadID].compactMap { $0 }
+            postIDs = [postID, alternatePostID].compactMap { $0 }
+            hasUnparseableIdentifier = (
+                container.contains(.threadID)
+                    && validSubmissionThreadIdentifier(threadID) == false
+            ) || [
+                (CodingKeys.postID, postID),
+                (CodingKeys.alternatePostID, alternatePostID)
+            ].contains { key, value in
+                container.contains(key) && validSubmissionPostIdentifier(value) == false
+            }
+        }
+    }
+
+    private let result: Int?
+    private let hasResult: Bool
+    private let codes: [Int]
+    private let hasUnparseableCode: Bool
+    private let messages: [String]
+    private let threadIDs: [String]
+    private let postIDs: [String]
+    private let hasUnparseableIdentifier: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case result
+        case errorCode = "error_code"
+        case legacyErrorCode = "err_code"
+        case no
+        case errno
+        case errorNo = "error_no"
+        case errorMessage = "error_msg"
+        case legacyErrorMessage = "err_msg"
+        case error
+        case message = "msg"
+        case threadID = "tid"
+        case postID = "pid"
+        case alternatePostID = "post_id"
+        case data
+    }
+
+    init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let data = try? container.decodeIfPresent(DataDTO.self, forKey: .data)
+        hasResult = container.contains(.result) || (data?.hasResult ?? false)
+        let topResult = container.submissionInt(forKey: .result)
+        if let topResult, let nestedResult = data?.result, topResult != nestedResult {
+            result = nil
+        } else {
+            result = topResult ?? data?.result
+        }
+        let codeKeys: [CodingKeys] = [.errorCode, .legacyErrorCode, .no, .errno, .errorNo]
+        codes = codeKeys.compactMap { container.submissionInt(forKey: $0) } + (data?.codes ?? [])
+        hasUnparseableCode = codeKeys.contains {
+            container.contains($0) && container.submissionInt(forKey: $0) == nil
+        } || (data?.hasUnparseableCode ?? false)
+        messages = [
+            container.submissionString(forKey: .errorMessage),
+            container.submissionString(forKey: .legacyErrorMessage),
+            container.submissionString(forKey: .error),
+            container.submissionString(forKey: .message)
+        ].compactMap { $0 } + (data?.messages ?? [])
+        let threadID = container.submissionIdentifierString(forKey: .threadID)
+        let postID = container.submissionIdentifierString(forKey: .postID)
+        let alternatePostID = container.submissionIdentifierString(forKey: .alternatePostID)
+        threadIDs = [threadID].compactMap { $0 } + (data?.threadIDs ?? [])
+        postIDs = [postID, alternatePostID].compactMap { $0 } + (data?.postIDs ?? [])
+        hasUnparseableIdentifier = (
+            container.contains(.threadID)
+                && validSubmissionThreadIdentifier(threadID) == false
+        ) || [
+            (CodingKeys.postID, postID),
+            (CodingKeys.alternatePostID, alternatePostID)
+        ].contains { key, value in
+            container.contains(key) && validSubmissionPostIdentifier(value) == false
+        } || (data?.hasUnparseableIdentifier ?? false)
+    }
+
+    func submissionReceipt(for target: ContentSubmissionTarget) throws -> ContentSubmissionReceipt {
+        guard let targetThreadID = target.threadID, targetThreadID > 0 else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        guard hasUnparseableCode == false,
+              hasUnparseableIdentifier == false,
+              (hasResult == false || result != nil) else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        let uniqueCodes = Set(codes)
+        guard uniqueCodes.count <= 1 else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        let code = uniqueCodes.first
+        let resultIsSuccess = result == 1
+        let resultIsFailure = hasResult && resultIsSuccess == false
+        let codeIsSuccess = code == 0
+        let codeIsFailure = code.map { $0 != 0 } ?? false
+        guard (resultIsSuccess && codeIsFailure) == false,
+              (resultIsFailure && codeIsSuccess) == false else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+
+        let normalizedMessages = normalizedSubmissionMessages(messages)
+        let message = normalizedMessages.first ?? ""
+        if let code, TiebaAPIError.isSessionExpired(code: code, message: message) {
+            throw ContentSubmissionError.sessionExpired
+        }
+        if normalizedMessages.contains(where: \.requiresSubmissionVerification) {
+            throw ContentSubmissionError.verificationRequired(message: message)
+        }
+        if let code, code != 0 {
+            throw ContentSubmissionError.business(code: code, message: message)
+        }
+        if resultIsFailure {
+            throw ContentSubmissionError.business(code: -1, message: message)
+        }
+        guard resultIsSuccess || codeIsSuccess else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+
+        let returnedThreadIDs = try validatedPositiveInt64Values(threadIDs)
+        guard returnedThreadIDs.isEmpty || returnedThreadIDs == [targetThreadID] else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        let returnedPostIDs = try validatedPositiveUInt64Values(postIDs)
+        guard returnedPostIDs.count <= 1 else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        return ContentSubmissionReceipt(
+            threadID: targetThreadID,
+            postID: returnedPostIDs.first
+        )
+    }
+}
+
 enum TiebaContentSubmissionRequestFactory {
     static let clientVersion = "12.35.1.0"
-    static let packageVersion = "hybrid-main-pb_1.0.324.1"
+    static let postingLoginClientVersion = "22.5.1.0"
 
     private static var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.3.6"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
     }
 
     static func common(
@@ -104,7 +530,7 @@ enum TiebaContentSubmissionRequestFactory {
         now: Date = Date()
     ) -> Tieba_CommonRequest {
         let timestamp = Int64(now.timeIntervalSince1970 * 1_000)
-        let firstRunTimestamp = max(1, timestamp - 30 * 24 * 60 * 60 * 1_000)
+        let firstRunTimestamp = max(1, timestamp - 30 * 86_400)
         let dateComponents = Calendar(identifier: .gregorian).dateComponents(
             [.year, .month, .day],
             from: now
@@ -118,26 +544,23 @@ enum TiebaContentSubmissionRequestFactory {
         common.from = "1008621x"
         common.cuid = bootstrap.identity.cuidGalaxy2
         common.timestamp = timestamp
-        common.model = UIDevice.current.model
+        common.model = "SM-G988N"
         common.bduss = account.bduss
         common.tbs = tbs
         common.netType = 1
         common.pversion = "1.0.3"
-        common.osVersion = UIDevice.current.systemVersion
-        common.brand = "Apple"
+        common.osVersion = "9"
+        common.brand = "samsung"
         common.legoLibVersion = "3.0.0"
         common.applist = ""
         common.stoken = account.stoken
         common.zID = bootstrap.zID
         common.cuidGalaxy2 = bootstrap.identity.cuidGalaxy2
-        common.cuidGid = ""
         common.c3Aid = bootstrap.identity.c3AID
         common.sampleID = bootstrap.sampleID
-        common.scrW = Int32(clamping: requestBuilder.screenWidth)
-        common.scrH = Int32(clamping: requestBuilder.screenHeight)
-        common.scrDip = requestBuilder.screenScale
-        common.qType = 0
-        common.isTeenager = 0
+        common.scrW = 720
+        common.scrH = 1_280
+        common.scrDip = 1.5
         common.sdkVer = "2.34.0"
         common.frameworkVer = "3340042"
         common.nawsGameVer = "1038000"
@@ -153,10 +576,9 @@ enum TiebaContentSubmissionRequestFactory {
         common.startType = 1
         common.idfv = "0"
         common.extra = ""
-        common.userAgent = "TiebaPure/\(appVersion) tieba/\(clientVersion)"
+        common.userAgent = "tieba/\(clientVersion) skin/default TiebaPure/\(appVersion)"
         common.personalizedRecSwitch = 1
         common.deviceScore = "0.4"
-        common.packageVersion = packageVersion
         return common
     }
 
@@ -199,14 +621,9 @@ enum TiebaContentSubmissionRequestFactory {
         data.isBarrage = "0"
         data.fromFourmID = String(request.target.forumID)
         data.tid = String(threadID)
-        data.floorNum = "0"
         data.isAd = "0"
-        data.isAddition = "0"
-        data.isGiftpost = "0"
         data.nameShow = account.displayName.isEmpty ? account.name : account.displayName
         data.isPictxt = uploadedImages.isEmpty ? "0" : "1"
-        data.showCustomFigure = 0
-        data.isShowBless = 0
 
         switch request.target.kind {
         case .threadReply:
@@ -230,59 +647,89 @@ enum TiebaContentSubmissionRequestFactory {
         return protobuf
     }
 
-    static func addThread(
+    static func webThreadFields(
         account: Account,
         tbs: String,
         request: ContentSubmissionRequest,
-        bootstrap: TiebaPostingBootstrapResult,
-        requestBuilder: TiebaRequestBuilder,
         now: Date = Date()
-    ) throws -> Tieba_AddThreadRequest {
+    ) throws -> [String: String] {
         guard request.target.kind == .newThread else {
-            throw ContentSubmissionError.unsupported(message: "回复必须使用回帖协议。")
+            throw ContentSubmissionError.unsupported(message: "回复不能使用网页发帖协议。")
         }
         guard request.images.isEmpty else {
             throw ContentSubmissionValidationError.imagesUnsupportedForNewThread
         }
+        guard tbs.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            throw TiebaMutationError.missingTBS
+        }
+        return [
+            "ie": "utf-8",
+            "fid": String(request.target.forumID),
+            "kw": request.target.forumName,
+            "tbs": tbs,
+            "title": request.title,
+            "content": request.body,
+            "nick_name": account.displayName.isEmpty ? account.name : account.displayName,
+            "bsk": String(Int64(now.timeIntervalSince1970 * 1_000))
+        ]
+    }
 
-        var data = Tieba_AddThreadRequest.DataMessage()
-        data.common = common(
-            account: account,
-            tbs: tbs,
-            bootstrap: bootstrap,
-            requestBuilder: requestBuilder,
-            now: now
-        )
-        data.anonymous = "1"
-        data.canNoForum = "0"
-        data.isFeedback = "0"
-        data.takephotoNum = "0"
-        data.entranceType = "1"
-        data.vcodeTag = "12"
-        data.newVcode = "1"
-        data.content = request.body
-        data.fid = String(request.target.forumID)
-        data.kw = request.target.forumName
-        data.isHide = "0"
-        data.isRepostToDynamic = "0"
-        data.proZone = "0"
-        data.callFrom = "2"
-        data.title = request.title
-        data.isNtitle = "0"
-        data.isLinkThread = "0"
-        data.isForumBusinessAccount = "0"
-        data.nameShow = account.displayName.isEmpty ? account.name : account.displayName
-        data.isPictxt = "0"
-        data.isArticle = "0"
-        data.showCustomFigure = 0
-        data.isQuestion = 0
-        data.isXiuxiuThread = 0
-        data.isShowBless = 0
-        data.ext = #"{"need_image":0,"is_hide":0,"need_follow_forum":0}"#
+    static func webReplyFields(
+        account: Account,
+        tbs: String,
+        request: ContentSubmissionRequest,
+        uploadedImageInfo: String,
+        timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1_000)
+    ) throws -> [String: String] {
+        guard request.target.kind != .newThread,
+              let threadID = request.target.threadID,
+              threadID > 0 else {
+            throw ContentSubmissionValidationError.invalidThread
+        }
+        let resolvedTBS = tbs.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard resolvedTBS.isEmpty == false else {
+            throw TiebaMutationError.missingTBS
+        }
+        let imageInfo = uploadedImageInfo.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard imageInfo.utf8.count <= ContentSubmissionPolicy.maximumImages * 16_384,
+              containsASCIIControlLineBreak(imageInfo) == false else {
+            throw ContentSubmissionValidationError.invalidImage
+        }
 
-        var protobuf = Tieba_AddThreadRequest()
-        protobuf.data = data
-        return protobuf
+        var fields = [
+            "co": webReplyBody(request.body, target: request.target),
+            "_t": String(timestamp),
+            "tag": "11",
+            "upload_img_info": imageInfo,
+            "fid": String(request.target.forumID),
+            "src": "1",
+            "word": request.target.forumName,
+            "tbs": resolvedTBS,
+            "z": String(threadID),
+            "lp": "6026",
+            "nick_name": account.displayName.isEmpty ? account.name : account.displayName,
+            "_BSK": String(timestamp)
+        ]
+
+        switch request.target.kind {
+        case .threadReply:
+            break
+        case .postReply, .subpostReply:
+            guard let parentPostID = request.target.parentPostID, parentPostID > 0 else {
+                throw ContentSubmissionValidationError.invalidThread
+            }
+            fields["pid"] = String(parentPostID)
+            fields["floor"] = String(max(1, request.target.parentFloor ?? 1))
+            if request.target.kind == .subpostReply {
+                guard let subpostID = request.target.subpostID, subpostID > 0 else {
+                    throw ContentSubmissionValidationError.invalidThread
+                }
+                fields["lzl_id"] = String(subpostID)
+            }
+        case .newThread:
+            throw ContentSubmissionError.unsupported(message: "新主题不能使用网页回帖协议。")
+        }
+        return fields
     }
 
     static func appHeaders(
@@ -302,12 +749,77 @@ enum TiebaContentSubmissionRequestFactory {
         ]
     }
 
-    static func protobufHeaders(
+    static func postProtobufHeaders(
         bootstrap: TiebaPostingBootstrapResult,
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1_000)
     ) -> [String: String] {
         var headers = appHeaders(bootstrap: bootstrap, timestamp: timestamp)
         headers["x_bd_data_type"] = "protobuf"
+        return headers
+    }
+
+    static func webThreadHeaders(
+        account: Account,
+        forumName: String
+    ) throws -> [String: String] {
+        guard BaiduCredentialPolicy.isValid(account) else {
+            throw ContentSubmissionError.sessionExpired
+        }
+        var referer = URLComponents(url: TiebaEndpoint.base.appending(path: "/f"), resolvingAgainstBaseURL: false)
+        referer?.queryItems = [.init(name: "kw", value: forumName)]
+        return [
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Origin": TiebaEndpoint.base.absoluteString,
+            "Referer": referer?.url?.absoluteString ?? TiebaEndpoint.base.absoluteString,
+            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) "
+                + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
+            "X-Requested-With": "XMLHttpRequest",
+            // Do not reuse Account.minimalCookieHeader here: the web write only
+            // needs these two validated credentials and must not expose BAIDUID.
+            "Cookie": "BDUSS=\(account.bduss); STOKEN=\(account.stoken)"
+        ]
+    }
+
+    static func webReplyHeaders(
+        account: Account,
+        threadID: Int64
+    ) throws -> [String: String] {
+        guard BaiduCredentialPolicy.isValid(account) else {
+            throw ContentSubmissionError.sessionExpired
+        }
+        guard threadID > 0 else {
+            throw ContentSubmissionValidationError.invalidThread
+        }
+        return webMutationHeaders(
+            account: account,
+            referer: "https://tieba.baidu.com/p/\(threadID)?lp=5028&mo_device=1&is_jingpost=0&pn=1&"
+        )
+    }
+
+    static func webUploadHeaders(account: Account) throws -> [String: String] {
+        guard BaiduCredentialPolicy.isValid(account) else {
+            throw ContentSubmissionError.sessionExpired
+        }
+        return webMutationHeaders(account: account, referer: nil)
+    }
+
+    private static func webMutationHeaders(
+        account: Account,
+        referer: String?
+    ) -> [String: String] {
+        var headers = [
+            "Accept": "application/json, text/plain, */*",
+            "Host": "tieba.baidu.com",
+            "Origin": TiebaEndpoint.base.absoluteString,
+            "User-Agent": "Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ3A.230805.001; wv) "
+                + "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 "
+                + "Chrome/109.0.5414.86 Mobile Safari/537.36 tieba/11.10.8.6 skin/default",
+            "X-Requested-With": "XMLHttpRequest",
+            "Cookie": "BDUSS=\(account.bduss); STOKEN=\(account.stoken)"
+        ]
+        if let referer {
+            headers["Referer"] = referer
+        }
         return headers
     }
 
@@ -349,6 +861,17 @@ enum TiebaContentSubmissionRequestFactory {
         return "回复 #(reply, \(portrait), \(displayName)) :\(body)"
     }
 
+    private static func webReplyBody(
+        _ body: String,
+        target: ContentSubmissionTarget
+    ) -> String {
+        guard target.kind == .subpostReply,
+              let displayName = protocolReplyComponent(target.replyUserDisplayName) else {
+            return body
+        }
+        return "回复 \(displayName) : \(body)"
+    }
+
     private static func protocolReplyComponent(_ value: String?) -> String? {
         guard let value else { return nil }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -356,11 +879,16 @@ enum TiebaContentSubmissionRequestFactory {
               normalized.utf8.count <= 512,
               normalized.contains(",") == false,
               normalized.contains(")") == false,
-              normalized.contains("\r") == false,
-              normalized.contains("\n") == false else {
+              containsASCIIControlLineBreak(normalized) == false else {
             return nil
         }
         return normalized
+    }
+}
+
+private func containsASCIIControlLineBreak(_ value: String) -> Bool {
+    value.unicodeScalars.contains { scalar in
+        scalar.value == 0x0A || scalar.value == 0x0D
     }
 }
 
@@ -372,87 +900,65 @@ extension TiebaAPI {
         try ContentSubmissionPolicy.validateForNetwork(request)
         try Task.checkCancellation()
 
-        let bootstrap: TiebaPostingBootstrapResult
+        if request.target.kind == .newThread {
+            return try await submitWebThread(account: account, request: request)
+        }
+        return try await submitWebReply(account: account, request: request)
+    }
+
+    func strictlyRefreshedPostingTBS(for account: Account) async throws -> String {
+        guard BaiduCredentialPolicy.isValid(account) else {
+            throw ContentSubmissionError.sessionExpired
+        }
+        let response: LoginResponseDTO
         do {
-            bootstrap = try await postingBootstrap.bootstrap(bduss: account.bduss)
+            response = try await client.postForm(
+                .postingLogin,
+                fields: [
+                    "_client_version": TiebaContentSubmissionRequestFactory.postingLoginClientVersion,
+                    "bdusstoken": account.bduss
+                ],
+                headers: [
+                    "User-Agent": "tieba/\(TiebaContentSubmissionRequestFactory.postingLoginClientVersion) skin/default"
+                ],
+                signingSecret: "tiebaclient!!!",
+                as: LoginResponseDTO.self
+            )
         } catch is CancellationError {
             throw CancellationError()
         } catch where Task.isCancelled {
             throw CancellationError()
-        } catch let error as TiebaPostingBootstrapError {
-            if error.invalidatesPostingSession {
-                throw ContentSubmissionError.sessionExpired
-            }
-            throw error
         } catch {
             throw error
         }
-        try Task.checkCancellation()
 
-        let uploadedImages = try await uploadImages(
-            request.images,
-            account: account,
-            bootstrap: bootstrap
-        )
         try Task.checkCancellation()
-
-        let refreshedTBS: String
-        do {
-            refreshedTBS = try await strictlyRefreshedClientTBS(for: account)
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch let error as TiebaAPIError {
-            if case .sessionExpired = error {
-                throw ContentSubmissionError.sessionExpired
+        let code = Int(response.errorCode ?? "0") ?? -1
+        guard code == 0 else {
+            do {
+                try TiebaResponseValidator.validate(
+                    code: code,
+                    message: response.errorMessage ?? ""
+                )
+            } catch let error as TiebaAPIError {
+                if case .sessionExpired = error {
+                    throw ContentSubmissionError.sessionExpired
+                }
+                throw ContentSubmissionError.business(
+                    code: code,
+                    message: "发布登录校验失败（\(code)）：\(response.errorMessage ?? "")"
+                )
             }
-            throw error
+            throw ContentSubmissionError.business(
+                code: code,
+                message: response.errorMessage ?? ""
+            )
         }
-        try Task.checkCancellation()
-
-        switch request.target.kind {
-        case .newThread:
-            let protobuf = try TiebaContentSubmissionRequestFactory.addThread(
-                account: account,
-                tbs: refreshedTBS,
-                request: request,
-                bootstrap: bootstrap,
-                requestBuilder: requestBuilder
-            )
-            let multipart = try requestBuilder.multipart(
-                protobuf: protobuf,
-                account: account,
-                includeSToken: false
-            )
-            let response: Tieba_AddThreadResponse = try await sendFinalMutation(
-                endpoint: .addThread,
-                body: multipart.body,
-                contentType: multipart.contentType,
-                headers: TiebaContentSubmissionRequestFactory.protobufHeaders(bootstrap: bootstrap)
-            )
-            return try response.submissionReceipt
-
-        case .threadReply, .postReply, .subpostReply:
-            let protobuf = try TiebaContentSubmissionRequestFactory.addPost(
-                account: account,
-                tbs: refreshedTBS,
-                request: request,
-                uploadedImages: uploadedImages,
-                bootstrap: bootstrap,
-                requestBuilder: requestBuilder
-            )
-            let multipart = try requestBuilder.multipart(
-                protobuf: protobuf,
-                account: account,
-                includeSToken: false
-            )
-            let response: Tieba_AddPostResponse = try await sendFinalMutation(
-                endpoint: .addPost,
-                body: multipart.body,
-                contentType: multipart.contentType,
-                headers: TiebaContentSubmissionRequestFactory.protobufHeaders(bootstrap: bootstrap)
-            )
-            return try response.submissionReceipt(for: request.target)
+        let tbs = response.anti?.tbs.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard tbs.isEmpty == false else {
+            throw TiebaMutationError.missingTBS
         }
+        return tbs
     }
 
     private func sendFinalMutation<Response: SwiftProtobuf.Message>(
@@ -478,6 +984,138 @@ extension TiebaAPI {
             // The write may already have reached Tieba. Never retry it automatically.
             throw ContentSubmissionError.outcomeUnknown
         }
+    }
+
+    private func submitWebThread(
+        account: Account,
+        request: ContentSubmissionRequest
+    ) async throws -> ContentSubmissionReceipt {
+        let refreshedTBS = try await strictlyRefreshedPostingTBS(for: account)
+        try Task.checkCancellation()
+        let fields = try TiebaContentSubmissionRequestFactory.webThreadFields(
+            account: account,
+            tbs: refreshedTBS,
+            request: request
+        )
+        let headers = try TiebaContentSubmissionRequestFactory.webThreadHeaders(
+            account: account,
+            forumName: request.target.forumName
+        )
+
+        // Once this POST starts, losing or failing to decode the response does
+        // not prove the server rejected the thread. Never retry or fall back to
+        // the app Protobuf endpoint after this point.
+        try Task.checkCancellation()
+        let response: TiebaWebThreadSubmissionResponseDTO
+        do {
+            let data = try await client.postFormData(
+                .webAddThread,
+                fields: fields,
+                headers: headers
+            )
+            try validateStrictSubmissionIntegerTypes(in: data, kind: .thread)
+            response = try JSONDecoder().decode(
+                TiebaWebThreadSubmissionResponseDTO.self,
+                from: data
+            )
+        } catch {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        return try response.submissionReceipt
+    }
+
+    private func submitWebReply(
+        account: Account,
+        request: ContentSubmissionRequest
+    ) async throws -> ContentSubmissionReceipt {
+        let uploadedImageInfo = try await uploadWebImages(
+            request.images,
+            account: account
+        )
+        try Task.checkCancellation()
+
+        let refreshedTBS: String
+        do {
+            refreshedTBS = try await strictlyRefreshedPostingTBS(for: account)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as TiebaAPIError {
+            if case .sessionExpired = error {
+                throw ContentSubmissionError.sessionExpired
+            }
+            throw error
+        }
+        try Task.checkCancellation()
+
+        let timestamp = Int64(Date().timeIntervalSince1970 * 1_000)
+        let fields = try TiebaContentSubmissionRequestFactory.webReplyFields(
+            account: account,
+            tbs: refreshedTBS,
+            request: request,
+            uploadedImageInfo: uploadedImageInfo,
+            timestamp: timestamp
+        )
+        let threadID = request.target.threadID ?? 0
+        let headers = try TiebaContentSubmissionRequestFactory.webReplyHeaders(
+            account: account,
+            threadID: threadID
+        )
+
+        // From this point the server may have accepted the reply even if the
+        // connection or local task ends before a response is decoded.
+        try Task.checkCancellation()
+        let response: TiebaWebReplySubmissionResponseDTO
+        do {
+            let data = try await client.postFormData(
+                .webAddPost(timestamp: timestamp),
+                fields: fields,
+                headers: headers
+            )
+            try validateStrictSubmissionIntegerTypes(in: data, kind: .reply)
+            response = try JSONDecoder().decode(
+                TiebaWebReplySubmissionResponseDTO.self,
+                from: data
+            )
+        } catch {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        return try response.submissionReceipt(for: request.target)
+    }
+
+    private func uploadWebImages(
+        _ images: [ContentSubmissionImage],
+        account: Account
+    ) async throws -> String {
+        guard images.isEmpty == false else { return "" }
+        let headers = try TiebaContentSubmissionRequestFactory.webUploadHeaders(account: account)
+        var imageInfo: [String] = []
+        imageInfo.reserveCapacity(images.count)
+        for (index, image) in images.enumerated() {
+            try Task.checkCancellation()
+            _ = try ContentSubmissionImageInspector.inspect(image.data)
+            let nonce = "\(Int64(Date().timeIntervalSince1970 * 1_000))_\(index)"
+            do {
+                let response = try await client.postForm(
+                    .webUploadPicture(nonce: nonce),
+                    fields: ["pic": image.data.base64EncodedString()],
+                    headers: headers,
+                    as: TiebaWebUploadPictureResponseDTO.self
+                )
+                imageInfo.append(try response.validatedImageInfo())
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as ContentSubmissionError {
+                throw error
+            } catch where Task.isCancelled {
+                throw CancellationError()
+            } catch {
+                throw ContentSubmissionError.business(
+                    code: -1,
+                    message: "图片上传失败，请检查网络后重试。"
+                )
+            }
+        }
+        return imageInfo.joined(separator: "|")
     }
 
     private func uploadImages(
@@ -560,8 +1198,8 @@ private extension TiebaPostingBootstrapError {
         switch self {
         case .invalidCredential:
             return true
-        case let .server(code, _):
-            return TiebaAPIError.sessionExpiredCodes.contains(code)
+        case let .server(code, message):
+            return TiebaAPIError.isSessionExpired(code: code, message: message)
         default:
             return false
         }
@@ -603,36 +1241,6 @@ private extension Tieba_AddPostResponse {
     }
 }
 
-private extension Tieba_AddThreadResponse {
-    var submissionReceipt: ContentSubmissionReceipt {
-        get throws {
-            let messages = submissionMessages
-            try validateSubmissionStatus(
-                error: error,
-                verification: data.info,
-                messages: messages
-            )
-            guard hasData, let threadID = positiveInt64(data.tid) else {
-                throw ContentSubmissionError.outcomeUnknown
-            }
-            return ContentSubmissionReceipt(
-                threadID: threadID,
-                postID: positiveUInt64(data.pid)
-            )
-        }
-    }
-
-    var submissionMessages: [String] {
-        normalizedSubmissionMessages([
-            error.userMsg,
-            error.errorMsg,
-            data.msg,
-            data.preMsg,
-            data.colorMsg
-        ])
-    }
-}
-
 private func validateSubmissionStatus(
     error: Tieba_Error,
     verification: Tieba_SubmissionVerificationInfo,
@@ -640,7 +1248,7 @@ private func validateSubmissionStatus(
 ) throws {
     let code = Int(error.errorCode)
     let message = messages.first ?? ""
-    if TiebaAPIError.sessionExpiredCodes.contains(code) {
+    if TiebaAPIError.isSessionExpired(code: code, message: message) {
         throw ContentSubmissionError.sessionExpired
     }
     if verification.requiresVerification
@@ -656,6 +1264,67 @@ private extension Tieba_SubmissionVerificationInfo {
     var requiresVerification: Bool {
         let value = needVcode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return value.isEmpty == false && value != "0" && value != "false"
+    }
+}
+
+private enum SubmissionStatusResponseKind {
+    case thread
+    case reply
+
+    var integerKeys: Set<String> {
+        switch self {
+        case .thread:
+            return ["result", "error_code", "err_code", "tid", "pid"]
+        case .reply:
+            return [
+                "result", "error_code", "err_code", "no", "errno", "error_no",
+                "tid", "pid", "post_id"
+            ]
+        }
+    }
+}
+
+/// JSONDecoder accepts integral floating-point tokens such as `1.0` when
+/// decoding an Int. Mutation statuses and identifiers determine whether a
+/// dispatched write is considered successful, so inspect their raw JSON types
+/// before decoding and accept only integer JSON numbers or integer strings.
+private func validateStrictSubmissionIntegerTypes(
+    in data: Data,
+    kind: SubmissionStatusResponseKind
+) throws {
+    guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw ContentSubmissionError.outcomeUnknown
+    }
+    var containers = [object]
+    if let nestedValue = object["data"], nestedValue is NSNull == false {
+        guard let nested = nestedValue as? [String: Any] else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        containers.append(nested)
+    }
+    for container in containers {
+        for key in kind.integerKeys {
+            guard let value = container[key] else { continue }
+            guard isStrictSubmissionInteger(value) else {
+                throw ContentSubmissionError.outcomeUnknown
+            }
+        }
+    }
+}
+
+private func isStrictSubmissionInteger(_ value: Any) -> Bool {
+    if let value = value as? String {
+        return Int(value) != nil
+    }
+    guard let number = value as? NSNumber,
+          CFGetTypeID(number) != CFBooleanGetTypeID() else {
+        return false
+    }
+    switch String(cString: number.objCType) {
+    case "c", "s", "i", "l", "q", "C", "S", "I", "L", "Q":
+        return true
+    default:
+        return false
     }
 }
 
@@ -675,6 +1344,32 @@ private func normalizedSubmissionMessages(_ values: [String]) -> [String] {
         .filter { $0.isEmpty == false }
 }
 
+private func validatedPositiveInt64Values(_ values: [String]) throws -> Set<Int64> {
+    var result = Set<Int64>()
+    for value in values {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty { continue }
+        guard let parsed = positiveInt64(normalized) else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        result.insert(parsed)
+    }
+    return result
+}
+
+private func validatedPositiveUInt64Values(_ values: [String]) throws -> Set<UInt64> {
+    var result = Set<UInt64>()
+    for value in values {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty { continue }
+        guard let parsed = positiveUInt64(normalized) else {
+            throw ContentSubmissionError.outcomeUnknown
+        }
+        result.insert(parsed)
+    }
+    return result
+}
+
 private func positiveInt64(_ value: String) -> Int64? {
     guard let number = Int64(value), number > 0 else { return nil }
     return number
@@ -685,7 +1380,30 @@ private func positiveUInt64(_ value: String) -> UInt64? {
     return number
 }
 
+private func validSubmissionThreadIdentifier(_ value: String?) -> Bool {
+    guard let value else { return false }
+    return positiveInt64(value.trimmingCharacters(in: .whitespacesAndNewlines)) != nil
+}
+
+private func validSubmissionPostIdentifier(_ value: String?) -> Bool {
+    guard let value else { return false }
+    return positiveUInt64(value.trimmingCharacters(in: .whitespacesAndNewlines)) != nil
+}
+
 private extension KeyedDecodingContainer {
+    func submissionIdentifierString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Int64.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decodeIfPresent(UInt64.self, forKey: key) {
+            return String(value)
+        }
+        return nil
+    }
+
     func submissionString(forKey key: Key) -> String? {
         if let value = try? decodeIfPresent(String.self, forKey: key) {
             return value
@@ -706,6 +1424,15 @@ private extension KeyedDecodingContainer {
     }
 
     func submissionInt(forKey key: Key) -> Int? {
-        submissionString(forKey: key).flatMap(Int.init)
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return Int(value)
+        }
+        if let value = try? decodeIfPresent(Int64.self, forKey: key) {
+            return Int(exactly: value)
+        }
+        if let value = try? decodeIfPresent(UInt64.self, forKey: key) {
+            return Int(exactly: value)
+        }
+        return nil
     }
 }

--- a/TiebaPure/Core/Network/TiebaEndpoint.swift
+++ b/TiebaPure/Core/Network/TiebaEndpoint.swift
@@ -7,6 +7,7 @@ enum TiebaEndpoint {
     static let socialBase = URL(string: "https://tiebac.baidu.com")!
 
     case login
+    case postingLogin
     case initNickname
     case webMyInfo
     case followedForums
@@ -19,6 +20,8 @@ enum TiebaEndpoint {
     case searchUser
     case userProfile
     case userThreads
+    case modifyProfile
+    case deleteOwnThread
     case followUser
     case unfollowUser
     case followedUsers
@@ -28,7 +31,9 @@ enum TiebaEndpoint {
     case followForum
     case unfollowForum
     case agreePost
-    case addThread
+    case webAddThread
+    case webAddPost(timestamp: Int64)
+    case webUploadPicture(nonce: String)
     case addPost
     case uploadPicture
 
@@ -36,6 +41,8 @@ enum TiebaEndpoint {
         switch self {
         case .login:
             return Self.appBase.appending(path: "/c/s/login")
+        case .postingLogin:
+            return Self.protobufBase.appending(path: "/c/s/login")
         case .initNickname:
             return Self.appBase.appending(path: "/c/s/initNickname")
         case .webMyInfo:
@@ -84,6 +91,10 @@ enum TiebaEndpoint {
                     .init(name: "cmd", value: "303002"),
                     .init(name: "format", value: "protobuf")
                 ])
+        case .modifyProfile:
+            return Self.socialBase.appending(path: "/c/c/profile/modify")
+        case .deleteOwnThread:
+            return Self.appBase.appending(path: "/c/c/bawu/delthread")
         case .followUser:
             return Self.socialBase.appending(path: "/c/c/user/follow")
         case .unfollowUser:
@@ -102,20 +113,23 @@ enum TiebaEndpoint {
             return Self.socialBase.appending(path: "/c/c/forum/unfavolike")
         case .agreePost:
             return Self.socialBase.appending(path: "/c/c/agree/opAgree")
-        case .addThread:
-            return Self.protobufBase
-                .appending(path: "/c/c/thread/add")
+        case .webAddThread:
+            return Self.base.appending(path: "/f/commit/thread/add")
+        case let .webAddPost(timestamp):
+            return Self.base
+                .appending(path: "/mo/q/apubpost")
+                .appending(queryItems: [.init(name: "_t", value: String(timestamp))])
+        case let .webUploadPicture(nonce):
+            return Self.base
+                .appending(path: "/mo/q/cooluploadpic")
                 .appending(queryItems: [
-                    .init(name: "cmd", value: "309730"),
-                    .init(name: "format", value: "protobuf")
+                    .init(name: "type", value: "ajax"),
+                    .init(name: "r", value: nonce)
                 ])
         case .addPost:
             return Self.protobufBase
                 .appending(path: "/c/c/post/add")
-                .appending(queryItems: [
-                    .init(name: "cmd", value: "309731"),
-                    .init(name: "format", value: "protobuf")
-                ])
+                .appending(queryItems: [.init(name: "cmd", value: "309731")])
         case .uploadPicture:
             return Self.protobufBase.appending(path: "/c/s/uploadPicture")
         }

--- a/TiebaPure/Core/Network/TiebaHTTPClient.swift
+++ b/TiebaPure/Core/Network/TiebaHTTPClient.swift
@@ -46,7 +46,7 @@ struct TiebaHTTPClient {
             maximumBytes: maximumResponseBytes
         )
         try validate(response: response, data: data)
-        return try JSONDecoder().decode(T.self, from: data)
+        return try JSONDecoder().decode(type, from: data)
     }
 
     func postForm<T: Decodable>(
@@ -56,6 +56,21 @@ struct TiebaHTTPClient {
         signingSecret: String? = nil,
         as type: T.Type
     ) async throws -> T {
+        let data = try await postFormData(
+            endpoint,
+            fields: fields,
+            headers: headers,
+            signingSecret: signingSecret
+        )
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    func postFormData(
+        _ endpoint: TiebaEndpoint,
+        fields: [String: String],
+        headers: [String: String] = [:],
+        signingSecret: String? = nil
+    ) async throws -> Data {
         var request = URLRequest(url: endpoint.url)
         var requestFields = fields
         let shouldSortFields = signingSecret != nil
@@ -78,7 +93,7 @@ struct TiebaHTTPClient {
             maximumBytes: maximumResponseBytes
         )
         try validate(response: response, data: data)
-        return try JSONDecoder().decode(T.self, from: data)
+        return data
     }
 
     func postProtobuf<Response: SwiftProtobuf.Message>(

--- a/TiebaPure/Core/Network/TiebaPostingBootstrap.swift
+++ b/TiebaPure/Core/Network/TiebaPostingBootstrap.swift
@@ -250,7 +250,10 @@ struct TiebaPostingBootstrapEndpoints: Equatable, Sendable {
 
 actor TiebaPostingBootstrap: TiebaPostingBootstrapping {
     static let maximumStoredIdentityBytes = 4 * 1_024
-    static let maximumSyncResponseBytes = 128 * 1_024
+    // The sync payload contains a compressed server configuration whose decoded
+    // JSON currently exceeds 128 KiB for real accounts. Keep a dedicated bound
+    // well below the general API ceiling while allowing that valid response.
+    static let maximumSyncResponseBytes = 1 * 1_024 * 1_024
     static let maximumZIDResponseBytes = 64 * 1_024
 
     private static let currentClientVersion = "22.5.1.0"
@@ -488,13 +491,13 @@ actor TiebaPostingBootstrap: TiebaPostingBootstrapping {
             throw TiebaPostingBootstrapError.invalidCiphertext
         }
         let decrypted = try TiebaPostingCrypto.aesCBCDecryptRaw(ciphertext, key: responseKey)
-        guard decrypted.count >= 32 else { throw TiebaPostingBootstrapError.invalidCiphertext }
-        let responseDigest = Data(decrypted.suffix(16))
-        let paddedJSON = decrypted.dropLast(16)
-        let responseJSON = try TiebaPostingCrypto.removePKCS7Padding(Data(paddedJSON))
-        guard TiebaPostingCrypto.md5(responseJSON) == responseDigest else {
+        guard decrypted.count >= 32 else {
             throw TiebaPostingBootstrapError.invalidCiphertext
         }
+        // Sofire appends an opaque 16-byte suffix. It is not a keyed MAC and
+        // live responses do not consistently contain MD5(unpadded JSON).
+        let paddedJSON = decrypted.dropLast(16)
+        let responseJSON = try TiebaPostingCrypto.removePKCS7Padding(Data(paddedJSON))
         let responseObject = try jsonObject(responseJSON)
         return try validatedServerValue(responseObject["token"], field: "token", maximumBytes: 4_096)
     }

--- a/TiebaPure/Core/Network/TiebaRequestBuilder.swift
+++ b/TiebaPure/Core/Network/TiebaRequestBuilder.swift
@@ -142,13 +142,19 @@ struct TiebaRequestBuilder {
     func multipart<Message: SwiftProtobuf.Message>(
         protobuf: Message,
         account: Account?,
-        includeSToken: Bool
+        includeSToken: Bool,
+        fileContentType: String? = "application/octet-stream"
     ) throws -> (body: Data, contentType: String) {
         let form = MultipartFormData(boundary: Self.boundary)
         if includeSToken, let stoken = account?.stoken {
             form.addField(name: "stoken", value: stoken)
         }
-        form.addFile(name: "data", filename: "file", data: try protobuf.serializedData())
+        form.addFile(
+            name: "data",
+            filename: "file",
+            contentType: fileContentType,
+            data: try protobuf.serializedData()
+        )
         return (form.finalize(), "multipart/form-data; boundary=\(Self.boundary)")
     }
 }

--- a/TiebaPure/Core/Network/TiebaUserProfileAPI.swift
+++ b/TiebaPure/Core/Network/TiebaUserProfileAPI.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 struct UserProfileRequestContext {
@@ -6,6 +7,8 @@ struct UserProfileRequestContext {
 }
 
 enum UserProfileRequestFactory {
+    static let ownThreadDeleteClientVersion = "12.25.1.0"
+
     static func profileRequest(
         account: Account?,
         user: UserSummary,
@@ -88,6 +91,73 @@ enum UserProfileRequestFactory {
             "tbs": resolvedTBS
         ]
     }
+
+    static func profileEditFields(
+        account: Account,
+        request: UserProfileEditRequest
+    ) throws -> [String: String] {
+        let nickname = request.nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard nickname.isEmpty == false else {
+            throw UserProfileMutationError.missingNickname
+        }
+        var fields = [
+            "BDUSS": account.bduss,
+            "intro": request.introduction,
+            "nick_name": nickname
+        ]
+        // The profile endpoint accepts 1/2 for male/female, but a submitted 0
+        // may be normalized to male. Omit the field to preserve an unset value.
+        if let sex = request.sex.profileMutationProtocolValue {
+            fields["sex"] = "\(sex)"
+        }
+        return fields
+    }
+
+    static func deleteThreadFields(
+        account: Account,
+        tbs: String,
+        target: OwnThreadDeletionTarget,
+        requestBuilder: TiebaRequestBuilder,
+        timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1_000)
+    ) throws -> [String: String] {
+        try validateDeletionTarget(target)
+        let resolvedTBS = tbs.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard resolvedTBS.isEmpty == false else {
+            throw UserProfileAPIError.missingTBS
+        }
+        var fields = requestBuilder.officialCommonFields(
+            bduss: account.bduss,
+            baiduID: account.baiduID,
+            clientVersion: ownThreadDeleteClientVersion,
+            timestamp: timestamp
+        )
+        fields.merge([
+            "delete_my_thread": "1",
+            "fid": "\(target.forumID)",
+            "is_frs_mask": "0",
+            "is_vipdel": "0",
+            "src": "1",
+            "tbs": resolvedTBS,
+            "word": target.forumName.trimmingCharacters(in: .whitespacesAndNewlines),
+            "z": "\(target.threadID)"
+        ], uniquingKeysWith: { _, new in new })
+        return fields
+    }
+
+    static func validateDeletionTarget(_ target: OwnThreadDeletionTarget) throws {
+        guard target.forumID > 0 else {
+            throw UserProfileMutationError.invalidForumID
+        }
+        guard target.forumName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            throw UserProfileMutationError.invalidForumName
+        }
+        guard target.threadID > 0 else {
+            throw UserProfileMutationError.invalidThreadID
+        }
+        guard target.firstPostID > 0 else {
+            throw UserProfileMutationError.invalidFirstPostID
+        }
+    }
 }
 
 enum UserProfileAPIError: Error, Equatable, CustomStringConvertible {
@@ -106,6 +176,35 @@ enum UserProfileAPIError: Error, Equatable, CustomStringConvertible {
             return "缺少用户标识，无法修改关注状态。"
         case .missingTBS:
             return "登录状态不完整，请重新登录后再试。"
+        }
+    }
+}
+
+enum UserProfileMutationError: Error, Equatable, CustomStringConvertible {
+    case missingNickname
+    case invalidForumID
+    case invalidForumName
+    case invalidThreadID
+    case invalidFirstPostID
+    case outcomeUnknown
+    case unsupportedByService
+
+    var description: String {
+        switch self {
+        case .missingNickname:
+            return "昵称不能为空。"
+        case .invalidForumID:
+            return "贴吧 ID 无效，无法删除主题。"
+        case .invalidForumName:
+            return "贴吧名称无效，无法删除主题。"
+        case .invalidThreadID:
+            return "主题 ID 无效，无法删除主题。"
+        case .invalidFirstPostID:
+            return "缺少主题首帖 ID，无法确认删除目标。"
+        case .outcomeUnknown:
+            return "请求已经发出，但未能确认贴吧是否处理成功。请刷新后再决定是否重试。"
+        case .unsupportedByService:
+            return "当前数据服务不支持该操作。"
         }
     }
 }
@@ -172,6 +271,49 @@ extension TiebaAPI {
         return UserProfileMapper.threadsPage(from: response, page: page)
     }
 
+    func updateOwnProfile(account: Account, request: UserProfileEditRequest) async throws {
+        let fields = try UserProfileRequestFactory.profileEditFields(
+            account: account,
+            request: request
+        )
+        let response = try await sendFinalUserProfileMutation(
+            endpoint: .modifyProfile,
+            fields: fields
+        )
+        try TiebaResponseValidator.validate(
+            code: response.errorCode,
+            message: response.errorMessage
+        )
+    }
+
+    func deleteOwnThread(account: Account, target: OwnThreadDeletionTarget) async throws {
+        try Task.checkCancellation()
+        try UserProfileRequestFactory.validateDeletionTarget(target)
+        let tbs = try await refreshedClientTBS(for: account)
+        try Task.checkCancellation()
+        let timestamp = Int64(Date().timeIntervalSince1970 * 1_000)
+        let fields = try UserProfileRequestFactory.deleteThreadFields(
+            account: account,
+            tbs: tbs,
+            target: target,
+            requestBuilder: requestBuilder,
+            timestamp: timestamp
+        )
+        let response = try await sendFinalUserProfileMutation(
+            endpoint: .deleteOwnThread,
+            fields: fields,
+            headers: requestBuilder.officialHeaders(
+                baiduID: account.baiduID,
+                clientVersion: UserProfileRequestFactory.ownThreadDeleteClientVersion,
+                timestamp: timestamp
+            )
+        )
+        try TiebaResponseValidator.validate(
+            code: response.errorCode,
+            message: response.errorMessage
+        )
+    }
+
     func setUserFollowed(account: Account, user: UserSummary, followed: Bool) async throws {
         let tbs = try await refreshedClientTBS(for: account)
         try Task.checkCancellation()
@@ -189,5 +331,122 @@ extension TiebaAPI {
             as: UserFollowResponseDTO.self
         )
         try TiebaResponseValidator.validate(code: response.errorCode, message: response.errorMessage)
+    }
+
+    private func sendFinalUserProfileMutation(
+        endpoint: TiebaEndpoint,
+        fields: [String: String],
+        headers: [String: String] = ["User-Agent": "tieba/\(TiebaClientVersion.v22.rawValue)"]
+    ) async throws -> StrictUserProfileMutationResponse {
+        try Task.checkCancellation()
+        do {
+            let data = try await client.postFormData(
+                endpoint,
+                fields: fields,
+                headers: headers,
+                signingSecret: "tiebaclient!!!"
+            )
+            return try strictUserProfileMutationResponse(from: data)
+        } catch {
+            // Once the final POST is dispatched, losing its response cannot
+            // prove that Tieba did not apply the mutation. Keep this distinct
+            // from a preflight failure so callers never retry automatically.
+            throw UserProfileMutationError.outcomeUnknown
+        }
+    }
+}
+
+private struct StrictUserProfileMutationResponse {
+    var errorCode: Int
+    var errorMessage: String
+}
+
+/// JSONDecoder accepts integral floating-point tokens such as `0.0` when
+/// decoding an Int. Inspect the raw JSON instead, then reconcile every known
+/// status alias before treating an already-dispatched mutation as successful.
+private func strictUserProfileMutationResponse(
+    from data: Data
+) throws -> StrictUserProfileMutationResponse {
+    guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw UserProfileMutationError.outcomeUnknown
+    }
+
+    var containers = [object]
+    if let nestedData = object["data"] {
+        guard let nestedData = nestedData as? [String: Any] else {
+            throw UserProfileMutationError.outcomeUnknown
+        }
+        containers.append(nestedData)
+    }
+    var errorString: String?
+    if let nestedError = object["error"], nestedError is NSNull == false {
+        if let nestedError = nestedError as? [String: Any] {
+            containers.append(nestedError)
+        } else if let nestedError = nestedError as? String {
+            errorString = nestedError
+        } else {
+            throw UserProfileMutationError.outcomeUnknown
+        }
+    }
+
+    let integerKeys: Set<String> = [
+        "result", "error_code", "err_code", "errno", "error_no", "no"
+    ]
+    var statusValues: [Int] = []
+    for container in containers {
+        for key in integerKeys {
+            guard let value = container[key] else { continue }
+            statusValues.append(try strictUserProfileMutationInteger(value))
+        }
+    }
+
+    guard let status = statusValues.first,
+          statusValues.allSatisfy({ $0 == status }) else {
+        throw UserProfileMutationError.outcomeUnknown
+    }
+
+    let normalizedErrorString = errorString?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    if status == 0, normalizedErrorString?.isEmpty == false {
+        throw UserProfileMutationError.outcomeUnknown
+    }
+
+    let messageKeys = ["error_msg", "err_msg", "errmsg", "user_msg", "message", "msg"]
+    let message = containers.lazy
+        .flatMap { container in
+            messageKeys.compactMap { key -> String? in
+                guard let value = container[key] as? String else { return nil }
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+        }
+        .first
+        ?? normalizedErrorString
+        ?? ""
+    return StrictUserProfileMutationResponse(
+        errorCode: status,
+        errorMessage: message
+    )
+}
+
+private func strictUserProfileMutationInteger(_ value: Any) throws -> Int {
+    if let value = value as? String {
+        guard let integer = Int(value) else {
+            throw UserProfileMutationError.outcomeUnknown
+        }
+        return integer
+    }
+    guard let number = value as? NSNumber,
+          CFGetTypeID(number) != CFBooleanGetTypeID() else {
+        throw UserProfileMutationError.outcomeUnknown
+    }
+    switch String(cString: number.objCType) {
+    case "c", "s", "i", "l", "q", "C", "S", "I", "L", "Q":
+        guard let integer = Int(number.stringValue) else {
+            throw UserProfileMutationError.outcomeUnknown
+        }
+        return integer
+    default:
+        throw UserProfileMutationError.outcomeUnknown
     }
 }

--- a/TiebaPure/Core/State/ContentSubmissionCoordinator.swift
+++ b/TiebaPure/Core/State/ContentSubmissionCoordinator.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ContentSubmissionCoordinatorError: Error, Equatable, LocalizedError {
     case operationInProgress
     case sessionTransition
+    case repliesDisabled
 
     var errorDescription: String? {
         switch self {
@@ -10,6 +11,8 @@ enum ContentSubmissionCoordinatorError: Error, Equatable, LocalizedError {
             return "同一位置已有内容正在发送，请等待发送完成。"
         case .sessionTransition:
             return "账号状态正在切换，请稍后重试。"
+        case .repliesDisabled:
+            return "请先在设置中开启“允许回帖”。"
         }
     }
 }
@@ -27,13 +30,34 @@ final class ContentSubmissionCoordinator {
         let task: Task<ContentSubmissionReceipt, Error>
     }
 
+    enum AccountWriteTarget: Hashable, Sendable {
+        case profile
+        case deleteThread(Int64)
+    }
+
+    private struct AccountWriteKey: Hashable, Sendable {
+        let accountID: String
+        let target: AccountWriteTarget
+    }
+
+    private struct AccountWrite {
+        let id: UUID
+        let task: Task<Void, Error>
+    }
+
     private let api: any TiebaAPIService
+    private let allowsSubmission: @MainActor (ContentSubmissionKind) -> Bool
     private var operations: [OperationKey: Operation] = [:]
+    private var accountWrites: [AccountWriteKey: AccountWrite] = [:]
     private var globalInvalidationCount = 0
     private var accountInvalidationCounts: [String: Int] = [:]
 
-    init(api: any TiebaAPIService) {
+    init(
+        api: any TiebaAPIService,
+        allowsSubmission: @escaping @MainActor (ContentSubmissionKind) -> Bool = { _ in true }
+    ) {
         self.api = api
+        self.allowsSubmission = allowsSubmission
     }
 
     static func operationKey(
@@ -57,6 +81,9 @@ final class ContentSubmissionCoordinator {
     ) async throws -> ContentSubmissionReceipt {
         guard canSubmit(accountID: account.id) else {
             throw ContentSubmissionCoordinatorError.sessionTransition
+        }
+        guard allowsSubmission(request.target.kind) else {
+            throw ContentSubmissionCoordinatorError.repliesDisabled
         }
         let key = Self.operationKey(account: account, target: request.target)
         if let existing = operations[key] {
@@ -83,15 +110,64 @@ final class ContentSubmissionCoordinator {
         }
     }
 
-    /// Closes the matching submission entry point before draining active writes.
-    /// The barrier remains active until the matching `endInvalidation` call.
-    func beginInvalidation(accountID: String? = nil) async {
+    /// Registers non-composer account mutations with the same session barrier
+    /// used by logout and account replacement. The stored task survives a view
+    /// dismissal, but session invalidation cancels and drains it before account
+    /// artifacts are cleared.
+    func performAccountWrite(
+        account: Account,
+        target: AccountWriteTarget,
+        coalescesConcurrentCalls: Bool = false,
+        operation: @escaping () async throws -> Void
+    ) async throws {
+        guard canSubmit(accountID: account.id) else {
+            throw ContentSubmissionCoordinatorError.sessionTransition
+        }
+
+        let key = AccountWriteKey(accountID: account.id, target: target)
+        if let existing = accountWrites[key] {
+            guard coalescesConcurrentCalls else {
+                throw ContentSubmissionCoordinatorError.operationInProgress
+            }
+            return try await existing.task.value
+        }
+
+        let id = UUID()
+        let task = Task {
+            try await operation()
+        }
+        accountWrites[key] = AccountWrite(id: id, task: task)
+
+        do {
+            try await task.value
+            finishAccountWrite(id: id, for: key)
+        } catch {
+            finishAccountWrite(id: id, for: key)
+            throw error
+        }
+    }
+
+    /// Closes the matching submission entry point synchronously. Callers that
+    /// coordinate multiple write domains must establish every barrier before
+    /// awaiting any drain operation.
+    func establishInvalidationBarrier(accountID: String? = nil) {
         if let accountID {
             accountInvalidationCounts[accountID, default: 0] += 1
         } else {
             globalInvalidationCount += 1
         }
+    }
+
+    /// Cancels and drains writes covered by an already-established barrier.
+    func drainInvalidatedOperations(accountID: String? = nil) async {
         await drainOperations(accountID: accountID)
+    }
+
+    /// Closes the matching submission entry point before draining active writes.
+    /// The barrier remains active until the matching `endInvalidation` call.
+    func beginInvalidation(accountID: String? = nil) async {
+        establishInvalidationBarrier(accountID: accountID)
+        await drainInvalidatedOperations(accountID: accountID)
     }
 
     func endInvalidation(accountID: String? = nil) {
@@ -117,6 +193,11 @@ final class ContentSubmissionCoordinator {
         operations[key] = nil
     }
 
+    private func finishAccountWrite(id: UUID, for key: AccountWriteKey) {
+        guard accountWrites[key]?.id == id else { return }
+        accountWrites[key] = nil
+    }
+
     private func canSubmit(accountID: String) -> Bool {
         globalInvalidationCount == 0 && accountInvalidationCounts[accountID] == nil
     }
@@ -126,14 +207,26 @@ final class ContentSubmissionCoordinator {
             let matching = operations.filter { key, _ in
                 accountID == nil || key.accountID == accountID
             }
-            guard matching.isEmpty == false else { return }
+            let matchingAccountWrites = accountWrites.filter { key, _ in
+                accountID == nil || key.accountID == accountID
+            }
+            guard matching.isEmpty == false || matchingAccountWrites.isEmpty == false else {
+                return
+            }
 
             matching.values.forEach { $0.task.cancel() }
+            matchingAccountWrites.values.forEach { $0.task.cancel() }
             for operation in matching.values {
                 _ = await operation.task.result
             }
+            for write in matchingAccountWrites.values {
+                _ = await write.task.result
+            }
             for (key, operation) in matching {
                 finishOperation(id: operation.id, for: key)
+            }
+            for (key, write) in matchingAccountWrites {
+                finishAccountWrite(id: write.id, for: key)
             }
         }
     }

--- a/TiebaPure/Core/State/ContentSubmissionCoordinator.swift
+++ b/TiebaPure/Core/State/ContentSubmissionCoordinator.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ContentSubmissionCoordinatorError: Error, Equatable, LocalizedError {
     case operationInProgress
     case sessionTransition
+    case newThreadsDisabled
     case repliesDisabled
 
     var errorDescription: String? {
@@ -11,6 +12,8 @@ enum ContentSubmissionCoordinatorError: Error, Equatable, LocalizedError {
             return "同一位置已有内容正在发送，请等待发送完成。"
         case .sessionTransition:
             return "账号状态正在切换，请稍后重试。"
+        case .newThreadsDisabled:
+            return "请先在设置中开启“允许发帖”。"
         case .repliesDisabled:
             return "请先在设置中开启“允许回帖”。"
         }
@@ -83,7 +86,12 @@ final class ContentSubmissionCoordinator {
             throw ContentSubmissionCoordinatorError.sessionTransition
         }
         guard allowsSubmission(request.target.kind) else {
-            throw ContentSubmissionCoordinatorError.repliesDisabled
+            switch request.target.kind {
+            case .newThread:
+                throw ContentSubmissionCoordinatorError.newThreadsDisabled
+            case .threadReply, .postReply, .subpostReply:
+                throw ContentSubmissionCoordinatorError.repliesDisabled
+            }
         }
         let key = Self.operationKey(account: account, target: request.target)
         if let existing = operations[key] {

--- a/TiebaPure/Core/State/OwnThreadMutationState.swift
+++ b/TiebaPure/Core/State/OwnThreadMutationState.swift
@@ -1,0 +1,50 @@
+import Combine
+import Foundation
+
+enum OwnThreadMutationOutcome: Equatable, Sendable {
+    case deleted
+    case needsRefresh
+}
+
+struct OwnThreadMutationEvent: Equatable, Sendable {
+    let accountID: String
+    let threadID: Int64
+    let outcome: OwnThreadMutationOutcome
+}
+
+@MainActor
+final class OwnThreadMutationState {
+    let didChange = PassthroughSubject<OwnThreadMutationEvent, Never>()
+    private var unconfirmedDeletionKeys = Set<DeletionKey>()
+
+    func hasUnconfirmedDeletion(accountID: String, threadID: Int64) -> Bool {
+        unconfirmedDeletionKeys.contains(DeletionKey(
+            accountID: accountID,
+            threadID: threadID
+        ))
+    }
+
+    func publish(
+        accountID: String,
+        threadID: Int64,
+        outcome: OwnThreadMutationOutcome
+    ) {
+        let key = DeletionKey(accountID: accountID, threadID: threadID)
+        switch outcome {
+        case .deleted:
+            unconfirmedDeletionKeys.remove(key)
+        case .needsRefresh:
+            unconfirmedDeletionKeys.insert(key)
+        }
+        didChange.send(OwnThreadMutationEvent(
+            accountID: accountID,
+            threadID: threadID,
+            outcome: outcome
+        ))
+    }
+}
+
+private struct DeletionKey: Hashable {
+    let accountID: String
+    let threadID: Int64
+}

--- a/TiebaPure/Core/State/SocialMutationCoordinator.swift
+++ b/TiebaPure/Core/State/SocialMutationCoordinator.swift
@@ -1,35 +1,59 @@
 import Foundation
 
-enum SocialMutationCoordinatorError: Error, Equatable, CustomStringConvertible {
+enum SocialMutationCoordinatorError: Error, Equatable, LocalizedError, CustomStringConvertible {
     case operationInProgress
+    case sessionTransition
 
     var description: String {
-        "操作正在处理中，请稍候。"
+        errorDescription ?? "操作失败。"
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .operationInProgress:
+            return "操作正在处理中，请稍候。"
+        case .sessionTransition:
+            return "账号状态正在切换，请稍后重试。"
+        }
     }
 }
 
 @MainActor
 final class SocialMutationCoordinator {
+    private struct OperationKey: Hashable {
+        let session: AccountSessionIdentity
+        let target: String
+    }
+
     private struct UserOperation {
-        var targetState: Bool
-        var task: Task<Void, Error>
+        let id: UUID
+        let accountID: String
+        let user: UserSummary
+        let targetState: Bool
+        let task: Task<Void, Error>
     }
 
     private struct ForumOperation {
-        var targetState: Bool
-        var task: Task<ForumMembership, Error>
+        let id: UUID
+        let accountID: String
+        let forum: Forum
+        let targetState: Bool
+        let task: Task<ForumMembership, Error>
     }
 
     private struct LikeOperation {
-        var targetState: Bool
-        var task: Task<Void, Error>
+        let id: UUID
+        let targetState: Bool
+        let task: Task<Void, Error>
     }
 
     private let api: any TiebaAPIService
     private let state: SocialRelationshipState
-    private var userOperations: [String: UserOperation] = [:]
-    private var forumOperations: [String: ForumOperation] = [:]
-    private var likeOperations: [String: LikeOperation] = [:]
+    private var userOperations: [OperationKey: UserOperation] = [:]
+    private var forumOperations: [OperationKey: ForumOperation] = [:]
+    private var likeOperations: [OperationKey: LikeOperation] = [:]
+    private var globalInvalidationCount = 0
+    private var sessionInvalidationCounts: [AccountSessionIdentity: Int] = [:]
 
     init(api: any TiebaAPIService, state: SocialRelationshipState) {
         self.api = api
@@ -37,7 +61,14 @@ final class SocialMutationCoordinator {
     }
 
     func setUserFollowed(account: Account, user: UserSummary, followed: Bool) async throws {
-        let key = "\(account.id)|\(SocialRelationshipState.userOperationKey(user))"
+        let session = account.sessionIdentity
+        guard canMutate(session: session) else {
+            throw SocialMutationCoordinatorError.sessionTransition
+        }
+        let key = OperationKey(
+            session: session,
+            target: "user|\(SocialRelationshipState.userOperationKey(user))"
+        )
         if let existing = userOperations[key] {
             guard existing.targetState == followed else {
                 throw SocialMutationCoordinatorError.operationInProgress
@@ -46,38 +77,58 @@ final class SocialMutationCoordinator {
         }
 
         state.beginUserMutation(accountID: account.id, user: user)
+        let operationID = UUID()
         let api = api
-        let state = state
-        let task = Task {
+        let task = Task { @MainActor [weak self] in
             do {
                 try await api.setUserFollowed(account: account, user: user, followed: followed)
-                state.recordUserFollow(accountID: account.id, user: user, isFollowed: followed)
+                guard let self else { throw CancellationError() }
+                try self.commitUserMutation(
+                    id: operationID,
+                    key: key,
+                    user: user,
+                    followed: followed
+                )
             } catch {
                 let originalError = error
-                if let profile = try? await api.userProfile(account: account, user: user) {
-                    state.recordUserFollow(
-                        accountID: account.id,
-                        user: profile.user,
-                        isFollowed: profile.isFollowed
-                    )
+                guard let self else { throw CancellationError() }
+                guard Task.isCancelled == false,
+                      originalError is CancellationError == false else {
+                    self.finishUserOperation(id: operationID, for: key)
+                    throw CancellationError()
                 }
+                let profile = try? await api.userProfile(account: account, user: user)
+                guard Task.isCancelled == false else {
+                    self.finishUserOperation(id: operationID, for: key)
+                    throw CancellationError()
+                }
+                try self.commitUserReconciliation(
+                    id: operationID,
+                    key: key,
+                    profile: profile
+                )
                 throw originalError
             }
         }
-        userOperations[key] = UserOperation(targetState: followed, task: task)
-        do {
-            try await task.value
-            userOperations[key] = nil
-            state.endUserMutation(accountID: account.id, user: user)
-        } catch {
-            userOperations[key] = nil
-            state.endUserMutation(accountID: account.id, user: user)
-            throw error
-        }
+        userOperations[key] = UserOperation(
+            id: operationID,
+            accountID: account.id,
+            user: user,
+            targetState: followed,
+            task: task
+        )
+        try await task.value
     }
 
     func setForumFollowed(account: Account, forum: Forum, followed: Bool) async throws -> ForumMembership {
-        let key = "\(account.id)|\(SocialRelationshipState.forumOperationKey(forum))"
+        let session = account.sessionIdentity
+        guard canMutate(session: session) else {
+            throw SocialMutationCoordinatorError.sessionTransition
+        }
+        let key = OperationKey(
+            session: session,
+            target: "forum|\(SocialRelationshipState.forumOperationKey(forum))"
+        )
         if let existing = forumOperations[key] {
             guard existing.targetState == followed else {
                 throw SocialMutationCoordinatorError.operationInProgress
@@ -86,48 +137,53 @@ final class SocialMutationCoordinator {
         }
 
         state.beginForumMutation(accountID: account.id, forum: forum)
+        let operationID = UUID()
         let api = api
-        let state = state
-        let task = Task {
+        let task = Task { @MainActor [weak self] in
             do {
                 let membership = try await api.setForumFollowed(
                     account: account,
                     forum: forum,
                     followed: followed
                 )
-                var resolvedForum = forum
-                resolvedForum.id = membership.forumID
-                state.recordForumFollow(
-                    accountID: account.id,
-                    forum: resolvedForum,
-                    isFollowed: membership.isFollowed
+                guard let self else { throw CancellationError() }
+                try self.commitForumMutation(
+                    id: operationID,
+                    key: key,
+                    forum: forum,
+                    membership: membership
                 )
                 return membership
             } catch {
                 let originalError = error
-                if let membership = try? await api.forumMembership(account: account, forum: forum) {
-                    var resolvedForum = forum
-                    resolvedForum.id = membership.forumID
-                    state.recordForumFollow(
-                        accountID: account.id,
-                        forum: resolvedForum,
-                        isFollowed: membership.isFollowed
-                    )
+                guard let self else { throw CancellationError() }
+                guard Task.isCancelled == false,
+                      originalError is CancellationError == false else {
+                    self.finishForumOperation(id: operationID, for: key)
+                    throw CancellationError()
                 }
+                let membership = try? await api.forumMembership(account: account, forum: forum)
+                guard Task.isCancelled == false else {
+                    self.finishForumOperation(id: operationID, for: key)
+                    throw CancellationError()
+                }
+                try self.commitForumReconciliation(
+                    id: operationID,
+                    key: key,
+                    forum: forum,
+                    membership: membership
+                )
                 throw originalError
             }
         }
-        forumOperations[key] = ForumOperation(targetState: followed, task: task)
-        do {
-            let membership = try await task.value
-            forumOperations[key] = nil
-            state.endForumMutation(accountID: account.id, forum: forum)
-            return membership
-        } catch {
-            forumOperations[key] = nil
-            state.endForumMutation(accountID: account.id, forum: forum)
-            throw error
-        }
+        forumOperations[key] = ForumOperation(
+            id: operationID,
+            accountID: account.id,
+            forum: forum,
+            targetState: followed,
+            task: task
+        )
+        return try await task.value
     }
 
     func setPostLiked(
@@ -137,7 +193,14 @@ final class SocialMutationCoordinator {
         objectType: TiebaLikeObjectType,
         liked: Bool
     ) async throws {
-        let key = "\(account.id)|\(threadID)|\(postID)|\(objectType.rawValue)"
+        let session = account.sessionIdentity
+        guard canMutate(session: session) else {
+            throw SocialMutationCoordinatorError.sessionTransition
+        }
+        let key = OperationKey(
+            session: session,
+            target: "like|\(threadID)|\(postID)|\(objectType.rawValue)"
+        )
         if let existing = likeOperations[key] {
             guard existing.targetState == liked else {
                 throw SocialMutationCoordinatorError.operationInProgress
@@ -145,23 +208,220 @@ final class SocialMutationCoordinator {
             return try await existing.task.value
         }
 
+        let operationID = UUID()
         let api = api
-        let task = Task {
-            try await api.setPostLiked(
-                account: account,
-                threadID: threadID,
-                postID: postID,
-                objectType: objectType,
-                liked: liked
+        let task = Task { @MainActor [weak self] in
+            do {
+                try await api.setPostLiked(
+                    account: account,
+                    threadID: threadID,
+                    postID: postID,
+                    objectType: objectType,
+                    liked: liked
+                )
+                guard let self else { throw CancellationError() }
+                try self.commitLikeMutation(id: operationID, key: key)
+            } catch {
+                guard let self else { throw CancellationError() }
+                let shouldCancel = Task.isCancelled || error is CancellationError
+                self.finishLikeOperation(id: operationID, for: key)
+                if shouldCancel {
+                    throw CancellationError()
+                }
+                throw error
+            }
+        }
+        likeOperations[key] = LikeOperation(
+            id: operationID,
+            targetState: liked,
+            task: task
+        )
+        try await task.value
+    }
+
+    func isInvalidating(session: AccountSessionIdentity) -> Bool {
+        canMutate(session: session) == false
+    }
+
+    /// Closes the selected session (or every session) synchronously. Callers
+    /// that coordinate multiple write domains must establish every barrier
+    /// before awaiting any drain operation.
+    func establishInvalidationBarrier(session: AccountSessionIdentity? = nil) {
+        if let session {
+            sessionInvalidationCounts[session, default: 0] += 1
+        } else {
+            globalInvalidationCount += 1
+        }
+    }
+
+    /// Cancels and drains mutations covered by an already-established barrier.
+    func drainInvalidatedOperations(session: AccountSessionIdentity? = nil) async {
+        await drainOperations(session: session)
+    }
+
+    /// Closes the selected session (or every session) before cancelling and
+    /// draining its stored social mutations. The barrier remains active until
+    /// the matching `endInvalidation` call.
+    func beginInvalidation(session: AccountSessionIdentity? = nil) async {
+        establishInvalidationBarrier(session: session)
+        await drainInvalidatedOperations(session: session)
+    }
+
+    func endInvalidation(session: AccountSessionIdentity? = nil) {
+        if let session {
+            guard let count = sessionInvalidationCounts[session] else { return }
+            if count > 1 {
+                sessionInvalidationCounts[session] = count - 1
+            } else {
+                sessionInvalidationCounts[session] = nil
+            }
+        } else {
+            globalInvalidationCount = max(0, globalInvalidationCount - 1)
+        }
+    }
+
+    private func canMutate(session: AccountSessionIdentity) -> Bool {
+        globalInvalidationCount == 0 && sessionInvalidationCounts[session] == nil
+    }
+
+    private func commitUserMutation(
+        id: UUID,
+        key: OperationKey,
+        user: UserSummary,
+        followed: Bool
+    ) throws {
+        guard canMutate(session: key.session), userOperations[key]?.id == id else {
+            finishUserOperation(id: id, for: key)
+            throw CancellationError()
+        }
+        state.recordUserFollow(accountID: key.session.accountID, user: user, isFollowed: followed)
+        finishUserOperation(id: id, for: key)
+    }
+
+    private func commitUserReconciliation(
+        id: UUID,
+        key: OperationKey,
+        profile: UserProfile?
+    ) throws {
+        guard canMutate(session: key.session), userOperations[key]?.id == id else {
+            finishUserOperation(id: id, for: key)
+            throw CancellationError()
+        }
+        if let profile {
+            state.recordUserFollow(
+                accountID: key.session.accountID,
+                user: profile.user,
+                isFollowed: profile.isFollowed
             )
         }
-        likeOperations[key] = LikeOperation(targetState: liked, task: task)
-        do {
-            try await task.value
-            likeOperations[key] = nil
-        } catch {
-            likeOperations[key] = nil
-            throw error
+        finishUserOperation(id: id, for: key)
+    }
+
+    private func commitForumMutation(
+        id: UUID,
+        key: OperationKey,
+        forum: Forum,
+        membership: ForumMembership
+    ) throws {
+        guard canMutate(session: key.session), forumOperations[key]?.id == id else {
+            finishForumOperation(id: id, for: key)
+            throw CancellationError()
+        }
+        recordForumMembership(key: key, forum: forum, membership: membership)
+        finishForumOperation(id: id, for: key)
+    }
+
+    private func commitForumReconciliation(
+        id: UUID,
+        key: OperationKey,
+        forum: Forum,
+        membership: ForumMembership?
+    ) throws {
+        guard canMutate(session: key.session), forumOperations[key]?.id == id else {
+            finishForumOperation(id: id, for: key)
+            throw CancellationError()
+        }
+        if let membership {
+            recordForumMembership(key: key, forum: forum, membership: membership)
+        }
+        finishForumOperation(id: id, for: key)
+    }
+
+    private func recordForumMembership(
+        key: OperationKey,
+        forum: Forum,
+        membership: ForumMembership
+    ) {
+        var resolvedForum = forum
+        resolvedForum.id = membership.forumID
+        state.recordForumFollow(
+            accountID: key.session.accountID,
+            forum: resolvedForum,
+            isFollowed: membership.isFollowed
+        )
+    }
+
+    private func commitLikeMutation(id: UUID, key: OperationKey) throws {
+        guard canMutate(session: key.session), likeOperations[key]?.id == id else {
+            finishLikeOperation(id: id, for: key)
+            throw CancellationError()
+        }
+        finishLikeOperation(id: id, for: key)
+    }
+
+    private func finishUserOperation(id: UUID, for key: OperationKey) {
+        guard let operation = userOperations[key], operation.id == id else { return }
+        userOperations[key] = nil
+        state.endUserMutation(accountID: operation.accountID, user: operation.user)
+    }
+
+    private func finishForumOperation(id: UUID, for key: OperationKey) {
+        guard let operation = forumOperations[key], operation.id == id else { return }
+        forumOperations[key] = nil
+        state.endForumMutation(accountID: operation.accountID, forum: operation.forum)
+    }
+
+    private func finishLikeOperation(id: UUID, for key: OperationKey) {
+        guard likeOperations[key]?.id == id else { return }
+        likeOperations[key] = nil
+    }
+
+    private func drainOperations(session: AccountSessionIdentity?) async {
+        while true {
+            let users = userOperations.filter { key, _ in
+                session == nil || key.session == session
+            }
+            let forums = forumOperations.filter { key, _ in
+                session == nil || key.session == session
+            }
+            let likes = likeOperations.filter { key, _ in
+                session == nil || key.session == session
+            }
+            guard users.isEmpty == false || forums.isEmpty == false || likes.isEmpty == false else {
+                return
+            }
+
+            users.values.forEach { $0.task.cancel() }
+            forums.values.forEach { $0.task.cancel() }
+            likes.values.forEach { $0.task.cancel() }
+            for operation in users.values {
+                _ = await operation.task.result
+            }
+            for operation in forums.values {
+                _ = await operation.task.result
+            }
+            for operation in likes.values {
+                _ = await operation.task.result
+            }
+            for (key, operation) in users {
+                finishUserOperation(id: operation.id, for: key)
+            }
+            for (key, operation) in forums {
+                finishForumOperation(id: operation.id, for: key)
+            }
+            for (key, operation) in likes {
+                finishLikeOperation(id: operation.id, for: key)
+            }
         }
     }
 }

--- a/TiebaPure/Core/State/SocialMutationCoordinator.swift
+++ b/TiebaPure/Core/State/SocialMutationCoordinator.swift
@@ -3,6 +3,7 @@ import Foundation
 enum SocialMutationCoordinatorError: Error, Equatable, LocalizedError, CustomStringConvertible {
     case operationInProgress
     case sessionTransition
+    case likesDisabled
 
     var description: String {
         errorDescription ?? "操作失败。"
@@ -14,6 +15,8 @@ enum SocialMutationCoordinatorError: Error, Equatable, LocalizedError, CustomStr
             return "操作正在处理中，请稍候。"
         case .sessionTransition:
             return "账号状态正在切换，请稍后重试。"
+        case .likesDisabled:
+            return "请先在设置中开启“允许点赞”。"
         }
     }
 }
@@ -49,15 +52,21 @@ final class SocialMutationCoordinator {
 
     private let api: any TiebaAPIService
     private let state: SocialRelationshipState
+    private let allowsLikes: @MainActor () -> Bool
     private var userOperations: [OperationKey: UserOperation] = [:]
     private var forumOperations: [OperationKey: ForumOperation] = [:]
     private var likeOperations: [OperationKey: LikeOperation] = [:]
     private var globalInvalidationCount = 0
     private var sessionInvalidationCounts: [AccountSessionIdentity: Int] = [:]
 
-    init(api: any TiebaAPIService, state: SocialRelationshipState) {
+    init(
+        api: any TiebaAPIService,
+        state: SocialRelationshipState,
+        allowsLikes: @escaping @MainActor () -> Bool = { true }
+    ) {
         self.api = api
         self.state = state
+        self.allowsLikes = allowsLikes
     }
 
     func setUserFollowed(account: Account, user: UserSummary, followed: Bool) async throws {
@@ -196,6 +205,9 @@ final class SocialMutationCoordinator {
         let session = account.sessionIdentity
         guard canMutate(session: session) else {
             throw SocialMutationCoordinatorError.sessionTransition
+        }
+        guard allowsLikes() else {
+            throw SocialMutationCoordinatorError.likesDisabled
         }
         let key = OperationKey(
             session: session,

--- a/TiebaPure/Core/UI/MetadataLine.swift
+++ b/TiebaPure/Core/UI/MetadataLine.swift
@@ -167,6 +167,7 @@ struct CompactLikeCountView: View {
         }
         .fixedSize(horizontal: true, vertical: false)
         .foregroundStyle(.secondary)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel("点赞\(count)")
     }
 }

--- a/TiebaPure/Core/UI/ReaderSplitLayout.swift
+++ b/TiebaPure/Core/UI/ReaderSplitLayout.swift
@@ -6,15 +6,18 @@ struct ReaderSplitThreadRoute: Hashable {
     let threadID: Int64
     let forumID: Int64?
     let initialPostID: UInt64?
+    let ownThreadDeletionTarget: OwnThreadDeletionTarget?
 
     init(
         threadID: Int64,
         forumID: Int64?,
-        initialPostID: UInt64? = nil
+        initialPostID: UInt64? = nil,
+        ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil
     ) {
         self.threadID = threadID
         self.forumID = forumID
         self.initialPostID = initialPostID
+        self.ownThreadDeletionTarget = ownThreadDeletionTarget
     }
 }
 
@@ -110,7 +113,8 @@ struct ReaderSplitLayout<Route: Hashable, ListColumn: View, DetailRoot: View>: V
                                 account: account,
                                 threadID: route.threadID,
                                 forumID: route.forumID,
-                                initialPostID: route.initialPostID
+                                initialPostID: route.initialPostID,
+                                ownThreadDeletionTarget: route.ownThreadDeletionTarget
                             )
                             // Replacing the selection must never reuse the
                             // previous thread's loaded state.

--- a/TiebaPure/Domain/Mapping/UserProfileMapper.swift
+++ b/TiebaPure/Domain/Mapping/UserProfileMapper.swift
@@ -66,9 +66,18 @@ enum UserProfileMapper {
         page: Int
     ) -> UserThreadsPage {
         let rawItems = response.data.postList
-        let threads = rawItems
-            .compactMap(thread(from:))
-            .filter(TiebaContentFilter.shouldKeep(thread:))
+        var threads: [ThreadSummary] = []
+        var deletionTargetsByThreadID: [Int64: OwnThreadDeletionTarget] = [:]
+        for item in rawItems {
+            guard let thread = thread(from: item),
+                  TiebaContentFilter.shouldKeep(thread: thread) else {
+                continue
+            }
+            threads.append(thread)
+            if let deletionTarget = deletionTarget(from: item) {
+                deletionTargetsByThreadID[thread.id] = deletionTarget
+            }
+        }
         return UserThreadsPage(
             threads: threads,
             currentPage: page,
@@ -76,7 +85,24 @@ enum UserProfileMapper {
             // server page; keep pagination alive so later visible entries
             // remain reachable.
             hasMore: response.data.hidePost == 0 && rawItems.isEmpty == false,
-            visibility: response.data.hidePost == 0 ? .visible : .privateContent
+            visibility: response.data.hidePost == 0 ? .visible : .privateContent,
+            deletionTargetsByThreadID: deletionTargetsByThreadID
+        )
+    }
+
+    static func deletionTarget(
+        from item: Tiebapure_Profile_UserThreadItem
+    ) -> OwnThreadDeletionTarget? {
+        guard let forumID = Int64(exactly: item.forumID), forumID > 0,
+              let threadID = Int64(exactly: item.threadID), threadID > 0,
+              item.postID > 0 else {
+            return nil
+        }
+        return OwnThreadDeletionTarget(
+            forumID: forumID,
+            forumName: item.forumName,
+            threadID: threadID,
+            firstPostID: item.postID
         )
     }
 

--- a/TiebaPure/Domain/Models/Account.swift
+++ b/TiebaPure/Domain/Models/Account.swift
@@ -12,6 +12,10 @@ struct Account: Codable, Equatable, Identifiable, Sendable {
 
     var id: String { uid }
 
+    var sessionIdentity: AccountSessionIdentity {
+        AccountSessionIdentity(account: self)
+    }
+
     var portraitURL: URL? {
         TiebaURL.avatar(portrait)
     }
@@ -36,4 +40,20 @@ struct Account: Codable, Equatable, Identifiable, Sendable {
         baiduID: nil,
         tbs: ""
     )
+}
+
+/// Identifies the authenticated Baidu session without treating display
+/// metadata or a refreshed TBS value as a different login.
+struct AccountSessionIdentity: Hashable, Sendable {
+    let accountID: String
+    private let bduss: String
+    private let stoken: String
+    private let baiduID: String?
+
+    init(account: Account) {
+        accountID = account.id
+        bduss = account.bduss
+        stoken = account.stoken
+        baiduID = account.baiduID
+    }
 }

--- a/TiebaPure/Domain/Models/ContentSubmissionSettings.swift
+++ b/TiebaPure/Domain/Models/ContentSubmissionSettings.swift
@@ -4,42 +4,83 @@ import SwiftUI
 @MainActor
 final class ContentSubmissionSettingsStore: ObservableObject {
     nonisolated static let liveKey = "dev.infinityf4p.tiebapure.content-submission.replies-enabled"
+    nonisolated static let newThreadsLiveKey = "dev.infinityf4p.tiebapure.content-submission.new-threads-enabled"
+    nonisolated static let likesLiveKey = "dev.infinityf4p.tiebapure.content-submission.likes-enabled"
 
     @Published private(set) var repliesEnabled: Bool
+    @Published private(set) var newThreadsEnabled: Bool
+    @Published private(set) var likesEnabled: Bool
 
     private let defaults: UserDefaults
-    private let key: String
+    private let repliesKey: String
+    private let newThreadsKey: String
+    private let likesKey: String
 
     init(
         defaults: UserDefaults = .standard,
-        key: String = ContentSubmissionSettingsStore.liveKey
+        key: String = ContentSubmissionSettingsStore.liveKey,
+        newThreadsKey: String = ContentSubmissionSettingsStore.newThreadsLiveKey,
+        likesKey: String = ContentSubmissionSettingsStore.likesLiveKey
     ) {
         self.defaults = defaults
-        self.key = key
+        repliesKey = key
+        self.newThreadsKey = newThreadsKey
+        self.likesKey = likesKey
         repliesEnabled = defaults.bool(forKey: key)
+        newThreadsEnabled = Self.readDefaultOnSetting(defaults: defaults, key: newThreadsKey)
+        likesEnabled = Self.readDefaultOnSetting(defaults: defaults, key: likesKey)
     }
 
     func setRepliesEnabled(_ isEnabled: Bool) {
         guard repliesEnabled != isEnabled else { return }
         if isEnabled {
-            defaults.set(true, forKey: key)
+            defaults.set(true, forKey: repliesKey)
         } else {
-            defaults.removeObject(forKey: key)
+            defaults.removeObject(forKey: repliesKey)
         }
         repliesEnabled = isEnabled
     }
 
+    func setNewThreadsEnabled(_ isEnabled: Bool) {
+        guard newThreadsEnabled != isEnabled else { return }
+        persistDefaultOnSetting(isEnabled, key: newThreadsKey)
+        newThreadsEnabled = isEnabled
+    }
+
+    func setLikesEnabled(_ isEnabled: Bool) {
+        guard likesEnabled != isEnabled else { return }
+        persistDefaultOnSetting(isEnabled, key: likesKey)
+        likesEnabled = isEnabled
+    }
+
     func reset() {
-        defaults.removeObject(forKey: key)
+        defaults.removeObject(forKey: repliesKey)
+        defaults.removeObject(forKey: newThreadsKey)
+        defaults.removeObject(forKey: likesKey)
         repliesEnabled = false
+        newThreadsEnabled = true
+        likesEnabled = true
     }
 
     func allowsSubmission(kind: ContentSubmissionKind) -> Bool {
         switch kind {
         case .newThread:
-            return true
+            return newThreadsEnabled
         case .threadReply, .postReply, .subpostReply:
             return repliesEnabled
+        }
+    }
+
+    private static func readDefaultOnSetting(defaults: UserDefaults, key: String) -> Bool {
+        guard defaults.object(forKey: key) != nil else { return true }
+        return defaults.bool(forKey: key)
+    }
+
+    private func persistDefaultOnSetting(_ isEnabled: Bool, key: String) {
+        if isEnabled {
+            defaults.removeObject(forKey: key)
+        } else {
+            defaults.set(false, forKey: key)
         }
     }
 }

--- a/TiebaPure/Domain/Models/ContentSubmissionSettings.swift
+++ b/TiebaPure/Domain/Models/ContentSubmissionSettings.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ContentSubmissionSettingsStore: ObservableObject {
+    nonisolated static let liveKey = "dev.infinityf4p.tiebapure.content-submission.replies-enabled"
+
+    @Published private(set) var repliesEnabled: Bool
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        key: String = ContentSubmissionSettingsStore.liveKey
+    ) {
+        self.defaults = defaults
+        self.key = key
+        repliesEnabled = defaults.bool(forKey: key)
+    }
+
+    func setRepliesEnabled(_ isEnabled: Bool) {
+        guard repliesEnabled != isEnabled else { return }
+        if isEnabled {
+            defaults.set(true, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        repliesEnabled = isEnabled
+    }
+
+    func reset() {
+        defaults.removeObject(forKey: key)
+        repliesEnabled = false
+    }
+
+    func allowsSubmission(kind: ContentSubmissionKind) -> Bool {
+        switch kind {
+        case .newThread:
+            return true
+        case .threadReply, .postReply, .subpostReply:
+            return repliesEnabled
+        }
+    }
+}

--- a/TiebaPure/Domain/Models/RecentForum.swift
+++ b/TiebaPure/Domain/Models/RecentForum.swift
@@ -205,6 +205,29 @@ final class RecentForumStore: ObservableObject {
         ))
     }
 
+    @discardableResult
+    func clear() -> Bool {
+        guard persistentBackendIsAvailable else {
+            persistenceAvailability = .unavailable
+            return false
+        }
+        do {
+            try PersistedRecordStore.replaceAll(
+                RecentForumRecord.self,
+                with: [],
+                in: modelContext
+            )
+            defaults.removeObject(forKey: key)
+            items = []
+            markPersistenceSucceeded()
+            return true
+        } catch {
+            PersistenceDiagnostics.report(error, operation: "clear recent forums")
+            persistenceAvailability = .unavailable
+            return false
+        }
+    }
+
     private func save(_ recent: RecentForum) -> Bool {
         guard persistentBackendIsAvailable else {
             persistenceAvailability = .unavailable

--- a/TiebaPure/Domain/Models/UserProfile.swift
+++ b/TiebaPure/Domain/Models/UserProfile.swift
@@ -31,6 +31,34 @@ enum UserProfileSex: Equatable, Sendable {
             return "性别未公开"
         }
     }
+
+    var profileMutationProtocolValue: Int? {
+        switch self {
+        case .unspecified:
+            return nil
+        case .male:
+            return 1
+        case .female:
+            return 2
+        }
+    }
+}
+
+struct UserProfileEditRequest: Equatable, Sendable {
+    var nickname: String
+    var introduction: String
+    var sex: UserProfileSex
+
+    var normalizedNickname: String {
+        nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct OwnThreadDeletionTarget: Equatable, Hashable, Sendable {
+    var forumID: Int64
+    var forumName: String
+    var threadID: Int64
+    var firstPostID: UInt64
 }
 
 struct UserProfile: Equatable, Sendable {
@@ -57,6 +85,113 @@ struct UserThreadsPage: Equatable, Sendable {
     var currentPage: Int
     var hasMore: Bool
     var visibility: UserContentVisibility
+    var deletionTargetsByThreadID: [Int64: OwnThreadDeletionTarget] = [:]
+}
+
+enum UserProfileManagementPolicy {
+    static func canEdit(profile: UserProfile, account: Account?) -> Bool {
+        guard profile.isCurrentUser, let account else { return false }
+        if let accountID = Int64(account.uid), accountID > 0, profile.user.id > 0 {
+            return accountID == profile.user.id
+        }
+        return account.name.isEmpty == false && account.name == profile.user.name
+    }
+
+    static func deletionTarget(
+        profile: UserProfile?,
+        account: Account?,
+        threadID: Int64,
+        targetsByThreadID: [Int64: OwnThreadDeletionTarget]
+    ) -> OwnThreadDeletionTarget? {
+        guard let profile,
+              canEdit(profile: profile, account: account),
+              let target = targetsByThreadID[threadID],
+              target.threadID == threadID,
+              target.forumID > 0,
+              target.firstPostID > 0 else {
+            return nil
+        }
+        return target
+    }
+
+    static func threadDetailDeletionTarget(
+        account: Account?,
+        threadID: Int64,
+        page: ThreadPage?,
+        explicitTarget: OwnThreadDeletionTarget?
+    ) -> OwnThreadDeletionTarget? {
+        guard let account,
+              let accountID = Int64(account.uid),
+              accountID > 0,
+              threadID > 0,
+              let page,
+              page.thread.id == threadID,
+              let mainPost = page.mainPost ?? page.posts.first(where: { $0.floor == 1 }),
+              mainPost.id > 0,
+              mainPost.author.id == accountID else {
+            return nil
+        }
+
+        if let explicitTarget,
+           explicitTarget.threadID == threadID,
+           explicitTarget.forumID > 0,
+           explicitTarget.firstPostID == mainPost.id,
+           explicitTarget.forumName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return explicitTarget
+        }
+
+        let forumName = page.forum.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard page.forum.id > 0, forumName.isEmpty == false else { return nil }
+        return OwnThreadDeletionTarget(
+            forumID: page.forum.id,
+            forumName: forumName,
+            threadID: threadID,
+            firstPostID: mainPost.id
+        )
+    }
+
+    static func updatedAccount(
+        _ account: Account,
+        applying request: UserProfileEditRequest
+    ) -> Account {
+        var updated = account
+        updated.displayName = request.normalizedNickname
+        return updated
+    }
+
+    static func updatedProfile(
+        _ profile: UserProfile,
+        applying request: UserProfileEditRequest
+    ) -> UserProfile {
+        var updated = profile
+        updated.user.displayName = request.normalizedNickname
+        updated.intro = request.introduction
+        if request.sex != .unspecified {
+            updated.sex = request.sex
+        }
+        return updated
+    }
+
+    static func profile(
+        _ profile: UserProfile,
+        confirms request: UserProfileEditRequest
+    ) -> Bool {
+        guard profile.user.displayNameResolved == request.normalizedNickname,
+              profile.intro == request.introduction else {
+            return false
+        }
+        return request.sex == .unspecified || profile.sex == request.sex
+    }
+}
+
+enum OwnThreadDeletionDispatchPolicy {
+    static func canSubmit(
+        hasValidatedTarget: Bool,
+        isSubmitting: Bool,
+        hasUnconfirmedOutcome: Bool
+    ) -> Bool {
+        hasValidatedTarget && isSubmitting == false && hasUnconfirmedOutcome == false
+    }
 }
 
 enum UserRelationshipKind: String, CaseIterable, Equatable, Hashable, Sendable {

--- a/TiebaPure/Features/Compose/ContentComposerView.swift
+++ b/TiebaPure/Features/Compose/ContentComposerView.swift
@@ -310,6 +310,7 @@ struct ContentComposerView: View {
                     systemImage: "exclamationmark.triangle.fill",
                     tint: .red
                 )
+                .accessibilityIdentifier("content-composer-submission-error")
             }
         }
     }

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -111,13 +111,13 @@ struct ForumThreadsView: View {
             guard didLoad == false else { return }
             await reload()
         }
-        .task(id: account?.id) {
+        .task(id: account?.sessionIdentity) {
             await loadForumMembership()
         }
-        .onChange(of: account) { _ in
+        .onChange(of: account?.sessionIdentity) { _ in
             cancelSubmissionNavigation()
-            loadTask?.cancel()
             requestGeneration += 1
+            loadTask?.cancel()
             activeRequestKey = nil
             threads = []
             page = 1
@@ -232,7 +232,7 @@ struct ForumThreadsView: View {
                     target: route.target,
                     onDismiss: { composerRoute = nil },
                     onSent: { receipt in
-                        guard self.account == account,
+                        guard self.account?.sessionIdentity == account.sessionIdentity,
                               composerRoute?.id == route.id,
                               presentationGeneration == submissionNavigationGeneration else { return }
                         pendingSubmissionReceipt = receipt
@@ -574,6 +574,7 @@ struct ForumThreadsView: View {
     ) async {
         guard isLoading == false, hasMore else { return }
         let requestedAccountID = account?.id
+        let requestedSession = account?.sessionIdentity
         let requestedPage = page
         let requestKey = ForumThreadsRequestKey(
             accountID: requestedAccountID,
@@ -600,7 +601,7 @@ struct ForumThreadsView: View {
             let next = try await task.value
             guard generation == requestGeneration,
                   requestKey == activeRequestKey,
-                  requestedAccountID == account?.id,
+                  requestedSession == account?.sessionIdentity,
                   requestKey.category == selectedCategory else { return }
             let visibleNext = next.filter(TiebaContentFilter.shouldKeep(thread:))
             if requestedPage == 1 {
@@ -619,7 +620,8 @@ struct ForumThreadsView: View {
             )
         } catch is CancellationError {
             guard generation == requestGeneration,
-                  requestKey == activeRequestKey else { return }
+                  requestKey == activeRequestKey,
+                  requestedSession == account?.sessionIdentity else { return }
             loadTask = nil
             activeRequestKey = nil
             isLoading = false
@@ -627,12 +629,13 @@ struct ForumThreadsView: View {
         } catch {
             guard generation == requestGeneration,
                   requestKey == activeRequestKey,
-                  requestedAccountID == account?.id,
+                  requestedSession == account?.sessionIdentity,
                   requestKey.category == selectedCategory else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
         }
         guard generation == requestGeneration,
-              requestKey == activeRequestKey else { return }
+              requestKey == activeRequestKey,
+              requestedSession == account?.sessionIdentity else { return }
         loadTask = nil
         activeRequestKey = nil
         isLoading = false
@@ -680,7 +683,7 @@ struct ForumThreadsView: View {
         pendingSubmissionForumID = nil
         pendingSubmissionAccount = nil
         pendingSubmissionRouteID = nil
-        guard account == submittedAccount else { return }
+        guard account?.sessionIdentity == submittedAccount.sessionIdentity else { return }
 
         submissionNavigationTask?.cancel()
         submissionNavigationGeneration += 1
@@ -690,7 +693,7 @@ struct ForumThreadsView: View {
             await reload()
             guard Task.isCancelled == false,
                   generation == submissionNavigationGeneration,
-                  account == submittedAccount,
+                  account?.sessionIdentity == submittedAccount.sessionIdentity,
                   composerRoute == nil else { return }
             openThread(threadID: receipt.threadID, forumID: submittedForumID ?? forum.id)
             submissionNavigationTask = nil
@@ -734,7 +737,7 @@ struct ForumThreadsView: View {
         }
         socialGeneration += 1
         let generation = socialGeneration
-        let requestedAccountID = account.id
+        let requestedSession = account.sessionIdentity
         if let known = environment.socialRelationshipState.forumFollowState(
             accountID: account.id,
             forum: forum
@@ -750,7 +753,8 @@ struct ForumThreadsView: View {
             let task = Task { try await environment.api.forumMembership(account: account, forum: forum) }
             membershipTask = task
             let membership = try await task.value
-            guard generation == socialGeneration, requestedAccountID == self.account?.id else { return }
+            guard generation == socialGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             let followed = environment.socialRelationshipState.forumFollowOverride(
                 accountID: account.id,
                 forum: forum
@@ -765,10 +769,12 @@ struct ForumThreadsView: View {
             )
             membershipTask = nil
         } catch is CancellationError {
-            guard generation == socialGeneration else { return }
+            guard generation == socialGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             membershipTask = nil
         } catch {
-            guard generation == socialGeneration, requestedAccountID == self.account?.id else { return }
+            guard generation == socialGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             membershipTask = nil
             if forumMembership == nil {
                 forumActionError = ReaderErrorMessage.message(for: error)
@@ -789,7 +795,7 @@ struct ForumThreadsView: View {
         let targetState = forumMembership?.isFollowed != true
         socialGeneration += 1
         let generation = socialGeneration
-        let requestedAccountID = account.id
+        let requestedSession = account.sessionIdentity
         isUpdatingForumFollow = true
         forumActionError = nil
         membershipTask?.cancel()
@@ -803,16 +809,19 @@ struct ForumThreadsView: View {
                     followed: targetState
                 )
                 try Task.checkCancellation()
-                guard generation == socialGeneration, requestedAccountID == self.account?.id else { return }
+                guard generation == socialGeneration,
+                      requestedSession == self.account?.sessionIdentity else { return }
                 forumMembership = membership
             } catch is CancellationError {
                 // The coordinator owns the write and its read-only
                 // reconciliation after this page disappears.
             } catch {
-                guard generation == socialGeneration, requestedAccountID == self.account?.id else { return }
+                guard generation == socialGeneration,
+                      requestedSession == self.account?.sessionIdentity else { return }
                 forumActionError = ReaderErrorMessage.message(for: error)
             }
-            guard generation == socialGeneration, requestedAccountID == self.account?.id else { return }
+            guard generation == socialGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             forumFollowTask = nil
             isUpdatingForumFollow = environment.socialRelationshipState.isForumMutationPending(
                 accountID: account.id,

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ForumThreadsView: View {
     @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     @Environment(\.readerSplitOpenThread) private var readerSplitOpenThread
     @Environment(\.dismiss) private var dismiss
     let account: Account?
@@ -179,16 +180,18 @@ struct ForumThreadsView: View {
                 .accessibilityHint(account == nil ? "登录后可以关注贴吧" : "切换当前贴吧的关注状态")
                 .accessibilityIdentifier("forum-follow-button")
 
-                Button {
-                    openNewThreadComposer()
-                } label: {
-                    Image(systemName: "square.and.pencil")
+                if contentSubmissionSettingsStore.newThreadsEnabled {
+                    Button {
+                        openNewThreadComposer()
+                    } label: {
+                        Image(systemName: "square.and.pencil")
+                    }
+                    .minTouchTarget()
+                    .accessibilityLabel("发布新帖")
+                    .accessibilityHint(newThreadAccessibilityHint)
+                    .accessibilityIdentifier("forum-new-thread-button")
+                    .disabled(account != nil && resolvedPostingForum == nil)
                 }
-                .minTouchTarget()
-                .accessibilityLabel("发布新帖")
-                .accessibilityHint(newThreadAccessibilityHint)
-                .accessibilityIdentifier("forum-new-thread-button")
-                .disabled(account != nil && resolvedPostingForum == nil)
 
                 Button {
                     launchSearch(.toolbarButton)
@@ -662,6 +665,10 @@ struct ForumThreadsView: View {
     }
 
     private func openNewThreadComposer() {
+        guard contentSubmissionSettingsStore.newThreadsEnabled else {
+            forumActionError = "请先在设置中开启“允许发帖”。"
+            return
+        }
         guard account != nil else {
             forumActionError = "登录后才能发布新帖。"
             return

--- a/TiebaPure/Features/ForumHub/ForumHubView.swift
+++ b/TiebaPure/Features/ForumHub/ForumHubView.swift
@@ -137,9 +137,9 @@ struct ForumHubView: View {
             guard let account, didLoadFollowed == false else { return }
             await loadFollowed(account: account)
         }
-        .onChange(of: account?.id) { _ in
-            loadTask?.cancel()
+        .onChange(of: account?.sessionIdentity) { _ in
             requestGeneration += 1
+            loadTask?.cancel()
             followedForums = []
             followedError = nil
             didLoadFollowed = false
@@ -176,6 +176,7 @@ struct ForumHubView: View {
                     threadID: threadRoute.threadID,
                     forumID: threadRoute.forumID,
                     initialPostID: threadRoute.initialPostID,
+                    ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget,
                     openSearchInParent: { scope in
                         openSearch(scope)
                     },
@@ -283,6 +284,7 @@ struct ForumHubView: View {
         requestGeneration += 1
         let generation = requestGeneration
         let accountID = account.id
+        let requestedSession = account.sessionIdentity
         isLoadingFollowed = true
         followedError = nil
 
@@ -290,7 +292,8 @@ struct ForumHubView: View {
             let task = Task { try await environment.api.followedForums(account: account) }
             loadTask = task
             let loaded = try await task.value
-            guard generation == requestGeneration, accountID == self.account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             followedForums = environment.socialRelationshipState.reconciledFollowedForums(
                 accountID: accountID,
                 loaded: loaded
@@ -300,15 +303,18 @@ struct ForumHubView: View {
                 forums: followedForums
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             loadTask = nil
             isLoadingFollowed = false
             return
         } catch {
-            guard generation == requestGeneration, accountID == self.account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             followedError = ReaderErrorMessage.message(for: error)
         }
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == self.account?.sessionIdentity else { return }
         loadTask = nil
         isLoadingFollowed = false
         didLoadFollowed = true

--- a/TiebaPure/Features/ForumList/ForumListView.swift
+++ b/TiebaPure/Features/ForumList/ForumListView.swift
@@ -96,7 +96,7 @@ struct ForumListView: View {
             await reload()
         }
         .onReceive(environment.accountStore.accountDidChange) { current in
-            guard current?.id != account.id else { return }
+            guard current?.sessionIdentity != account.sessionIdentity else { return }
             loadTask?.cancel()
             requestGeneration += 1
             forums = []
@@ -198,6 +198,7 @@ struct ForumListView: View {
         loadTask?.cancel()
         requestGeneration += 1
         let generation = requestGeneration
+        let requestedSession = account.sessionIdentity
         isLoading = true
         errorMessage = nil
 
@@ -205,7 +206,8 @@ struct ForumListView: View {
             let task = Task { try await environment.api.followedForums(account: account) }
             loadTask = task
             let loaded = try await task.value
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account.sessionIdentity else { return }
             forums = environment.socialRelationshipState.reconciledFollowedForums(
                 accountID: account.id,
                 loaded: loaded
@@ -215,15 +217,18 @@ struct ForumListView: View {
                 forums: forums
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account.sessionIdentity else { return }
             loadTask = nil
             isLoading = false
             return
         } catch {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account.sessionIdentity else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
         }
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == account.sessionIdentity else { return }
         loadTask = nil
         isLoading = false
         didLoad = true

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -97,11 +97,13 @@ struct HomeView: View {
         }
         .navigationDestination(for: HomeNavigationRoute.self) { route in
             switch route {
-            case let .thread(threadID, forumID):
+            case let .thread(threadRoute):
                 ThreadDetailView(
                     account: account,
-                    threadID: threadID,
-                    forumID: forumID
+                    threadID: threadRoute.threadID,
+                    forumID: threadRoute.forumID,
+                    initialPostID: threadRoute.initialPostID,
+                    ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget
                 )
                 .interactiveNavigationPopStateSync {
                     removeNavigationRouteIfCurrent(route)
@@ -154,9 +156,9 @@ struct HomeView: View {
             }
             programmaticRefreshToken &+= 1
         }
-        .onChange(of: account?.id) { _ in
-            loadTask?.cancel()
+        .onChange(of: account?.sessionIdentity) { _ in
             requestGeneration += 1
+            loadTask?.cancel()
             threads = []
             page = 1
             hasMore = true
@@ -237,11 +239,12 @@ struct HomeView: View {
     }
 
     private func openThread(threadID: Int64, forumID: Int64?) {
+        let route = ReaderSplitThreadRoute(threadID: threadID, forumID: forumID)
         if usesSplitDetailLayout {
-            openThreadInSplitDetail(ReaderSplitThreadRoute(threadID: threadID, forumID: forumID))
+            openThreadInSplitDetail(route)
             return
         }
-        navigationPath.append(.thread(threadID: threadID, forumID: forumID))
+        navigationPath.append(.thread(route))
     }
 
     private func openThreadInSplitDetail(_ route: ReaderSplitThreadRoute) {
@@ -252,9 +255,7 @@ struct HomeView: View {
     }
 
     private func openThreadInCompactStack(_ route: ReaderSplitThreadRoute) {
-        navigationPath.append(
-            .thread(threadID: route.threadID, forumID: route.forumID)
-        )
+        navigationPath.append(.thread(route))
     }
 
     private func openThreadFromNestedForum(_ route: ReaderSplitThreadRoute) {
@@ -268,18 +269,13 @@ struct HomeView: View {
     /// Keeps the open thread when the split layout appears or collapses
     /// mid-session (e.g. iPad Split View resizes across the width threshold).
     private func foldNavigationForSizeClassChange(to sizeClass: UserInterfaceSizeClass?) {
-        switch sizeClass {
-        case .compact:
-            guard let route = splitDetailPath.last else { return }
-            splitDetailPath = []
-            navigationPath.append(.thread(threadID: route.threadID, forumID: route.forumID))
-        case .regular:
-            guard case let .thread(threadID, forumID)? = navigationPath.last else { return }
-            navigationPath.removeLast()
-            splitDetailPath = [ReaderSplitThreadRoute(threadID: threadID, forumID: forumID)]
-        default:
-            break
-        }
+        let bridged = HomeSplitDetailBridgePolicy.state(
+            changingTo: sizeClass,
+            navigationPath: navigationPath,
+            splitDetail: splitDetailPath.last
+        )
+        navigationPath = bridged.navigationPath
+        splitDetailPath = bridged.splitDetail.map { [$0] } ?? []
     }
 
     @ViewBuilder
@@ -477,7 +473,7 @@ struct HomeView: View {
             pendingPaginationRequest = true
             return
         }
-        let requestedAccountID = account?.id
+        let requestedSession = account?.sessionIdentity
         isLoading = true
         errorMessage = nil
         var continuation: LocallyFilteredPaginationDecision?
@@ -494,7 +490,7 @@ struct HomeView: View {
             loadTask = task
             let next = try await task.value
             guard generation == requestGeneration,
-                  requestedAccountID == account?.id else { return }
+                  requestedSession == account?.sessionIdentity else { return }
             let visibleNext = next.filter(TiebaContentFilter.shouldKeep(thread:))
             if requestedPage == 1 {
                 threads = HomeFeedMerge.refresh(existing: threads, incoming: visibleNext)
@@ -511,17 +507,20 @@ struct HomeView: View {
                 consecutiveHiddenPageCount: consecutiveHiddenPageCount
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             loadTask = nil
             isLoading = false
             pendingPaginationRequest = false
             paginationRequestScheduled = false
             return
         } catch {
-            guard generation == requestGeneration, requestedAccountID == account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
         }
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == account?.sessionIdentity else { return }
         loadTask = nil
         isLoading = false
         didLoad = true
@@ -668,8 +667,8 @@ enum HomeMediaActionPolicy {
     }
 }
 
-private enum HomeNavigationRoute: Hashable {
-    case thread(threadID: Int64, forumID: Int64?)
+enum HomeNavigationRoute: Hashable {
+    case thread(ReaderSplitThreadRoute)
     case forum(id: Int64, name: String, displayName: String, avatarURL: URL?)
 
     static func fromForum(_ forum: Forum) -> HomeNavigationRoute {
@@ -679,5 +678,48 @@ private enum HomeNavigationRoute: Hashable {
             displayName: forum.displayName,
             avatarURL: forum.avatarURL
         )
+    }
+}
+
+struct HomeSplitDetailBridgeState: Equatable {
+    var navigationPath: [HomeNavigationRoute]
+    var splitDetail: ReaderSplitThreadRoute?
+}
+
+enum HomeSplitDetailBridgePolicy {
+    static func state(
+        changingTo sizeClass: UserInterfaceSizeClass?,
+        navigationPath: [HomeNavigationRoute],
+        splitDetail: ReaderSplitThreadRoute?
+    ) -> HomeSplitDetailBridgeState {
+        switch sizeClass {
+        case .compact:
+            guard let splitDetail else {
+                return HomeSplitDetailBridgeState(
+                    navigationPath: navigationPath,
+                    splitDetail: nil
+                )
+            }
+            return HomeSplitDetailBridgeState(
+                navigationPath: navigationPath + [.thread(splitDetail)],
+                splitDetail: nil
+            )
+        case .regular:
+            guard case let .thread(compactDetail)? = navigationPath.last else {
+                return HomeSplitDetailBridgeState(
+                    navigationPath: navigationPath,
+                    splitDetail: splitDetail
+                )
+            }
+            return HomeSplitDetailBridgeState(
+                navigationPath: Array(navigationPath.dropLast()),
+                splitDetail: compactDetail
+            )
+        default:
+            return HomeSplitDetailBridgeState(
+                navigationPath: navigationPath,
+                splitDetail: splitDetail
+            )
+        }
     }
 }

--- a/TiebaPure/Features/Media/VideoPreviewTransition.swift
+++ b/TiebaPure/Features/Media/VideoPreviewTransition.swift
@@ -19,6 +19,120 @@ enum VideoPreviewPlaybackPolicy {
     }
 }
 
+enum VideoPreviewDismissAxis: Equatable {
+    case horizontalRight
+    case vertical
+}
+
+enum VideoPreviewDismissGesturePolicy {
+    private static let horizontalDominance: CGFloat = 1.15
+
+    static func axis(velocity: CGPoint) -> VideoPreviewDismissAxis? {
+        let horizontalSpeed = abs(velocity.x)
+        let verticalSpeed = abs(velocity.y)
+        guard horizontalSpeed > 0 || verticalSpeed > 0 else { return nil }
+
+        if horizontalSpeed > verticalSpeed * horizontalDominance {
+            return velocity.x > 0 ? .horizontalRight : nil
+        }
+        return .vertical
+    }
+
+    static func adjustedTranslation(
+        _ translation: CGPoint,
+        for axis: VideoPreviewDismissAxis
+    ) -> CGPoint {
+        switch axis {
+        case .horizontalRight:
+            return CGPoint(x: max(translation.x, 0), y: translation.y)
+        case .vertical:
+            return translation
+        }
+    }
+
+    static func shouldDismiss(
+        translation: CGPoint,
+        velocity: CGPoint,
+        axis: VideoPreviewDismissAxis,
+        viewportSize: CGSize
+    ) -> Bool {
+        switch axis {
+        case .horizontalRight:
+            let distanceThreshold = min(max(viewportSize.width * 0.24, 88), 160)
+            return translation.x >= distanceThreshold
+                || (translation.x >= 44 && velocity.x >= 900)
+        case .vertical:
+            let distanceThreshold = min(max(viewportSize.height * 0.18, 120), 180)
+            return abs(translation.y) >= distanceThreshold
+                || (abs(translation.y) >= 60 && abs(velocity.y) >= 1_000)
+        }
+    }
+
+    static func backgroundOpacity(
+        translation: CGPoint,
+        viewportSize: CGSize
+    ) -> CGFloat {
+        let diagonal = hypot(translation.x, translation.y)
+        let reference = max(min(viewportSize.width, viewportSize.height) * 0.65, 1)
+        return max(0.28, 1 - min(diagonal / reference, 1) * 0.72)
+    }
+}
+
+@MainActor
+enum VideoPreviewGestureTouchPolicy {
+    static func allowsDismissGesture(startingAt view: UIView?) -> Bool {
+        var candidate = view
+        while let current = candidate {
+            if current is UISlider || current.accessibilityTraits.contains(.adjustable) {
+                return false
+            }
+            candidate = current.superview
+        }
+        return true
+    }
+}
+
+struct VideoPreviewDismissalLifecycleState {
+    enum Phase: Equatable {
+        case active
+        case dismissing
+        case finished
+    }
+
+    private(set) var phase: Phase = .active
+
+    var dismissalStarted: Bool {
+        phase != .active
+    }
+
+    mutating func begin() -> Bool {
+        guard phase == .active else { return false }
+        phase = .dismissing
+        return true
+    }
+
+    mutating func finish() -> Bool {
+        guard phase == .dismissing else { return false }
+        phase = .finished
+        return true
+    }
+
+    mutating func cancel() -> Bool {
+        guard phase == .dismissing else { return false }
+        phase = .active
+        return true
+    }
+}
+
+enum VideoPreviewDetachmentPolicy {
+    static func shouldFinishDismissal(
+        hasPresentingController: Bool,
+        isInWindow: Bool
+    ) -> Bool {
+        hasPresentingController == false && isInWindow == false
+    }
+}
+
 struct VideoPreviewSession: Identifiable {
     let id = UUID()
     let video: VideoContent
@@ -334,6 +448,7 @@ private final class MediaPreviewSafariDriver: NSObject,
 private final class VideoPreviewController: UIViewController,
     UIAdaptivePresentationControllerDelegate,
     UIViewControllerTransitioningDelegate,
+    UIGestureRecognizerDelegate,
     MediaPreviewHeroTransitionParticipant {
     let session: VideoPreviewSession
 
@@ -344,7 +459,6 @@ private final class VideoPreviewController: UIViewController,
     private let failureView = UIView()
     private let failureLabel = UILabel()
     private let retryButton = UIButton(type: .system)
-    private let closeButton = UIButton(type: .system)
     private let onDismissalBegan: (UUID) -> Void
     private let onDismissalFinished: (UUID) -> Void
     private let onPresentationCancelled: (UUID) -> Void
@@ -357,13 +471,18 @@ private final class VideoPreviewController: UIViewController,
     private var voicePlaybackObserver: NSObjectProtocol?
     private var backgroundObserver: NSObjectProtocol?
     private var posterAnimator: UIViewPropertyAnimator?
+    private var gestureRestoreAnimator: UIViewPropertyAnimator?
     private var dismissalInteractionGate: MediaPreviewDismissalInteractionGate?
     private var didCancelPresentation = false
     private var didFinishPresentation = false
-    private var didBeginDismissal = false
-    private var didFinishDismissal = false
+    private var dismissalLifecycle = VideoPreviewDismissalLifecycleState()
     private var didReleasePlayer = false
     private var firstFrameReady = false
+    private lazy var dismissPanGestureRecognizer = UIPanGestureRecognizer(
+        target: self,
+        action: #selector(handleDismissPan(_:))
+    )
+    private var activeDismissAxis: VideoPreviewDismissAxis?
 
     init(
         session: VideoPreviewSession,
@@ -390,6 +509,7 @@ private final class VideoPreviewController: UIViewController,
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .black
+        view.isOpaque = false
 
         playerController.player = player
         playerController.showsPlaybackControls = true
@@ -400,7 +520,7 @@ private final class VideoPreviewController: UIViewController,
         playerController.didMove(toParent: self)
 
         configureContentOverlay()
-        configureCloseButton()
+        configureDismissGesture()
         installPlayerItem()
         observePlayback()
     }
@@ -408,17 +528,27 @@ private final class VideoPreviewController: UIViewController,
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         playerController.view.frame = view.bounds
-        closeButton.frame = CGRect(
-            x: view.bounds.maxX - view.safeAreaInsets.right - 60,
-            y: view.safeAreaInsets.top + 16,
-            width: 44,
-            height: 44
-        )
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         presentationController?.delegate = self
+        finishPresentationIfNeeded()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard isBeingDismissed else {
+            return
+        }
+        beginDismissalIfNeeded()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        DispatchQueue.main.async { [weak self] in
+            self?.finishDetachedDismissalIfNeeded()
+        }
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -488,16 +618,17 @@ private final class VideoPreviewController: UIViewController,
         dismissedView: UIView,
         containerView: UIView
     ) -> MediaPreviewHeroDismissalContent? {
-        _ = containerView
         guard firstFrameReady == false,
               let image = session.sourceImage ?? sourceView.image else {
             return nil
         }
+        let posterBounds = posterView.convert(posterView.bounds, to: containerView)
         return MediaPreviewHeroDismissalContent(
             image: image,
             frame: ImagePreviewTransitionGeometry.aspectFitFrame(
                 imageSize: image.size,
-                in: dismissedView.frame
+                in: ImagePreviewTransitionGeometry.validSourceFrame(posterBounds)
+                    ?? dismissedView.frame
             )
         )
     }
@@ -520,8 +651,7 @@ private final class VideoPreviewController: UIViewController,
     }
 
     func beginDismissalIfNeeded() {
-        guard didBeginDismissal == false else { return }
-        didBeginDismissal = true
+        guard dismissalLifecycle.begin() else { return }
         prepareForDismissal()
         onDismissalBegan(session.id)
         if let window = view.window {
@@ -538,8 +668,7 @@ private final class VideoPreviewController: UIViewController,
     }
 
     func finishDismissalIfNeeded() {
-        guard didFinishDismissal == false else { return }
-        didFinishDismissal = true
+        guard dismissalLifecycle.finish() else { return }
         releasePlayer()
         let finish = onDismissalFinished
         let sessionID = session.id
@@ -561,32 +690,34 @@ private final class VideoPreviewController: UIViewController,
     }
 
     func heroDismissalDidCancel() {
-        didBeginDismissal = false
-        didFinishDismissal = false
+        guard dismissalLifecycle.cancel() else { return }
         dismissalInteractionGate?.cancel()
         dismissalInteractionGate = nil
+        restoreVideoAfterCancelledDismissal(animated: false)
         playerController.showsPlaybackControls = true
         updatePosterVisibility(animated: false)
         updatePlaybackState()
         onDismissalCancelled(session.id)
     }
 
-    @objc
-    private func close() {
+    @discardableResult
+    private func requestDismissal() -> Bool {
         guard presentingViewController != nil,
-              isBeingDismissed == false else {
-            return
+              isBeingDismissed == false,
+              dismissalLifecycle.phase == .active else {
+            return false
         }
         beginDismissalIfNeeded()
         dismiss(animated: ImagePreviewTransitionMotionPolicy.animationsEnabled) { [weak self] in
             self?.finishDismissalIfNeeded()
         }
+        return true
     }
 
     @objc
     private func retryPlayback() {
         guard didReleasePlayer == false,
-              didBeginDismissal == false else {
+              dismissalLifecycle.phase == .active else {
             return
         }
         failureView.isHidden = true
@@ -658,16 +789,11 @@ private final class VideoPreviewController: UIViewController,
         ])
     }
 
-    private func configureCloseButton() {
-        var configuration = UIButton.Configuration.filled()
-        configuration.image = UIImage(systemName: "xmark")
-        configuration.baseForegroundColor = .white
-        configuration.baseBackgroundColor = UIColor.black.withAlphaComponent(0.45)
-        configuration.cornerStyle = .capsule
-        closeButton.configuration = configuration
-        closeButton.addTarget(self, action: #selector(close), for: .touchUpInside)
-        closeButton.accessibilityLabel = "关闭视频"
-        view.addSubview(closeButton)
+    private func configureDismissGesture() {
+        dismissPanGestureRecognizer.maximumNumberOfTouches = 1
+        dismissPanGestureRecognizer.cancelsTouchesInView = false
+        dismissPanGestureRecognizer.delegate = self
+        view.addGestureRecognizer(dismissPanGestureRecognizer)
     }
 
     private func installPlayerItem() {
@@ -775,7 +901,7 @@ private final class VideoPreviewController: UIViewController,
     private func updatePlaybackState() {
         guard VideoPreviewPlaybackPolicy.shouldPlay(
             presentationFinished: didFinishPresentation,
-            dismissalStarted: didBeginDismissal
+            dismissalStarted: dismissalLifecycle.dismissalStarted
         ), didReleasePlayer == false else {
             player.pause()
             return
@@ -787,7 +913,7 @@ private final class VideoPreviewController: UIViewController,
     private func updatePosterVisibility(animated: Bool) {
         let keepsPoster = VideoPreviewPlaybackPolicy.keepsPosterVisible(
             firstFrameReady: firstFrameReady,
-            dismissalStarted: didBeginDismissal
+            dismissalStarted: dismissalLifecycle.dismissalStarted
         )
         let targetAlpha: CGFloat = keepsPoster && posterView.image != nil ? 1 : 0
         guard posterView.alpha != targetAlpha else { return }
@@ -805,6 +931,8 @@ private final class VideoPreviewController: UIViewController,
     }
 
     private func prepareForDismissal() {
+        gestureRestoreAnimator?.stopAnimation(true)
+        gestureRestoreAnimator = nil
         posterAnimator?.stopAnimation(true)
         posterAnimator = nil
         player.pause()
@@ -812,9 +940,118 @@ private final class VideoPreviewController: UIViewController,
         updatePosterVisibility(animated: false)
     }
 
+    private func finishDetachedDismissalIfNeeded() {
+        guard VideoPreviewDetachmentPolicy.shouldFinishDismissal(
+            hasPresentingController: presentingViewController != nil,
+            isInWindow: viewIfLoaded?.window != nil
+        ) else {
+            return
+        }
+        beginDismissalIfNeeded()
+        finishDismissalIfNeeded()
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === dismissPanGestureRecognizer,
+              didFinishPresentation,
+              dismissalLifecycle.phase == .active,
+              didReleasePlayer == false else {
+            return false
+        }
+        activeDismissAxis = VideoPreviewDismissGesturePolicy.axis(
+            velocity: dismissPanGestureRecognizer.velocity(in: view)
+        )
+        return activeDismissAxis != nil
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive touch: UITouch
+    ) -> Bool {
+        guard gestureRecognizer === dismissPanGestureRecognizer else { return true }
+        return VideoPreviewGestureTouchPolicy.allowsDismissGesture(startingAt: touch.view)
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        gestureRecognizer === dismissPanGestureRecognizer
+            || otherGestureRecognizer === dismissPanGestureRecognizer
+    }
+
+    @objc
+    private func handleDismissPan(_ recognizer: UIPanGestureRecognizer) {
+        guard let axis = activeDismissAxis else { return }
+        let translation = VideoPreviewDismissGesturePolicy.adjustedTranslation(
+            recognizer.translation(in: view),
+            for: axis
+        )
+        switch recognizer.state {
+        case .began:
+            gestureRestoreAnimator?.stopAnimation(true)
+            gestureRestoreAnimator = nil
+            playerController.showsPlaybackControls = false
+        case .changed:
+            playerController.view.transform = CGAffineTransform(
+                translationX: translation.x,
+                y: translation.y
+            )
+            let opacity = VideoPreviewDismissGesturePolicy.backgroundOpacity(
+                translation: translation,
+                viewportSize: view.bounds.size
+            )
+            view.backgroundColor = UIColor.black.withAlphaComponent(opacity)
+        case .ended:
+            let shouldDismiss = VideoPreviewDismissGesturePolicy.shouldDismiss(
+                translation: translation,
+                velocity: recognizer.velocity(in: view),
+                axis: axis,
+                viewportSize: view.bounds.size
+            )
+            activeDismissAxis = nil
+            if shouldDismiss, requestDismissal() {
+                return
+            }
+            restoreVideoAfterCancelledDismissal(animated: true)
+        case .cancelled, .failed:
+            activeDismissAxis = nil
+            restoreVideoAfterCancelledDismissal(animated: true)
+        default:
+            break
+        }
+    }
+
+    private func restoreVideoAfterCancelledDismissal(animated: Bool) {
+        gestureRestoreAnimator?.stopAnimation(true)
+        gestureRestoreAnimator = nil
+        let changes = {
+            self.playerController.view.transform = .identity
+            self.view.backgroundColor = .black
+        }
+        guard animated, UIAccessibility.isReduceMotionEnabled == false else {
+            changes()
+            playerController.showsPlaybackControls = true
+            return
+        }
+        let animator = UIViewPropertyAnimator(
+            duration: 0.28,
+            dampingRatio: 0.84,
+            animations: changes
+        )
+        gestureRestoreAnimator = animator
+        animator.addCompletion { [weak self] _ in
+            self?.playerController.showsPlaybackControls = true
+            self?.gestureRestoreAnimator = nil
+        }
+        animator.startAnimation()
+    }
+
     private func releasePlayer() {
         guard didReleasePlayer == false else { return }
         didReleasePlayer = true
+        gestureRestoreAnimator?.stopAnimation(true)
+        gestureRestoreAnimator = nil
         posterAnimator?.stopAnimation(true)
         posterAnimator = nil
         readyObservation?.invalidate()

--- a/TiebaPure/Features/Messages/MessagesView.swift
+++ b/TiebaPure/Features/Messages/MessagesView.swift
@@ -50,7 +50,7 @@ struct MessagesView: View {
             resetForNewRequestScope()
             Task { await reload() }
         }
-        .onChange(of: account?.id) { _ in
+        .onChange(of: account?.sessionIdentity) { _ in
             activeMessage = nil
             resetForNewRequestScope()
             Task { await reload() }
@@ -233,6 +233,7 @@ struct MessagesView: View {
     ) async {
         guard let account else { return }
         guard isLoading == false, hasMore || replacing else { return }
+        let requestedSession = account.sessionIdentity
         let requestedKind = kind
         let requestedPage = replacing ? 1 : nextPage
         isLoading = true
@@ -249,7 +250,8 @@ struct MessagesView: View {
             }
             loadTask = task
             let page = try await task.value
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             let visibleItems = page.items.filter(TiebaContentFilter.shouldKeep(message:))
             if replacing {
                 items = deduplicated(visibleItems)
@@ -270,16 +272,19 @@ struct MessagesView: View {
                 consecutiveHiddenPageCount: consecutiveHiddenPageCount
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             loadTask = nil
             isLoading = false
             return
         } catch {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == self.account?.sessionIdentity else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
         }
 
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == self.account?.sessionIdentity else { return }
         loadTask = nil
         isLoading = false
         didLoad = true

--- a/TiebaPure/Features/Profile/FollowedUsersView.swift
+++ b/TiebaPure/Features/Profile/FollowedUsersView.swift
@@ -156,7 +156,7 @@ struct UserRelationshipsView: View {
             apply(change)
         }
         .onReceive(environment.accountStore.accountDidChange) { currentAccount in
-            guard currentAccount?.id != account?.id else { return }
+            guard currentAccount?.sessionIdentity != account?.sessionIdentity else { return }
             cancelRequests()
             users = []
             selectedUser = nil
@@ -205,7 +205,7 @@ struct UserRelationshipsView: View {
         }
         guard isLoading == false, hasMore || replacing else { return }
         let requestedPage = replacing ? 1 : nextPage
-        let requestAccountID = account?.id
+        let requestedSession = account?.sessionIdentity
         isLoading = true
         errorMessage = nil
         var continuation: LocallyFilteredPaginationDecision?
@@ -221,7 +221,8 @@ struct UserRelationshipsView: View {
             }
             loadTask = task
             let page = try await task.value
-            guard generation == requestGeneration, requestAccountID == account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             let reconciledUsers: [UserSummary]
             if let account, kind == .following, isCurrentAccountProfile {
                 for relationshipUser in page.users {
@@ -260,16 +261,19 @@ struct UserRelationshipsView: View {
                 consecutiveHiddenPageCount: consecutiveHiddenPageCount
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             loadTask = nil
             isLoading = false
             return
         } catch {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
         }
 
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == account?.sessionIdentity else { return }
         loadTask = nil
         isLoading = false
         didLoad = true

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -8,6 +8,7 @@ private enum UserProfileTab: String, CaseIterable {
 private struct UserProfileThreadRoute {
     let threadID: Int64
     let forumID: Int64?
+    let deletionTarget: OwnThreadDeletionTarget?
 }
 
 struct UserProfileView: View {
@@ -41,6 +42,7 @@ struct UserProfileView: View {
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     @State private var profile: UserProfile?
     @State private var threads: [ThreadSummary] = []
+    @State private var deletionTargetsByThreadID: [Int64: OwnThreadDeletionTarget] = [:]
     @State private var selectedTab: UserProfileTab = .threads
     @State private var nextPage = 1
     @State private var hasMoreThreads = true
@@ -59,6 +61,8 @@ struct UserProfileView: View {
     @State private var selectedThread: UserProfileThreadRoute?
     @State private var selectedForum: Forum?
     @State private var selectedRelationshipKind: UserRelationshipKind?
+    @State private var showsProfileEditor = false
+    @State private var pendingProfileEditRequest: UserProfileEditRequest?
 
     var body: some View {
         Group {
@@ -101,12 +105,29 @@ struct UserProfileView: View {
         } message: {
             Text(userActionError ?? "")
         }
+        .sheet(isPresented: $showsProfileEditor) {
+            if let account,
+               let profile,
+               pendingProfileEditRequest == nil,
+               UserProfileManagementPolicy.canEdit(profile: profile, account: account) {
+                UserProfileEditSheet(
+                    account: account,
+                    profile: profile,
+                    onApplied: applyProfileEdit,
+                    onNeedsRefresh: requestReadOnlyProfileRefresh
+                )
+                .environmentObject(environment)
+            }
+        }
         .navigationDestination(isPresented: threadIsActive) {
             if let selectedThread {
                 ThreadDetailView(
                     account: account,
                     threadID: selectedThread.threadID,
-                    forumID: selectedThread.forumID
+                    forumID: selectedThread.forumID,
+                    ownThreadDeletionTarget: selectedThread.deletionTarget,
+                    onOwnThreadDeleted: removeDeletedThread,
+                    onOwnThreadDeletionNeedsRefresh: requestReadOnlyThreadRefresh
                 )
                 .interactiveNavigationPopStateSync {
                     self.selectedThread = nil
@@ -137,11 +158,12 @@ struct UserProfileView: View {
             guard didLoad == false else { return }
             await reload()
         }
-        .onChange(of: account?.id) { _ in
+        .onChange(of: account?.sessionIdentity) { _ in
             cancelRequests()
             requestGeneration += 1
             profile = nil
             threads = []
+            deletionTargetsByThreadID = [:]
             nextPage = 1
             hasMoreThreads = true
             threadsVisibility = .visible
@@ -155,6 +177,8 @@ struct UserProfileView: View {
             selectedThread = nil
             selectedForum = nil
             selectedRelationshipKind = nil
+            showsProfileEditor = false
+            pendingProfileEditRequest = nil
             Task { await reload() }
         }
         .onChange(of: blocklistStore.entries) { _ in
@@ -187,6 +211,15 @@ struct UserProfileView: View {
                   SocialRelationshipState.sameUser(profile.user, change.user) else { return }
             isUpdatingFollow = change.isPending
         }
+        .onReceive(environment.ownThreadMutationState.didChange) { event in
+            guard event.accountID == account?.id else { return }
+            switch event.outcome {
+            case .deleted:
+                removeDeletedThread(event.threadID)
+            case .needsRefresh:
+                requestReadOnlyThreadRefresh()
+            }
+        }
         .onDisappear {
             cancelRequests()
             requestGeneration += 1
@@ -202,12 +235,38 @@ struct UserProfileView: View {
             LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                 UserProfileHeader(
                     profile: profile,
-                    onOpenRelationship: { selectedRelationshipKind = $0 }
+                    onOpenRelationship: { selectedRelationshipKind = $0 },
+                    onEditProfile: UserProfileManagementPolicy.canEdit(
+                        profile: profile,
+                        account: account
+                    ) && pendingProfileEditRequest == nil ? { showsProfileEditor = true } : nil
                 )
                     .environment(\.userProfileFollowAction, UserProfileFollowAction(
                         isUpdating: isUpdatingFollow,
                         toggle: { toggleFollow(profile) }
                     ))
+
+                if pendingProfileEditRequest != nil {
+                    InlineLoadErrorView(
+                        message: "资料修改请求已发出，但结果仍待确认。请只刷新资料，不要重复提交。"
+                    ) {
+                        Task { await reload() }
+                    }
+                    .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                    .padding(.vertical, TiebaPureTheme.Spacing.sm)
+                    .background(Color(uiColor: .systemBackground))
+                    .accessibilityIdentifier("user-profile-edit-result-pending-inline")
+                }
+
+                if let profileError {
+                    InlineLoadErrorView(message: profileError) {
+                        Task { await reload() }
+                    }
+                    .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                    .padding(.vertical, TiebaPureTheme.Spacing.sm)
+                    .background(Color(uiColor: .systemBackground))
+                    .accessibilityIdentifier("user-profile-inline-error")
+                }
 
                 Section {
                     selectedTabContent(profile)
@@ -357,17 +416,25 @@ struct UserProfileView: View {
             }
             return
         }
+        let deletionTarget = UserProfileManagementPolicy.deletionTarget(
+            profile: profile,
+            account: account,
+            threadID: thread.id,
+            targetsByThreadID: deletionTargetsByThreadID
+        )
         if let openThreadInParent {
             openThreadInParent(
                 ReaderSplitThreadRoute(
                     threadID: thread.id,
-                    forumID: thread.forumID
+                    forumID: thread.forumID,
+                    ownThreadDeletionTarget: deletionTarget
                 )
             )
         } else {
             selectedThread = UserProfileThreadRoute(
                 threadID: thread.id,
-                forumID: thread.forumID
+                forumID: thread.forumID,
+                deletionTarget: deletionTarget
             )
         }
     }
@@ -509,7 +576,7 @@ struct UserProfileView: View {
         cancelRequests()
         requestGeneration += 1
         let generation = requestGeneration
-        let requestedAccountID = account?.id
+        let requestedSession = account?.sessionIdentity
         isLoadingProfile = true
         // Cancelled loads from older generations exit without clearing the
         // flag, so each generation bump must reset it before loading again.
@@ -523,7 +590,8 @@ struct UserProfileView: View {
             }
             profileTask = task
             let loadedProfile = try await task.value
-            guard generation == requestGeneration, requestedAccountID == account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             var resolvedProfile = loadedProfile
             if let account {
                 if let override = environment.socialRelationshipState.userFollowOverride(
@@ -549,7 +617,19 @@ struct UserProfileView: View {
                     user: loadedProfile.user
                 )
             }
-            profile = profileApplyingCurrentBlocklist(resolvedProfile)
+            let displayedProfile = profileApplyingCurrentBlocklist(resolvedProfile)
+            profile = displayedProfile
+            if let pendingRequest = pendingProfileEditRequest,
+               UserProfileManagementPolicy.profile(
+                   displayedProfile,
+                   confirms: pendingRequest
+               ) {
+                pendingProfileEditRequest = nil
+            }
+            await synchronizeStoredAccountDisplayName(
+                from: displayedProfile,
+                expectedSession: requestedSession
+            )
             profileTask = nil
             isLoadingProfile = false
             await reloadThreads(generation: generation, userID: loadedProfile.user.id)
@@ -558,7 +638,8 @@ struct UserProfileView: View {
             profileTask = nil
             isLoadingProfile = false
         } catch {
-            guard generation == requestGeneration, requestedAccountID == account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             profileTask = nil
             isLoadingProfile = false
             profileError = ReaderErrorMessage.message(for: error)
@@ -596,7 +677,7 @@ struct UserProfileView: View {
         consecutiveHiddenPageCount: Int = 0
     ) async {
         guard isLoadingThreads == false, hasMoreThreads else { return }
-        let requestedAccountID = account?.id
+        let requestedSession = account?.sessionIdentity
         let requestedPage = replacing ? 1 : nextPage
         isLoadingThreads = true
         threadsError = nil
@@ -612,13 +693,20 @@ struct UserProfileView: View {
             }
             threadsTask = task
             let page = try await task.value
-            guard generation == requestGeneration, requestedAccountID == account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             threadsVisibility = page.visibility
             let visibleThreads = page.threads.filter(TiebaContentFilter.shouldKeep(thread:))
+            let visibleThreadIDs = Set(visibleThreads.map(\.id))
+            let visibleDeletionTargets = page.deletionTargetsByThreadID.filter {
+                visibleThreadIDs.contains($0.key)
+            }
             if replacing {
                 threads = visibleThreads
+                deletionTargetsByThreadID = visibleDeletionTargets
             } else {
                 threads = HomeFeedMerge.append(existing: threads, incoming: visibleThreads)
+                deletionTargetsByThreadID.merge(visibleDeletionTargets) { _, incoming in incoming }
             }
             hasMoreThreads = page.visibility == .visible && page.hasMore
             nextPage = page.currentPage + 1
@@ -633,7 +721,8 @@ struct UserProfileView: View {
             isLoadingThreads = false
             return
         } catch {
-            guard generation == requestGeneration, requestedAccountID == account?.id else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             threadsError = ReaderErrorMessage.message(for: error)
         }
         guard generation == requestGeneration else { return }
@@ -725,6 +814,53 @@ struct UserProfileView: View {
         return filtered
     }
 
+    private func applyProfileEdit(_ request: UserProfileEditRequest) {
+        guard let currentProfile = profile else { return }
+        profile = UserProfileManagementPolicy.updatedProfile(currentProfile, applying: request)
+    }
+
+    private func requestReadOnlyProfileRefresh(_ request: UserProfileEditRequest) {
+        pendingProfileEditRequest = request
+        Task { await reload() }
+    }
+
+    private func synchronizeStoredAccountDisplayName(
+        from loadedProfile: UserProfile,
+        expectedSession: AccountSessionIdentity?
+    ) async {
+        guard loadedProfile.isCurrentUser,
+              let account,
+              let expectedSession,
+              account.sessionIdentity == expectedSession,
+              loadedProfile.user.displayNameResolved.isEmpty == false,
+              account.displayName != loadedProfile.user.displayNameResolved else {
+            return
+        }
+        var updatedAccount = account
+        updatedAccount.displayName = loadedProfile.user.displayNameResolved
+        do {
+            try await environment.accountStore.updateDisplayName(
+                updatedAccount.displayName,
+                forSession: expectedSession
+            )
+        } catch let error as AccountStoreError where error == .sessionChanged {
+            // A newer login or completed logout owns the store now.
+        } catch {
+            profileError = "资料已刷新，但本机账号昵称暂时无法同步。"
+        }
+    }
+
+    private func removeDeletedThread(_ threadID: Int64) {
+        guard threads.contains(where: { $0.id == threadID }) else { return }
+        threads.removeAll { $0.id == threadID }
+        deletionTargetsByThreadID[threadID] = nil
+        profile?.threadCount = max((profile?.threadCount ?? 0) - 1, 0)
+    }
+
+    private func requestReadOnlyThreadRefresh() {
+        Task { await reloadThreads() }
+    }
+
     private func cancelRequests() {
         profileTask?.cancel()
         threadsTask?.cancel()
@@ -752,11 +888,294 @@ private extension EnvironmentValues {
     }
 }
 
+enum UserProfileMutationPresentationPolicy {
+    enum Failure: Equatable {
+        case resultPending
+        case retryable(message: String)
+    }
+
+    static func failure(for error: Error) -> Failure {
+        if let mutationError = error as? UserProfileMutationError {
+            if mutationError == .outcomeUnknown {
+                return .resultPending
+            }
+            return .retryable(message: mutationError.description)
+        }
+        return .retryable(message: ReaderErrorMessage.message(for: error))
+    }
+}
+
+private struct UserProfileEditSheet: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @Environment(\.dismiss) private var dismiss
+
+    let account: Account
+    let profile: UserProfile
+    let onApplied: (UserProfileEditRequest) -> Void
+    let onNeedsRefresh: (UserProfileEditRequest) -> Void
+
+    @State private var nickname: String
+    @State private var introduction: String
+    @State private var sex: UserProfileSex
+    @State private var isSaving = false
+    @State private var didSave = false
+    @State private var resultPending = false
+    @State private var pendingResultRequest: UserProfileEditRequest?
+    @State private var errorMessage: String?
+    @State private var pendingAccountSave: Account?
+
+    init(
+        account: Account,
+        profile: UserProfile,
+        onApplied: @escaping (UserProfileEditRequest) -> Void,
+        onNeedsRefresh: @escaping (UserProfileEditRequest) -> Void
+    ) {
+        self.account = account
+        self.profile = profile
+        self.onApplied = onApplied
+        self.onNeedsRefresh = onNeedsRefresh
+        _nickname = State(initialValue: profile.user.displayNameResolved)
+        _introduction = State(initialValue: profile.intro)
+        _sex = State(initialValue: profile.sex)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if didSave {
+                    successContent
+                } else {
+                    editForm
+                }
+            }
+            .navigationTitle("编辑资料")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { editorToolbar }
+        }
+        .interactiveDismissDisabled(isSaving)
+        .accessibilityIdentifier("user-profile-edit-sheet")
+    }
+
+    private var editForm: some View {
+        Form {
+            Section("昵称") {
+                TextField("请输入昵称", text: $nickname)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .accessibilityLabel("昵称")
+                    .accessibilityIdentifier("user-profile-edit-nickname")
+            }
+
+            Section("个人简介") {
+                TextEditor(text: $introduction)
+                    .frame(minHeight: 112)
+                    .accessibilityLabel("个人简介")
+                    .accessibilityIdentifier("user-profile-edit-introduction")
+            }
+
+            Section("性别") {
+                Picker("性别", selection: $sex) {
+                    if profile.sex == .unspecified {
+                        Text("未设置").tag(UserProfileSex.unspecified)
+                    }
+                    Text("男").tag(UserProfileSex.male)
+                    Text("女").tag(UserProfileSex.female)
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("user-profile-edit-sex")
+            }
+
+            if resultPending {
+                Section {
+                    Label(
+                        "请求已经发出，但暂时无法确认是否修改成功。关闭后将只刷新资料，不会再次提交。",
+                        systemImage: "questionmark.circle"
+                    )
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("user-profile-edit-result-pending")
+                }
+            } else if let pendingAccountSave {
+                Section {
+                    Text(errorMessage ?? "贴吧资料已修改，但本机账号显示尚未更新。")
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Button {
+                        Task { await retryAccountSave(pendingAccountSave) }
+                    } label: {
+                        Label("重试本机保存", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(isSaving)
+                    .accessibilityHint("只更新本机账号显示，不会再次提交贴吧资料")
+                    .accessibilityIdentifier("user-profile-edit-retry-local-save")
+                }
+            } else if let errorMessage {
+                Section {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("user-profile-edit-error")
+                }
+            }
+
+            if isSaving {
+                Section {
+                    HStack(spacing: TiebaPureTheme.Spacing.sm) {
+                        ProgressView()
+                        Text(pendingAccountSave == nil ? "正在保存资料" : "正在更新本机账号")
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("正在保存个人资料")
+                    .accessibilityIdentifier("user-profile-edit-loading")
+                }
+            }
+        }
+    }
+
+    private var successContent: some View {
+        ContentUnavailableView {
+            Label("资料已更新", systemImage: "checkmark.circle.fill")
+        } description: {
+            Text("昵称、简介和性别已保存。")
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("user-profile-edit-success")
+    }
+
+    @ToolbarContentBuilder
+    private var editorToolbar: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            if didSave == false {
+                Button("取消", action: close)
+                    .disabled(isSaving)
+                    .accessibilityIdentifier("user-profile-edit-cancel")
+            }
+        }
+
+        ToolbarItem(placement: .confirmationAction) {
+            if didSave {
+                Button("完成", action: close)
+                    .accessibilityIdentifier("user-profile-edit-done")
+            } else if resultPending {
+                Button("关闭并刷新", action: close)
+                    .accessibilityIdentifier("user-profile-edit-refresh")
+            } else if pendingAccountSave == nil {
+                Button("保存") {
+                    Task { await submit() }
+                }
+                .disabled(canSubmit == false)
+                .accessibilityHint("提交昵称、简介和性别修改")
+                .accessibilityIdentifier("user-profile-edit-save")
+            }
+        }
+    }
+
+    private var request: UserProfileEditRequest {
+        UserProfileEditRequest(
+            nickname: nickname,
+            introduction: introduction,
+            sex: sex
+        )
+    }
+
+    private var canSubmit: Bool {
+        guard isSaving == false,
+              resultPending == false,
+              pendingAccountSave == nil,
+              request.normalizedNickname.isEmpty == false else {
+            return false
+        }
+        return request != UserProfileEditRequest(
+            nickname: profile.user.displayNameResolved,
+            introduction: profile.intro,
+            sex: profile.sex
+        )
+    }
+
+    @MainActor
+    private func submit() async {
+        guard canSubmit else { return }
+        let submittedRequest = request
+        isSaving = true
+        errorMessage = nil
+
+        do {
+            try await environment.contentSubmissionCoordinator.performAccountWrite(
+                account: account,
+                target: .profile
+            ) {
+                try await environment.api.updateOwnProfile(
+                    account: account,
+                    request: submittedRequest
+                )
+            }
+            try Task.checkCancellation()
+            let updatedAccount = UserProfileManagementPolicy.updatedAccount(
+                account,
+                applying: submittedRequest
+            )
+            onApplied(submittedRequest)
+            do {
+                try await environment.accountStore.updateDisplayName(
+                    updatedAccount.displayName,
+                    forSession: account.sessionIdentity
+                )
+                didSave = true
+            } catch let error as AccountStoreError where error == .sessionChanged {
+                errorMessage = "账号状态已经变化，本机账号信息不会被旧页面覆盖。"
+            } catch {
+                pendingAccountSave = updatedAccount
+                errorMessage = "贴吧资料已修改，但本机账号显示更新失败。可只重试本机保存。"
+            }
+        } catch {
+            switch UserProfileMutationPresentationPolicy.failure(for: error) {
+            case .resultPending:
+                resultPending = true
+                pendingResultRequest = submittedRequest
+            case let .retryable(message):
+                errorMessage = message
+            }
+        }
+        isSaving = false
+    }
+
+    @MainActor
+    private func retryAccountSave(_ updatedAccount: Account) async {
+        guard isSaving == false else { return }
+        isSaving = true
+        errorMessage = nil
+        do {
+            try await environment.accountStore.updateDisplayName(
+                updatedAccount.displayName,
+                forSession: account.sessionIdentity
+            )
+            pendingAccountSave = nil
+            didSave = true
+        } catch let error as AccountStoreError where error == .sessionChanged {
+            pendingAccountSave = nil
+            errorMessage = "账号状态已经变化，本机账号信息不会被旧页面覆盖。"
+        } catch {
+            errorMessage = "本机账号显示仍未能更新，请稍后再试。贴吧资料不会重复提交。"
+        }
+        isSaving = false
+    }
+
+    private func close() {
+        if let pendingResultRequest {
+            onNeedsRefresh(pendingResultRequest)
+        }
+        dismiss()
+    }
+}
+
 private struct UserProfileHeader: View {
     @Environment(\.userProfileFollowAction) private var followAction
 
     let profile: UserProfile
     let onOpenRelationship: (UserRelationshipKind) -> Void
+    let onEditProfile: (() -> Void)?
 
     private enum Layout {
         static let coverHeight: CGFloat = 112
@@ -799,7 +1218,9 @@ private struct UserProfileHeader: View {
 
             HStack {
                 Spacer(minLength: Layout.avatarSize + TiebaPureTheme.Spacing.lg)
-                if profile.isCurrentUser == false {
+                if let onEditProfile {
+                    editProfileButton(action: onEditProfile)
+                } else if profile.isCurrentUser == false {
                     followButton
                 }
             }
@@ -917,6 +1338,28 @@ private struct UserProfileHeader: View {
         .accessibilityLabel(profile.isFollowed ? "取消关注" : "关注用户")
         .accessibilityHint(profile.isFollowed ? "停止关注该用户" : "关注该用户")
         .accessibilityIdentifier("user-profile-follow-button")
+    }
+
+    private func editProfileButton(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label("编辑资料", systemImage: "pencil")
+                .font(.body.weight(.semibold))
+                .frame(minWidth: 104, minHeight: 44)
+                .padding(.horizontal, TiebaPureTheme.Spacing.xs)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(TiebaPureTheme.ColorToken.readerSecondarySurface)
+                )
+                .overlay {
+                    Capsule(style: .continuous)
+                        .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
+                }
+                .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("编辑个人资料")
+        .accessibilityHint("修改昵称、简介和性别")
+        .accessibilityIdentifier("user-profile-edit-button")
     }
 
     @ViewBuilder

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -1171,6 +1171,8 @@ private struct UserProfileEditSheet: View {
 }
 
 private struct UserProfileHeader: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     @Environment(\.userProfileFollowAction) private var followAction
 
     let profile: UserProfile
@@ -1178,56 +1180,57 @@ private struct UserProfileHeader: View {
     let onEditProfile: (() -> Void)?
 
     private enum Layout {
-        static let coverHeight: CGFloat = 112
-        static let avatarSize: CGFloat = 96
-        static let overlap: CGFloat = 44
-        static let actionBandHeight = overlap + TiebaPureTheme.Spacing.sm
+        static let avatarSize: CGFloat = 72
+        static let actionMinWidth: CGFloat = 80
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ZStack(alignment: .bottomLeading) {
-                profileBackground
-                    .frame(maxWidth: .infinity)
-                    .frame(height: Layout.coverHeight)
-                    .clipped()
-                    .overlay(alignment: .bottom) {
-                        LinearGradient(
-                            colors: [.clear, Color.black.opacity(0.12)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                        .allowsHitTesting(false)
+        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
+            if showsProfileAction {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
+                        identityBlock
+                        profileAction
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                     }
-                    .accessibilityHidden(true)
-
-                AvatarView(
-                    url: profile.user.portraitURL,
-                    title: profile.user.displayNameResolved,
-                    size: Layout.avatarSize
-                )
-                .overlay {
-                    Circle()
-                        .stroke(Color(uiColor: .systemBackground), lineWidth: 4)
+                } else {
+                    HStack(alignment: .top, spacing: TiebaPureTheme.Spacing.sm) {
+                        identityBlock
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .layoutPriority(1)
+                        profileAction
+                    }
                 }
-                .padding(.leading, TiebaPureTheme.Spacing.md)
-                .offset(y: Layout.overlap)
-
+            } else {
+                identityBlock
             }
-            .frame(height: Layout.coverHeight)
 
-            HStack {
-                Spacer(minLength: Layout.avatarSize + TiebaPureTheme.Spacing.lg)
-                if let onEditProfile {
-                    editProfileButton(action: onEditProfile)
-                } else if profile.isCurrentUser == false {
-                    followButton
-                }
+            if profile.intro.isEmpty == false {
+                Text(profile.intro)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                    .accessibilityLabel("个人简介：\(profile.intro)")
             }
-            .frame(maxWidth: .infinity, minHeight: Layout.actionBandHeight)
-            .padding(.horizontal, TiebaPureTheme.Spacing.md)
 
-            VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
+            profileStats
+            .padding(.top, TiebaPureTheme.Spacing.xs)
+        }
+        .padding(.horizontal, TiebaPureTheme.Spacing.md)
+        .padding(.vertical, TiebaPureTheme.Spacing.sm)
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    private var identityBlock: some View {
+        HStack(alignment: .top, spacing: TiebaPureTheme.Spacing.sm) {
+            AvatarView(
+                url: profile.user.portraitURL,
+                title: profile.user.displayNameResolved,
+                size: Layout.avatarSize
+            )
+
+            VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xs) {
                 ViewThatFits(in: .horizontal) {
                     HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.xs) {
                         profileName
@@ -1240,50 +1243,45 @@ private struct UserProfileHeader: View {
                 }
 
                 ProfileMetadataView(profile: profile)
-
-                if profile.intro.isEmpty == false {
-                    Text(profile.intro)
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .textSelection(.enabled)
-                        .accessibilityLabel("个人简介：\(profile.intro)")
-                }
-
-                HStack(spacing: 0) {
-                    ProfileStat(value: profile.agreeCount, label: "获赞")
-                    ProfileStat(value: profile.followingCount, label: "关注") {
-                        onOpenRelationship(.following)
-                    }
-                    ProfileStat(value: profile.followerCount, label: "粉丝") {
-                        onOpenRelationship(.followers)
-                    }
-                }
-                .padding(.top, TiebaPureTheme.Spacing.xs)
             }
-            .padding(.horizontal, TiebaPureTheme.Spacing.md)
-            .padding(.bottom, TiebaPureTheme.Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .background(Color(uiColor: .systemBackground))
+    }
+
+    private var showsProfileAction: Bool {
+        onEditProfile != nil || profile.isCurrentUser == false
     }
 
     @ViewBuilder
-    private var profileBackground: some View {
-        if let backgroundURL = profile.backgroundURL {
-            TiebaRemoteImage(
-                primaryURL: backgroundURL,
-                contentMode: .fill,
-                showsProgress: false,
-                showsRetryButton: false
-            )
-        } else {
-            ZStack {
-                TiebaPureTheme.ColorToken.readerSecondarySurface
-                Image(systemName: "person.crop.rectangle.stack")
-                    .font(.system(size: 36, weight: .light))
-                    .foregroundStyle(.tertiary)
-                    .accessibilityHidden(true)
+    private var profileStats: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: 0) {
+                profileStatViews
             }
+        } else {
+            HStack(spacing: 0) {
+                profileStatViews
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var profileStatViews: some View {
+        ProfileStat(value: profile.agreeCount, label: "获赞")
+        ProfileStat(value: profile.followingCount, label: "关注") {
+            onOpenRelationship(.following)
+        }
+        ProfileStat(value: profile.followerCount, label: "粉丝") {
+            onOpenRelationship(.followers)
+        }
+    }
+
+    @ViewBuilder
+    private var profileAction: some View {
+        if let onEditProfile {
+            editProfileButton(action: onEditProfile)
+        } else if profile.isCurrentUser == false {
+            followButton
         }
     }
 
@@ -1302,38 +1300,35 @@ private struct UserProfileHeader: View {
         Button {
             followAction.toggle()
         } label: {
-            HStack(spacing: TiebaPureTheme.Spacing.xs) {
+            Group {
                 if followAction.isUpdating {
                     ProgressView()
                         .controlSize(.small)
-                        .tint(profile.isFollowed ? .primary : .white)
-                } else if profile.isFollowed == false {
-                    Image(systemName: "plus")
-                        .font(.body.weight(.semibold))
-                        .accessibilityHidden(true)
-                }
-
-                Text(profile.isFollowed ? "已关注" : "关注")
-                    .font(.body.weight(.semibold))
-            }
-            .foregroundStyle(profile.isFollowed ? Color.primary : Color.white)
-            .frame(minWidth: 96, minHeight: 44)
-            .padding(.horizontal, TiebaPureTheme.Spacing.xs)
-            .background(
-                Capsule(style: .continuous)
-                    .fill(profile.isFollowed
-                        ? TiebaPureTheme.ColorToken.readerSecondarySurface
-                        : TiebaPureTheme.ColorToken.primaryAccent)
-            )
-            .overlay {
-                if profile.isFollowed {
-                    Capsule(style: .continuous)
-                        .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
+                } else {
+                    Label(
+                        profile.isFollowed ? "已关注" : "关注",
+                        systemImage: profile.isFollowed ? "checkmark" : "plus"
+                    )
+                    .font(.subheadline.weight(.semibold))
                 }
             }
-            .contentShape(Capsule(style: .continuous))
+            .frame(minWidth: Layout.actionMinWidth, minHeight: 44)
+            .padding(.horizontal, TiebaPureTheme.Spacing.xxs)
         }
         .buttonStyle(.plain)
+        .foregroundStyle(
+            profile.isFollowed
+                ? Color.secondary
+                : TiebaPureTheme.ColorToken.primaryAccent
+        )
+        .background(
+            TiebaPureTheme.ColorToken.readerSecondarySurface,
+            in: RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
+                .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
+        }
         .disabled(followAction.isUpdating)
         .accessibilityLabel(profile.isFollowed ? "取消关注" : "关注用户")
         .accessibilityHint(profile.isFollowed ? "停止关注该用户" : "关注该用户")
@@ -1343,20 +1338,20 @@ private struct UserProfileHeader: View {
     private func editProfileButton(action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Label("编辑资料", systemImage: "pencil")
-                .font(.body.weight(.semibold))
-                .frame(minWidth: 104, minHeight: 44)
-                .padding(.horizontal, TiebaPureTheme.Spacing.xs)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(TiebaPureTheme.ColorToken.readerSecondarySurface)
-                )
-                .overlay {
-                    Capsule(style: .continuous)
-                        .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
-                }
-                .contentShape(Capsule(style: .continuous))
+                .font(.subheadline.weight(.semibold))
+                .frame(minWidth: 96, minHeight: 44)
+                .padding(.horizontal, TiebaPureTheme.Spacing.xxs)
         }
         .buttonStyle(.plain)
+        .foregroundStyle(TiebaPureTheme.ColorToken.primaryAccent)
+        .background(
+            TiebaPureTheme.ColorToken.readerSecondarySurface,
+            in: RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
+                .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
+        }
         .accessibilityLabel("编辑个人资料")
         .accessibilityHint("修改昵称、简介和性别")
         .accessibilityIdentifier("user-profile-edit-button")

--- a/TiebaPure/Features/Search/SearchResultsView.swift
+++ b/TiebaPure/Features/Search/SearchResultsView.swift
@@ -134,9 +134,9 @@ struct SearchResultsView: View {
             }
             await reload()
         }
-        .onChange(of: account?.id) { _ in
-            loadTask?.cancel()
+        .onChange(of: account?.sessionIdentity) { _ in
             requestGeneration += 1
+            loadTask?.cancel()
             results = []
             page = 1
             hasMore = true
@@ -602,6 +602,7 @@ struct SearchResultsView: View {
             sortType: sortType,
             page: requestedPage
         )
+        let requestedSession = account?.sessionIdentity
         isLoading = true
         errorMessage = nil
         var continuation: LocallyFilteredPaginationDecision?
@@ -617,6 +618,7 @@ struct SearchResultsView: View {
             loadTask = task
             let pageResult = try await task.value
             guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity,
                   key == currentRequestKey(page: requestedPage) else { return }
             let visibleResults = pageResult.results
                 .filter(TiebaContentFilter.shouldKeep(searchResult:))
@@ -643,15 +645,19 @@ struct SearchResultsView: View {
                 consecutiveHiddenPageCount: consecutiveHiddenPageCount
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             loadTask = nil
             isLoading = false
             return
         } catch {
-            guard generation == requestGeneration, key == currentRequestKey(page: requestedPage) else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity,
+                  key == currentRequestKey(page: requestedPage) else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
         }
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == account?.sessionIdentity else { return }
         loadTask = nil
         isLoading = false
         didLoad = true

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var appearanceStore: AppAppearanceStore
+    @EnvironmentObject private var contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     @Environment(\.colorScheme) private var effectiveColorScheme
     let account: Account?
 
@@ -42,6 +43,12 @@ struct SettingsView: View {
             }
 
             Section {
+                Toggle(isOn: repliesEnabledSelection) {
+                    Label("允许回帖", systemImage: "bubble.left.and.bubble.right")
+                }
+                .accessibilityHint("开启后可以回复帖子、楼层和楼中楼")
+                .accessibilityIdentifier("settings-replies-enabled-toggle")
+
                 NavigationLink {
                     ReadingSettingsView()
                 } label: {
@@ -60,7 +67,7 @@ struct SettingsView: View {
             } header: {
                 Text("内容")
             } footer: {
-                Text("阅读偏好和屏蔽规则仅保存在本机。")
+                Text("回帖功能默认关闭；尚未确认过发布风险时，首次发帖或回帖会显示非官方接口说明。设置和屏蔽规则仅保存在本机。")
             }
 
             if let account {
@@ -149,6 +156,13 @@ struct SettingsView: View {
         Binding(
             get: { appearanceStore.selection },
             set: { appearanceStore.select($0) }
+        )
+    }
+
+    private var repliesEnabledSelection: Binding<Bool> {
+        Binding(
+            get: { contentSubmissionSettingsStore.repliesEnabled },
+            set: { contentSubmissionSettingsStore.setRepliesEnabled($0) }
         )
     }
 

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -43,11 +43,23 @@ struct SettingsView: View {
             }
 
             Section {
+                Toggle(isOn: newThreadsEnabledSelection) {
+                    Label("允许发帖", systemImage: "square.and.pencil")
+                }
+                .accessibilityHint("关闭后不能发布新主题")
+                .accessibilityIdentifier("settings-new-threads-enabled-toggle")
+
                 Toggle(isOn: repliesEnabledSelection) {
                     Label("允许回帖", systemImage: "bubble.left.and.bubble.right")
                 }
                 .accessibilityHint("开启后可以回复帖子、楼层和楼中楼")
                 .accessibilityIdentifier("settings-replies-enabled-toggle")
+
+                Toggle(isOn: likesEnabledSelection) {
+                    Label("允许点赞", systemImage: "hand.thumbsup")
+                }
+                .accessibilityHint("关闭后仍会显示点赞数量，但不能点赞或取消点赞")
+                .accessibilityIdentifier("settings-likes-enabled-toggle")
 
                 NavigationLink {
                     ReadingSettingsView()
@@ -67,7 +79,7 @@ struct SettingsView: View {
             } header: {
                 Text("内容")
             } footer: {
-                Text("回帖功能默认关闭；尚未确认过发布风险时，首次发帖或回帖会显示非官方接口说明。设置和屏蔽规则仅保存在本机。")
+                Text("发帖和点赞默认开启，回帖默认关闭。关闭点赞后仍会显示点赞数量；尚未确认过发布风险时，首次发帖或回帖会显示非官方接口说明。设置和屏蔽规则仅保存在本机。")
             }
 
             if let account {
@@ -163,6 +175,20 @@ struct SettingsView: View {
         Binding(
             get: { contentSubmissionSettingsStore.repliesEnabled },
             set: { contentSubmissionSettingsStore.setRepliesEnabled($0) }
+        )
+    }
+
+    private var newThreadsEnabledSelection: Binding<Bool> {
+        Binding(
+            get: { contentSubmissionSettingsStore.newThreadsEnabled },
+            set: { contentSubmissionSettingsStore.setNewThreadsEnabled($0) }
+        )
+    }
+
+    private var likesEnabledSelection: Binding<Bool> {
+        Binding(
+            get: { contentSubmissionSettingsStore.likesEnabled },
+            set: { contentSubmissionSettingsStore.setLikesEnabled($0) }
         )
     }
 

--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -34,6 +34,7 @@ struct ContentBlocksView: View {
     var readerLineSpacing: ReaderLineSpacing = .standard
     var inlineAccessibilityIdentifier: String?
     var onOpenUser: ((UserSummary) -> Void)?
+    var onPlainTextTap: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
@@ -50,7 +51,8 @@ struct ContentBlocksView: View {
                             for: lineLimit
                         ),
                         accessibilityIdentifier: inlineAccessibilityIdentifier,
-                        onOpenUser: onOpenUser
+                        onOpenUser: onOpenUser,
+                        onPlainTextTap: onPlainTextTap
                     )
                     .fixedSize(horizontal: false, vertical: true)
                 case let .media(mediaBlocks):
@@ -74,6 +76,12 @@ struct ContentBlocksView: View {
             }
         }
     }
+}
+
+enum InlineContentTextTapTarget: Equatable {
+    case outsideText
+    case plainText
+    case link
 }
 
 struct ContentBlockView: View {
@@ -360,30 +368,39 @@ final class InlineContentTextView: UITextView {
         guard super.point(inside: point, with: event), isSelectable else {
             return false
         }
+        let target = tapTarget(at: point)
+        if allowsTextSelection {
+            return target != .outsideText
+        }
+        return target == .link
+    }
 
+    func tapTarget(at point: CGPoint) -> InlineContentTextTapTarget {
+        layoutManager.ensureLayout(for: textContainer)
         let textPoint = CGPoint(
-            x: point.x - textContainerInset.left,
-            y: point.y - textContainerInset.top
+            x: point.x + contentOffset.x - textContainerInset.left,
+            y: point.y + contentOffset.y - textContainerInset.top
         )
         guard textPoint.x >= 0, textPoint.y >= 0, layoutManager.numberOfGlyphs > 0 else {
-            return false
+            return .outsideText
         }
 
         let glyphIndex = layoutManager.glyphIndex(for: textPoint, in: textContainer)
-        guard glyphIndex < layoutManager.numberOfGlyphs else { return false }
+        guard glyphIndex < layoutManager.numberOfGlyphs else { return .outsideText }
 
         let glyphRect = layoutManager.boundingRect(
             forGlyphRange: NSRange(location: glyphIndex, length: 1),
             in: textContainer
         )
-        guard glyphRect.insetBy(dx: -4, dy: -4).contains(textPoint) else { return false }
+        guard glyphRect.insetBy(dx: -4, dy: -4).contains(textPoint) else {
+            return .outsideText
+        }
 
         let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
-        guard characterIndex < textStorage.length else { return false }
-        if allowsTextSelection {
-            return true
-        }
-        return textStorage.attribute(.link, at: characterIndex, effectiveRange: nil) != nil
+        guard characterIndex < textStorage.length else { return .outsideText }
+        return textStorage.attribute(.link, at: characterIndex, effectiveRange: nil) == nil
+            ? .plainText
+            : .link
     }
 
     private func configureTextContainer(forViewWidth width: CGFloat) {
@@ -506,12 +523,13 @@ struct InlineContentText: UIViewRepresentable {
     var allowsTextSelection = false
     var accessibilityIdentifier: String?
     var onOpenUser: ((UserSummary) -> Void)?
+    var onPlainTextTap: (() -> Void)?
     var emoticonImageProvider: (String) -> UIImage? = { code in
         TiebaEmoticon.cachedImage(for: code)
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onOpenUser: onOpenUser)
+        Coordinator(onOpenUser: onOpenUser, onPlainTextTap: onPlainTextTap)
     }
 
     func makeUIView(context: Context) -> InlineContentTextView {
@@ -542,6 +560,13 @@ struct InlineContentText: UIViewRepresentable {
         textView.linkTextAttributes = [:]
         textView.delegate = context.coordinator
         textView.accessibilityValue = accessibilityText()
+        let plainTextTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handlePlainTextTap(_:))
+        )
+        plainTextTap.cancelsTouchesInView = false
+        textView.addGestureRecognizer(plainTextTap)
+        context.coordinator.textView = textView
         return textView
     }
 
@@ -553,7 +578,7 @@ struct InlineContentText: UIViewRepresentable {
             maximumNumberOfLines: ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit),
             lineBreakMode: ThreadContentDisplayPolicy.lineBreakMode(for: lineLimit)
         )
-        let supportsInteraction = allowsLinkInteraction || allowsTextSelection
+        let supportsInteraction = allowsLinkInteraction || allowsTextSelection || onPlainTextTap != nil
         textView.isSelectable = supportsInteraction
         textView.isUserInteractionEnabled = supportsInteraction
         textView.allowsTextSelection = allowsTextSelection
@@ -562,6 +587,7 @@ struct InlineContentText: UIViewRepresentable {
             textView.setContentOffset(.zero, animated: false)
         }
         context.coordinator.onOpenUser = onOpenUser
+        context.coordinator.onPlainTextTap = onPlainTextTap
     }
 
     func sizeThatFits(
@@ -581,10 +607,25 @@ struct InlineContentText: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, UITextViewDelegate {
+        weak var textView: InlineContentTextView?
         var onOpenUser: ((UserSummary) -> Void)?
+        var onPlainTextTap: (() -> Void)?
 
-        init(onOpenUser: ((UserSummary) -> Void)?) {
+        init(
+            onOpenUser: ((UserSummary) -> Void)?,
+            onPlainTextTap: (() -> Void)?
+        ) {
             self.onOpenUser = onOpenUser
+            self.onPlainTextTap = onPlainTextTap
+        }
+
+        @objc func handlePlainTextTap(_ recognizer: UITapGestureRecognizer) {
+            guard recognizer.state == .ended,
+                  let textView,
+                  textView.tapTarget(at: recognizer.location(in: textView)) == .plainText else {
+                return
+            }
+            onPlainTextTap?()
         }
 
         func textView(

--- a/TiebaPure/Features/Thread/PostRowView.swift
+++ b/TiebaPure/Features/Thread/PostRowView.swift
@@ -57,13 +57,14 @@ struct PostRowView: View {
                     onOpenUser: onOpenUser.map { open in { open(post.author) } }
                 )
 
-                VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
+                VStack(alignment: .leading, spacing: ThreadReplyLayout.bodyStackSpacing) {
                     if isMainPost, let threadTitle, threadTitle.isEmpty == false {
                         Text(threadTitle)
                             .font(.title2.weight(.semibold))
                             .lineSpacing(4)
                             .fixedSize(horizontal: false, vertical: true)
                             .textSelection(.enabled)
+                            .padding(.bottom, TiebaPureTheme.Spacing.sm)
                     }
 
                     ContentBlocksView(
@@ -196,6 +197,7 @@ struct UserHeaderView: View {
             } else {
                 CompactLikeCountView(count: trailingLikeCount)
                     .frame(minWidth: 44, minHeight: 44, alignment: .trailing)
+                    .accessibilityIdentifier(likeAccessibilityIdentifier ?? "thread-like-count")
             }
         }
     }
@@ -283,6 +285,11 @@ enum ThreadAuthorIdentityLayout {
 enum ThreadReplyLayout {
     static let bodyLeadingInset = ThreadAuthorIdentityLayout.replyAvatarSize + TiebaPureTheme.Spacing.sm
     static let headerContentSpacing: CGFloat = TiebaPureTheme.Spacing.xxs
+    static let bodyStackSpacing: CGFloat = 0
+    static let metadataTopSpacing: CGFloat = TiebaPureTheme.Spacing.xxs
+    static let metadataVisualHeight: CGFloat = 28
+    static let metadataHitHeight: CGFloat = 44
+    static let metadataHitExpansion = (metadataHitHeight - metadataVisualHeight) / 2
     static let sectionSeparatorHeight: CGFloat = TiebaPureTheme.Spacing.xs
     static let previewTopPadding: CGFloat = TiebaPureTheme.Spacing.sm
     static let previewBottomPadding: CGFloat = TiebaPureTheme.Spacing.xxs
@@ -355,16 +362,29 @@ struct ThreadPostMetadataView: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
-                            .frame(minWidth: 56, minHeight: 44, alignment: .trailing)
+                            .frame(
+                                minWidth: 56,
+                                minHeight: ThreadReplyLayout.metadataVisualHeight,
+                                alignment: .trailing
+                            )
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .contentShape(
+                        .interaction,
+                        Rectangle().inset(by: -ThreadReplyLayout.metadataHitExpansion)
+                    )
                     .accessibilityLabel(replyAccessibilityLabel ?? "回复")
                     .accessibilityHint("打开回复编辑器")
                     .accessibilityIdentifier(replyAccessibilityIdentifier ?? "thread-reply-button")
                 }
             }
-            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: ThreadReplyLayout.metadataVisualHeight,
+                alignment: .leading
+            )
+            .padding(.top, ThreadReplyLayout.metadataTopSpacing)
         }
     }
 }

--- a/TiebaPure/Features/Thread/PostRowView.swift
+++ b/TiebaPure/Features/Thread/PostRowView.swift
@@ -74,7 +74,8 @@ struct PostRowView: View {
                         readerLineSpacing: readingPreferences.lineSpacing,
                         inlineAccessibilityIdentifier: isMainPost
                             ? "thread-main-text"
-                            : "thread-reply-text"
+                            : "thread-reply-text",
+                        onPlainTextTap: onReply
                     )
 
                     ThreadPostMetadataView(
@@ -82,21 +83,11 @@ struct PostRowView: View {
                         ipAddress: ThreadPostMetadataText.firstLocation(post.ipAddress, post.author.ipAddress),
                         accessibilityIdentifier: isMainPost
                             ? "thread-main-metadata"
-                            : "thread-reply-metadata"
+                            : "thread-reply-metadata",
+                        replyAccessibilityLabel: "回复第\(post.floor)楼",
+                        replyAccessibilityIdentifier: "thread-reply-button-\(post.id)",
+                        onReply: onReply
                     )
-
-                    if let onReply {
-                        Button(action: onReply) {
-                            Label("回复", systemImage: "bubble.left")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .frame(minWidth: 72, minHeight: 44, alignment: .leading)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("回复第\(post.floor)楼")
-                        .accessibilityIdentifier("thread-reply-button-\(post.id)")
-                    }
 
                     if post.previewSubposts.isEmpty == false {
                         SubpostPreviewView(
@@ -336,16 +327,44 @@ struct ThreadPostMetadataView: View {
     let createdAt: Date?
     let ipAddress: String?
     let accessibilityIdentifier: String
+    var replyAccessibilityLabel: String? = nil
+    var replyAccessibilityIdentifier: String? = nil
+    var onReply: (() -> Void)? = nil
 
     var body: some View {
         let displayText = ThreadPostMetadataText.text(createdAt: createdAt, ipAddress: ipAddress)
-        if displayText.isEmpty == false {
-            Text(displayText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .accessibilityIdentifier(accessibilityIdentifier)
-                .accessibilityLabel(displayText)
+        if displayText.isEmpty == false || onReply != nil {
+            HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.sm) {
+                if displayText.isEmpty == false {
+                    Text(displayText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .layoutPriority(1)
+                        .accessibilityIdentifier(accessibilityIdentifier)
+                        .accessibilityLabel(displayText)
+                }
+
+                Spacer(minLength: TiebaPureTheme.Spacing.xs)
+
+                if let onReply {
+                    Button(action: onReply) {
+                        Label("回复", systemImage: "bubble.left")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .frame(minWidth: 56, minHeight: 44, alignment: .trailing)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(replyAccessibilityLabel ?? "回复")
+                    .accessibilityHint("打开回复编辑器")
+                    .accessibilityIdentifier(replyAccessibilityIdentifier ?? "thread-reply-button")
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
         }
     }
 }

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -424,7 +424,9 @@ struct ThreadDetailView: View {
                 onOpenSubposts: openSubpostsIfPossible,
                 onOpenUser: openUser,
                 isLikeUpdating: updatingPostLikeIDs.contains(mainPost.id),
-                onToggleLike: { toggleLike(for: mainPost, objectType: .thread) },
+                onToggleLike: contentSubmissionSettingsStore.likesEnabled
+                    ? { toggleLike(for: mainPost, objectType: .thread) }
+                    : nil,
                 onReply: contentSubmissionSettingsStore.repliesEnabled
                     ? { openReplyComposer(for: mainPost) }
                     : nil
@@ -479,7 +481,9 @@ struct ThreadDetailView: View {
                     onOpenSubposts: openSubpostsIfPossible,
                     onOpenUser: openUser,
                     isLikeUpdating: updatingPostLikeIDs.contains(post.id),
-                    onToggleLike: { toggleLike(for: post, objectType: .post) },
+                    onToggleLike: contentSubmissionSettingsStore.likesEnabled
+                        ? { toggleLike(for: post, objectType: .post) }
+                        : nil,
                     onReply: contentSubmissionSettingsStore.repliesEnabled
                         ? { openReplyComposer(for: post) }
                         : nil
@@ -1419,6 +1423,7 @@ struct ThreadDetailView: View {
     }
 
     private func toggleLike(for post: Post, objectType: TiebaLikeObjectType) {
+        guard contentSubmissionSettingsStore.likesEnabled else { return }
         guard updatingPostLikeIDs.contains(post.id) == false else { return }
         guard let account else {
             likeActionError = "登录后才能点赞。"
@@ -1884,12 +1889,14 @@ private struct SubpostListSheet: View {
                                         trailingLikeCount: post.likeCount,
                                         isLiked: post.isLiked,
                                         isLikeUpdating: updatingLikeIDs.contains(post.id),
-                                        onToggleLike: { togglePostLike() },
+                                        onToggleLike: contentSubmissionSettingsStore.likesEnabled
+                                            ? { togglePostLike() }
+                                            : nil,
                                         likeAccessibilityIdentifier: "thread-subpost-parent-like-button",
                                         onOpenUser: { openUser(post.author) }
                                     )
 
-                                    VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
+                                    VStack(alignment: .leading, spacing: ThreadReplyLayout.bodyStackSpacing) {
                                         ContentBlocksView(
                                             blocks: post.blocks,
                                             textStyle: .reply,
@@ -1927,7 +1934,9 @@ private struct SubpostListSheet: View {
                                     threadAuthorID: threadAuthorID,
                                     onOpenUser: openUser,
                                     isLikeUpdating: updatingLikeIDs.contains(subpost.id),
-                                    onToggleLike: { toggleSubpostLike(subpost) },
+                                    onToggleLike: contentSubmissionSettingsStore.likesEnabled
+                                        ? { toggleSubpostLike(subpost) }
+                                        : nil,
                                     onReply: contentSubmissionSettingsStore.repliesEnabled
                                         ? { openSubpostReplyComposer(subpost) }
                                         : nil
@@ -2291,6 +2300,7 @@ private struct SubpostListSheet: View {
     }
 
     private func togglePostLike() {
+        guard contentSubmissionSettingsStore.likesEnabled else { return }
         let objectType: TiebaLikeObjectType = post.floor == 1 ? .thread : .post
         performLikeMutation(
             id: post.id,
@@ -2305,6 +2315,7 @@ private struct SubpostListSheet: View {
     }
 
     private func toggleSubpostLike(_ subpost: Subpost) {
+        guard contentSubmissionSettingsStore.likesEnabled else { return }
         performLikeMutation(
             id: subpost.id,
             objectType: .subpost,
@@ -2323,6 +2334,7 @@ private struct SubpostListSheet: View {
         currentlyLiked: Bool,
         apply: @escaping (Bool) -> Void
     ) {
+        guard contentSubmissionSettingsStore.likesEnabled else { return }
         guard updatingLikeIDs.contains(id) == false else { return }
         guard let account else {
             likeActionError = "登录后才能点赞。"
@@ -2409,7 +2421,7 @@ private struct SubpostRowView: View {
                     onOpenUser: onOpenUser.map { open in { open(subpost.author) } }
                 )
 
-                VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xs) {
+                VStack(alignment: .leading, spacing: ThreadReplyLayout.bodyStackSpacing) {
                     ContentBlocksView(
                         blocks: subpost.blocks,
                         textStyle: .reply,

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct ThreadDetailView: View {
     @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -13,6 +14,9 @@ struct ThreadDetailView: View {
     let threadID: Int64
     let forumID: Int64?
     let initialPostID: UInt64?
+    private let ownThreadDeletionTarget: OwnThreadDeletionTarget?
+    private let onOwnThreadDeleted: ((Int64) -> Void)?
+    private let onOwnThreadDeletionNeedsRefresh: (() -> Void)?
     private let openSearchInParent: ((SearchScope) -> Void)?
     private let openUserInParent: ((UserSummary) -> Void)?
     private let openForumInParent: ((Forum) -> Void)?
@@ -66,12 +70,19 @@ struct ThreadDetailView: View {
     @State private var contentNavigationTask: Task<Void, Never>?
     @State private var pendingSubpostInitialID: UInt64?
     @State private var contentActionError: String?
+    @State private var showsOwnThreadDeleteConfirmation = false
+    @State private var isDeletingOwnThread = false
+    @State private var hasUnconfirmedOwnThreadDeletion = false
+    @State private var ownThreadDeletionNotice: OwnThreadDeletionNotice?
 
     init(
         account: Account?,
         threadID: Int64,
         forumID: Int64? = nil,
         initialPostID: UInt64? = nil,
+        ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil,
+        onOwnThreadDeleted: ((Int64) -> Void)? = nil,
+        onOwnThreadDeletionNeedsRefresh: (() -> Void)? = nil,
         openSearchInParent: ((SearchScope) -> Void)? = nil,
         openUserInParent: ((UserSummary) -> Void)? = nil,
         openForumInParent: ((Forum) -> Void)? = nil
@@ -80,6 +91,9 @@ struct ThreadDetailView: View {
         self.threadID = threadID
         self.forumID = forumID
         self.initialPostID = initialPostID
+        self.ownThreadDeletionTarget = ownThreadDeletionTarget
+        self.onOwnThreadDeleted = onOwnThreadDeleted
+        self.onOwnThreadDeletionNeedsRefresh = onOwnThreadDeletionNeedsRefresh
         self.openSearchInParent = openSearchInParent
         self.openUserInParent = openUserInParent
         self.openForumInParent = openForumInParent
@@ -88,7 +102,9 @@ struct ThreadDetailView: View {
 
     var body: some View {
         lifecycleContent
-            .fullScreenInteractiveNavigationPop(isEnabled: selectedSubpostPost == nil)
+            .fullScreenInteractiveNavigationPop(
+                isEnabled: selectedSubpostPost == nil && isDeletingOwnThread == false
+            )
     }
 
     private var decoratedContent: some View {
@@ -109,7 +125,9 @@ struct ThreadDetailView: View {
                 }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
-                if threadPage != nil, selectedSubpostPost == nil {
+                if threadPage != nil,
+                   selectedSubpostPost == nil,
+                   contentSubmissionSettingsStore.repliesEnabled {
                     ContentReplyEntryBar(
                         title: "回复帖子",
                         accessibilityIdentifier: "thread-compose-reply-button",
@@ -177,6 +195,37 @@ struct ThreadDetailView: View {
             } message: {
                 Text(contentActionError ?? "")
             }
+            .confirmationDialog(
+                "删除这个帖子？",
+                isPresented: $showsOwnThreadDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("删除帖子", role: .destructive) {
+                    Task { await deleteOwnThread() }
+                }
+                Button("取消", role: .cancel) {}
+            } message: {
+                Text("删除后通常无法恢复。操作只会提交一次。")
+            }
+            .alert(item: $ownThreadDeletionNotice) { notice in
+                switch notice {
+                case let .failure(message):
+                    Alert(
+                        title: Text("删除失败"),
+                        message: Text(message),
+                        dismissButton: .default(Text("好"))
+                    )
+                case .resultPending:
+                    Alert(
+                        title: Text("结果待确认"),
+                        message: Text("删除请求已经发出，但暂时无法确认是否成功。返回后将只刷新帖子列表，不会再次删除。"),
+                        primaryButton: .default(Text("返回并刷新")) {
+                            dismiss()
+                        },
+                        secondaryButton: .cancel(Text("留在本页"))
+                    )
+                }
+            }
     }
 
     private var presentedContent: some View {
@@ -189,7 +238,7 @@ struct ThreadDetailView: View {
                         target: route.target,
                         onDismiss: { composerRoute = nil },
                         onSent: { receipt in
-                            guard self.account == account,
+                            guard self.account?.sessionIdentity == account.sessionIdentity,
                                   composerRoute?.id == route.id,
                                   presentationGeneration == contentNavigationGeneration else { return }
                             pendingSubmissionReceipt = receipt
@@ -213,9 +262,17 @@ struct ThreadDetailView: View {
 
     private var lifecycleContent: some View {
         presentedContent
-            .task { await initialLoadIfNeeded() }
-            .onChange(of: account) { _ in resetForAccountChange() }
+            .task {
+                synchronizeOwnThreadDeletionState()
+                await initialLoadIfNeeded()
+            }
+            .onChange(of: account?.sessionIdentity) { _ in resetForAccountChange() }
             .onChange(of: blocklistStore.entries) { _ in applyCurrentBlocklist() }
+            .onReceive(environment.ownThreadMutationState.didChange) { event in
+                guard event.accountID == account?.id,
+                      event.threadID == threadID else { return }
+                hasUnconfirmedOwnThreadDeletion = event.outcome == .needsRefresh
+            }
             .toolbar(.hidden, for: .tabBar)
             .onDisappear(perform: handleDisappear)
     }
@@ -292,6 +349,7 @@ struct ThreadDetailView: View {
         cancelLikeTasks()
         likeActionError = nil
         contentActionError = nil
+        synchronizeOwnThreadDeletionState()
         requestReload()
     }
 
@@ -366,7 +424,10 @@ struct ThreadDetailView: View {
                 onOpenSubposts: openSubpostsIfPossible,
                 onOpenUser: openUser,
                 isLikeUpdating: updatingPostLikeIDs.contains(mainPost.id),
-                onToggleLike: { toggleLike(for: mainPost, objectType: .thread) }
+                onToggleLike: { toggleLike(for: mainPost, objectType: .thread) },
+                onReply: contentSubmissionSettingsStore.repliesEnabled
+                    ? { openReplyComposer(for: mainPost) }
+                    : nil
             )
             .padding(.bottom, TiebaPureTheme.Spacing.xs)
             .threadReadingAnchor(post: mainPost)
@@ -419,7 +480,9 @@ struct ThreadDetailView: View {
                     onOpenUser: openUser,
                     isLikeUpdating: updatingPostLikeIDs.contains(post.id),
                     onToggleLike: { toggleLike(for: post, objectType: .post) },
-                    onReply: { openReplyComposer(for: post) }
+                    onReply: contentSubmissionSettingsStore.repliesEnabled
+                        ? { openReplyComposer(for: post) }
+                        : nil
                 )
                 .threadReadingAnchor(post: post)
                 .id(post.id)
@@ -542,10 +605,32 @@ struct ThreadDetailView: View {
             ShareLink(item: threadWebURL) {
                 Label("分享", systemImage: "square.and.arrow.up")
             }
+            if resolvedOwnThreadDeletionTarget != nil,
+               hasPendingOwnThreadDeletion == false {
+                Divider()
+                Button(role: .destructive) {
+                    showsOwnThreadDeleteConfirmation = true
+                } label: {
+                    Label("删除帖子", systemImage: "trash")
+                }
+                .disabled(isDeletingOwnThread)
+                .accessibilityHint("需要再次确认，删除请求只会提交一次")
+                .accessibilityIdentifier("thread-delete-own-thread")
+            } else if hasPendingOwnThreadDeletion {
+                Divider()
+                Label("删除结果待确认", systemImage: "questionmark.circle")
+                    .foregroundStyle(.secondary)
+            }
         } label: {
-            Image(systemName: "ellipsis")
+            if isDeletingOwnThread {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: "ellipsis")
+            }
         }
-        .accessibilityLabel("更多")
+        .disabled(isDeletingOwnThread)
+        .accessibilityLabel(isDeletingOwnThread ? "正在删除帖子" : "更多")
     }
 
     private func openThreadSearch() {
@@ -570,6 +655,62 @@ struct ThreadDetailView: View {
 
     private func openThreadInBrowser() {
         openURL(threadWebURL)
+    }
+
+    @MainActor
+    private func deleteOwnThread() async {
+        guard OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: resolvedOwnThreadDeletionTarget != nil,
+            isSubmitting: isDeletingOwnThread,
+            hasUnconfirmedOutcome: hasPendingOwnThreadDeletion
+        ),
+              let account,
+              let target = resolvedOwnThreadDeletionTarget,
+              target.threadID == threadID else { return }
+        isDeletingOwnThread = true
+        ownThreadDeletionNotice = nil
+        let submittedAccountID = account.id
+        let submittedSession = account.sessionIdentity
+
+        do {
+            try await environment.contentSubmissionCoordinator.performAccountWrite(
+                account: account,
+                target: .deleteThread(threadID),
+                coalescesConcurrentCalls: true
+            ) {
+                try await environment.api.deleteOwnThread(account: account, target: target)
+            }
+            try Task.checkCancellation()
+            isDeletingOwnThread = false
+            guard self.account?.sessionIdentity == submittedSession else { return }
+            environment.ownThreadMutationState.publish(
+                accountID: submittedAccountID,
+                threadID: threadID,
+                outcome: .deleted
+            )
+            onOwnThreadDeleted?(threadID)
+            dismiss()
+        } catch is CancellationError {
+            isDeletingOwnThread = false
+        } catch {
+            isDeletingOwnThread = false
+            guard self.account?.sessionIdentity == submittedSession else { return }
+            switch UserProfileMutationPresentationPolicy.failure(for: error) {
+            case .resultPending:
+                // A read-only list refresh is the only safe follow-up after a
+                // dispatched write loses its response. Never resend here.
+                hasUnconfirmedOwnThreadDeletion = true
+                environment.ownThreadMutationState.publish(
+                    accountID: submittedAccountID,
+                    threadID: threadID,
+                    outcome: .needsRefresh
+                )
+                onOwnThreadDeletionNeedsRefresh?()
+                ownThreadDeletionNotice = .resultPending
+            case let .retryable(message):
+                ownThreadDeletionNotice = .failure(message: message)
+            }
+        }
     }
 
     private var loadMoreRepliesButton: some View {
@@ -615,6 +756,10 @@ struct ThreadDetailView: View {
     }
 
     private func openThreadReplyComposer() {
+        guard contentSubmissionSettingsStore.repliesEnabled else {
+            contentActionError = "请先在设置中开启“允许回帖”。"
+            return
+        }
         guard account != nil else {
             contentActionError = "登录后才能回复帖子。"
             return
@@ -634,6 +779,10 @@ struct ThreadDetailView: View {
     }
 
     private func openReplyComposer(for post: Post) {
+        guard contentSubmissionSettingsStore.repliesEnabled else {
+            contentActionError = "请先在设置中开启“允许回帖”。"
+            return
+        }
         guard account != nil else {
             contentActionError = "登录后才能回复楼层。"
             return
@@ -661,7 +810,7 @@ struct ThreadDetailView: View {
         pendingSubmissionTarget = nil
         pendingSubmissionAccount = nil
         pendingSubmissionRouteID = nil
-        guard account == submittedAccount else { return }
+        guard account?.sessionIdentity == submittedAccount.sessionIdentity else { return }
         handleSentContent(
             receipt,
             target: target,
@@ -679,7 +828,7 @@ struct ThreadDetailView: View {
         let generation = contentNavigationGeneration
         contentNavigationTask = Task { @MainActor in
             guard target.threadID == threadID,
-                  account == submittedAccount,
+                  account?.sessionIdentity == submittedAccount.sessionIdentity,
                   composerRoute == nil else { return }
             seeLz = false
             switch target.kind {
@@ -717,7 +866,7 @@ struct ThreadDetailView: View {
     private func contentNavigationIsCurrent(_ generation: Int, account submittedAccount: Account) -> Bool {
         Task.isCancelled == false
             && generation == contentNavigationGeneration
-            && account == submittedAccount
+            && account?.sessionIdentity == submittedAccount.sessionIdentity
     }
 
     private func cancelContentNavigation() {
@@ -871,6 +1020,33 @@ struct ThreadDetailView: View {
 
     private var mainPost: Post? {
         threadPage?.mainPost ?? posts.first { $0.floor == 1 }
+    }
+
+    private var resolvedOwnThreadDeletionTarget: OwnThreadDeletionTarget? {
+        UserProfileManagementPolicy.threadDetailDeletionTarget(
+            account: account,
+            threadID: threadID,
+            page: threadPage,
+            explicitTarget: ownThreadDeletionTarget
+        )
+    }
+
+    private var hasPendingOwnThreadDeletion: Bool {
+        guard let account else { return false }
+        return hasUnconfirmedOwnThreadDeletion
+            || environment.ownThreadMutationState.hasUnconfirmedDeletion(
+                accountID: account.id,
+                threadID: threadID
+            )
+    }
+
+    private func synchronizeOwnThreadDeletionState() {
+        guard let account else {
+            hasUnconfirmedOwnThreadDeletion = false
+            return
+        }
+        hasUnconfirmedOwnThreadDeletion = environment.ownThreadMutationState
+            .hasUnconfirmedDeletion(accountID: account.id, threadID: threadID)
     }
 
     private var replyPosts: [Post] {
@@ -1117,7 +1293,7 @@ struct ThreadDetailView: View {
         consecutiveHiddenPageCount: Int = 0
     ) async {
         guard isLoading == false, hasMore else { return }
-        let requestedAccountID = account?.id
+        let requestedSession = account?.sessionIdentity
         let requestedSeeLz = seeLz
         let requestedSort = sortType
         isLoading = true
@@ -1139,7 +1315,7 @@ struct ThreadDetailView: View {
             loadTask = task
             let loaded = try await task.value
             guard generation == requestGeneration,
-                  requestedAccountID == account?.id,
+                  requestedSession == account?.sessionIdentity,
                   requestedSeeLz == seeLz,
                   requestedSort == sortType else { return }
             var visiblePage = loaded
@@ -1210,20 +1386,22 @@ struct ThreadDetailView: View {
                 consecutiveHiddenPageCount: consecutiveHiddenPageCount
             )
         } catch is CancellationError {
-            guard generation == requestGeneration else { return }
+            guard generation == requestGeneration,
+                  requestedSession == account?.sessionIdentity else { return }
             loadTask = nil
             isLoading = false
             isResumingReadingPosition = false
             return
         } catch {
             guard generation == requestGeneration,
-                  requestedAccountID == account?.id,
+                  requestedSession == account?.sessionIdentity,
                   requestedSeeLz == seeLz,
                   requestedSort == sortType else { return }
             errorMessage = ReaderErrorMessage.message(for: error)
             isResumingReadingPosition = false
         }
-        guard generation == requestGeneration else { return }
+        guard generation == requestGeneration,
+              requestedSession == account?.sessionIdentity else { return }
         loadTask = nil
         isLoading = false
         didLoad = true
@@ -1337,6 +1515,20 @@ struct ThreadDetailView: View {
 enum ThreadDetailSearchOpenDestination: Equatable {
     case parentPath
     case localSearch
+}
+
+private enum OwnThreadDeletionNotice: Identifiable {
+    case failure(message: String)
+    case resultPending
+
+    var id: String {
+        switch self {
+        case .failure:
+            return "failure"
+        case .resultPending:
+            return "result-pending"
+        }
+    }
 }
 
 enum ThreadDetailSearchOpenRoutingPolicy {
@@ -1603,6 +1795,7 @@ private struct ReplyControlBar: View {
 
 private struct SubpostListSheet: View {
     @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     @Environment(\.readingPreferences) private var readingPreferences
     @ObservedObject private var blocklistStore = BlocklistStore.shared
 
@@ -1703,7 +1896,10 @@ private struct SubpostListSheet: View {
                                             lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
                                             readerFontSize: readingPreferences.fontSize,
                                             readerLineSpacing: readingPreferences.lineSpacing,
-                                            inlineAccessibilityIdentifier: "thread-subpost-parent-text"
+                                            inlineAccessibilityIdentifier: "thread-subpost-parent-text",
+                                            onPlainTextTap: contentSubmissionSettingsStore.repliesEnabled
+                                                ? openParentReplyComposer
+                                                : nil
                                         )
                                         ThreadPostMetadataView(
                                             createdAt: post.createdAt,
@@ -1711,7 +1907,12 @@ private struct SubpostListSheet: View {
                                                 post.ipAddress,
                                                 post.author.ipAddress
                                             ),
-                                            accessibilityIdentifier: "thread-subpost-parent-metadata"
+                                            accessibilityIdentifier: "thread-subpost-parent-metadata",
+                                            replyAccessibilityLabel: "回复第\(post.floor)楼",
+                                            replyAccessibilityIdentifier: "subposts-compose-reply-button",
+                                            onReply: contentSubmissionSettingsStore.repliesEnabled
+                                                ? openParentReplyComposer
+                                                : nil
                                         )
                                     }
                                     .padding(.leading, ThreadReplyLayout.bodyLeadingInset)
@@ -1727,7 +1928,9 @@ private struct SubpostListSheet: View {
                                     onOpenUser: openUser,
                                     isLikeUpdating: updatingLikeIDs.contains(subpost.id),
                                     onToggleLike: { toggleSubpostLike(subpost) },
-                                    onReply: { openSubpostReplyComposer(subpost) }
+                                    onReply: contentSubmissionSettingsStore.repliesEnabled
+                                        ? { openSubpostReplyComposer(subpost) }
+                                        : nil
                                 )
                                     .onAppear {
                                         guard PaginationPrefetchPolicy.shouldLoadMore(
@@ -1770,13 +1973,6 @@ private struct SubpostListSheet: View {
                     }
                     .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
                 }
-                }
-                .safeAreaInset(edge: .bottom, spacing: 0) {
-                    ContentReplyEntryBar(
-                        title: "回复本楼",
-                        accessibilityIdentifier: "subposts-compose-reply-button",
-                        action: openParentReplyComposer
-                    )
                 }
                 .navigationTitle(SubpostSheetTitle.text(
                     floor: post.floor,
@@ -1835,7 +2031,7 @@ private struct SubpostListSheet: View {
                             target: route.target,
                             onDismiss: { composerRoute = nil },
                             onSent: { receipt in
-                                guard self.account == account,
+                                guard self.account?.sessionIdentity == account.sessionIdentity,
                                       composerRoute?.id == route.id,
                                       presentationGeneration == submissionReloadGeneration else { return }
                                 pendingSubmittedSubpostID = receipt.postID
@@ -1920,7 +2116,7 @@ private struct SubpostListSheet: View {
         hasPendingSubmission = false
         pendingSubmissionAccount = nil
         pendingSubmissionRouteID = nil
-        guard account == submittedAccount else { return }
+        guard account?.sessionIdentity == submittedAccount.sessionIdentity else { return }
 
         submissionReloadTask?.cancel()
         submissionReloadGeneration += 1
@@ -1930,13 +2126,17 @@ private struct SubpostListSheet: View {
             await reload()
             guard Task.isCancelled == false,
                   generation == submissionReloadGeneration,
-                  account == submittedAccount,
+                  account?.sessionIdentity == submittedAccount.sessionIdentity,
                   composerRoute == nil else { return }
             submissionReloadTask = nil
         }
     }
 
     private func openParentReplyComposer() {
+        guard contentSubmissionSettingsStore.repliesEnabled else {
+            contentActionError = "请先在设置中开启“允许回帖”。"
+            return
+        }
         guard account != nil else {
             contentActionError = "登录后才能回复楼层。"
             return
@@ -1948,6 +2148,10 @@ private struct SubpostListSheet: View {
     }
 
     private func openSubpostReplyComposer(_ subpost: Subpost) {
+        guard contentSubmissionSettingsStore.repliesEnabled else {
+            contentActionError = "请先在设置中开启“允许回帖”。"
+            return
+        }
         guard account != nil else {
             contentActionError = "登录后才能回复用户。"
             return
@@ -2213,7 +2417,8 @@ private struct SubpostRowView: View {
                         readerFontSize: readingPreferences.fontSize,
                         readerLineSpacing: readingPreferences.lineSpacing,
                         inlineAccessibilityIdentifier: "thread-subpost-text",
-                        onOpenUser: onOpenUser
+                        onOpenUser: onOpenUser,
+                        onPlainTextTap: onReply
                     )
                     ThreadPostMetadataView(
                         createdAt: subpost.createdAt,
@@ -2221,20 +2426,11 @@ private struct SubpostRowView: View {
                             subpost.ipAddress,
                             subpost.author.ipAddress
                         ),
-                        accessibilityIdentifier: "thread-subpost-metadata"
+                        accessibilityIdentifier: "thread-subpost-metadata",
+                        replyAccessibilityLabel: "回复用户\(subpost.author.displayNameResolved)",
+                        replyAccessibilityIdentifier: "subpost-reply-button-\(subpost.id)",
+                        onReply: onReply
                     )
-                    if let onReply {
-                        Button(action: onReply) {
-                            Label("回复", systemImage: "bubble.left")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .frame(minWidth: 72, minHeight: 44, alignment: .leading)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("回复用户\(subpost.author.displayNameResolved)")
-                        .accessibilityIdentifier("subpost-reply-button-\(subpost.id)")
-                    }
                 }
                 .padding(.leading, ThreadReplyLayout.bodyLeadingInset)
             }

--- a/TiebaPureTests/AuthSessionTests.swift
+++ b/TiebaPureTests/AuthSessionTests.swift
@@ -30,6 +30,74 @@ final class AuthSessionTests: XCTestCase {
         XCTAssertNil(clearedAccount)
     }
 
+    func testConditionalAccountMetadataSaveCannotRecreateLoggedOutSession() async throws {
+        let store = AccountStore(service: MemoryAccountStoreService())
+        let account = Self.makeAccount()
+        try await store.save(account)
+        try await store.clear()
+
+        do {
+            try await store.updateDisplayName("旧页面昵称", forSession: account.sessionIdentity)
+            XCTFail("注销后的旧页面不应重新写回账号")
+        } catch {
+            XCTAssertEqual(error as? AccountStoreError, .sessionChanged)
+        }
+        let storedAccount = try await store.load()
+        XCTAssertNil(storedAccount)
+    }
+
+    func testConditionalAccountMetadataSaveCannotReplaceNewerLogin() async throws {
+        let store = AccountStore(service: MemoryAccountStoreService())
+        let oldAccount = Self.makeAccount()
+        var newAccount = oldAccount
+        newAccount.uid = "84"
+        newAccount.name = "new-login"
+        newAccount.displayName = "新账号"
+        try await store.save(oldAccount)
+        try await store.save(newAccount)
+
+        do {
+            try await store.updateDisplayName("旧账号修改", forSession: oldAccount.sessionIdentity)
+            XCTFail("旧页面不应覆盖新的登录账号")
+        } catch {
+            XCTAssertEqual(error as? AccountStoreError, .sessionChanged)
+        }
+        let storedAccount = try await store.load()
+        XCTAssertEqual(storedAccount, newAccount)
+    }
+
+    func testMetadataUpdateRejectsOldSameUIDSessionAndPreservesNewCredentials() async throws {
+        let store = AccountStore(service: MemoryAccountStoreService())
+        let oldAccount = Self.makeAccount()
+        var refreshedAccount = oldAccount
+        refreshedAccount.bduss = "new-bduss"
+        refreshedAccount.stoken = "new-stoken"
+        refreshedAccount.baiduID = "new-baiduid"
+        refreshedAccount.tbs = "new-tbs"
+        refreshedAccount.displayName = "刷新前昵称"
+        try await store.save(oldAccount)
+        try await store.save(refreshedAccount)
+
+        do {
+            try await store.updateDisplayName("资料页新昵称", forSession: oldAccount.sessionIdentity)
+            XCTFail("旧会话不应更新同 UID 新登录的元数据")
+        } catch {
+            XCTAssertEqual(error as? AccountStoreError, .sessionChanged)
+        }
+
+        var storedAccount = try await store.load()
+        XCTAssertEqual(storedAccount, refreshedAccount)
+
+        try await store.updateDisplayName(
+            "资料页新昵称",
+            forSession: refreshedAccount.sessionIdentity
+        )
+        var expectedAccount = refreshedAccount
+        expectedAccount.displayName = "资料页新昵称"
+        storedAccount = try await store.load()
+        XCTAssertEqual(storedAccount, expectedAccount)
+    }
+
     func testAccountStoreRejectsPersistedCookieHeaderInjection() async throws {
         var account = Self.makeAccount()
         account.bduss = "safe\r\nX-Injected: true"

--- a/TiebaPureTests/ContentReplyFeatureTests.swift
+++ b/TiebaPureTests/ContentReplyFeatureTests.swift
@@ -24,6 +24,56 @@ final class ContentReplyFeatureTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: key))
     }
 
+    func testNewThreadAndLikeSettingsDefaultOnPersistDisabledOverridesAndReset() throws {
+        let suiteName = "dev.infinityf4p.tiebapure.content-action-settings-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let newThreadsKey = "new-threads-enabled"
+        let likesKey = "likes-enabled"
+
+        var store = ContentSubmissionSettingsStore(
+            defaults: defaults,
+            key: "replies-enabled",
+            newThreadsKey: newThreadsKey,
+            likesKey: likesKey
+        )
+        XCTAssertTrue(store.newThreadsEnabled)
+        XCTAssertTrue(store.likesEnabled)
+        XCTAssertNil(defaults.object(forKey: newThreadsKey))
+        XCTAssertNil(defaults.object(forKey: likesKey))
+
+        store.setNewThreadsEnabled(false)
+        store.setLikesEnabled(false)
+        XCTAssertFalse(store.newThreadsEnabled)
+        XCTAssertFalse(store.likesEnabled)
+        XCTAssertEqual(defaults.object(forKey: newThreadsKey) as? Bool, false)
+        XCTAssertEqual(defaults.object(forKey: likesKey) as? Bool, false)
+
+        store = ContentSubmissionSettingsStore(
+            defaults: defaults,
+            key: "replies-enabled",
+            newThreadsKey: newThreadsKey,
+            likesKey: likesKey
+        )
+        XCTAssertFalse(store.newThreadsEnabled)
+        XCTAssertFalse(store.likesEnabled)
+
+        store.setNewThreadsEnabled(true)
+        store.setLikesEnabled(true)
+        XCTAssertTrue(store.newThreadsEnabled)
+        XCTAssertTrue(store.likesEnabled)
+        XCTAssertNil(defaults.object(forKey: newThreadsKey))
+        XCTAssertNil(defaults.object(forKey: likesKey))
+
+        store.setNewThreadsEnabled(false)
+        store.setLikesEnabled(false)
+        store.reset()
+        XCTAssertTrue(store.newThreadsEnabled)
+        XCTAssertTrue(store.likesEnabled)
+        XCTAssertNil(defaults.object(forKey: newThreadsKey))
+        XCTAssertNil(defaults.object(forKey: likesKey))
+    }
+
     func testReplySettingAllowsNewThreadsButGatesEveryReplyKind() throws {
         let defaults = try scratchDefaults()
         let store = ContentSubmissionSettingsStore(defaults: defaults, key: "replies-enabled")
@@ -32,6 +82,10 @@ final class ContentReplyFeatureTests: XCTestCase {
         XCTAssertFalse(store.allowsSubmission(kind: .threadReply))
         XCTAssertFalse(store.allowsSubmission(kind: .postReply))
         XCTAssertFalse(store.allowsSubmission(kind: .subpostReply))
+
+        store.setNewThreadsEnabled(false)
+        XCTAssertFalse(store.allowsSubmission(kind: .newThread))
+        store.setNewThreadsEnabled(true)
 
         store.setRepliesEnabled(true)
         for kind in ContentSubmissionKind.allCases {
@@ -94,6 +148,29 @@ final class ContentReplyFeatureTests: XCTestCase {
                 error as? ContentSubmissionError,
                 .business(code: 7, message: "操作频繁，请稍后再试。")
             )
+        }
+    }
+
+    func testCoordinatorRejectsNewThreadBeforeNetworkWhenPostingIsDisabled() async throws {
+        let defaults = try scratchDefaults()
+        let store = ContentSubmissionSettingsStore(defaults: defaults, key: "replies-enabled")
+        store.setNewThreadsEnabled(false)
+        let coordinator = ContentSubmissionCoordinator(
+            api: FixtureTiebaAPI(scenario: .submissionFailure),
+            allowsSubmission: { store.allowsSubmission(kind: $0) }
+        )
+        let request = ContentSubmissionRequest(
+            target: .newThread(in: FixtureTiebaAPI.forum),
+            title: "关闭发帖开关",
+            body: "协调器必须在进入 Fixture 网络层前拒绝。",
+            images: []
+        )
+
+        do {
+            _ = try await coordinator.submit(account: FixtureTiebaAPI.account, request: request)
+            XCTFail("关闭发帖开关后不应提交请求")
+        } catch {
+            XCTAssertEqual(error as? ContentSubmissionCoordinatorError, .newThreadsDisabled)
         }
     }
 

--- a/TiebaPureTests/ContentReplyFeatureTests.swift
+++ b/TiebaPureTests/ContentReplyFeatureTests.swift
@@ -1,0 +1,196 @@
+import UIKit
+import XCTest
+@testable import TiebaPure
+
+@MainActor
+final class ContentReplyFeatureTests: XCTestCase {
+    func testReplySettingDefaultsOffPersistsAndRemovesDefaultOverride() throws {
+        let suiteName = "dev.infinityf4p.tiebapure.reply-settings-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let key = "replies-enabled"
+
+        let store = ContentSubmissionSettingsStore(defaults: defaults, key: key)
+        XCTAssertFalse(store.repliesEnabled)
+        XCTAssertNil(defaults.object(forKey: key))
+
+        store.setRepliesEnabled(true)
+        XCTAssertTrue(store.repliesEnabled)
+        XCTAssertEqual(defaults.object(forKey: key) as? Bool, true)
+        XCTAssertTrue(ContentSubmissionSettingsStore(defaults: defaults, key: key).repliesEnabled)
+
+        store.setRepliesEnabled(false)
+        XCTAssertFalse(store.repliesEnabled)
+        XCTAssertNil(defaults.object(forKey: key))
+    }
+
+    func testReplySettingAllowsNewThreadsButGatesEveryReplyKind() throws {
+        let defaults = try scratchDefaults()
+        let store = ContentSubmissionSettingsStore(defaults: defaults, key: "replies-enabled")
+
+        XCTAssertTrue(store.allowsSubmission(kind: .newThread))
+        XCTAssertFalse(store.allowsSubmission(kind: .threadReply))
+        XCTAssertFalse(store.allowsSubmission(kind: .postReply))
+        XCTAssertFalse(store.allowsSubmission(kind: .subpostReply))
+
+        store.setRepliesEnabled(true)
+        for kind in ContentSubmissionKind.allCases {
+            XCTAssertTrue(store.allowsSubmission(kind: kind))
+        }
+    }
+
+    func testCoordinatorRejectsRepliesBeforeNetworkAndObservesLiveSetting() async throws {
+        let defaults = try scratchDefaults()
+        let store = ContentSubmissionSettingsStore(defaults: defaults, key: "replies-enabled")
+        let api = FixtureTiebaAPI(scenario: .submissionFailure)
+        let coordinator = ContentSubmissionCoordinator(
+            api: api,
+            allowsSubmission: { store.allowsSubmission(kind: $0) }
+        )
+
+        for request in replyRequests() {
+            do {
+                _ = try await coordinator.submit(account: FixtureTiebaAPI.account, request: request)
+                XCTFail("关闭开关时不应发送 \(request.target.kind.rawValue)")
+            } catch {
+                XCTAssertEqual(error as? ContentSubmissionCoordinatorError, .repliesDisabled)
+            }
+        }
+
+        store.setRepliesEnabled(true)
+        do {
+            _ = try await coordinator.submit(
+                account: FixtureTiebaAPI.account,
+                request: try XCTUnwrap(replyRequests().first)
+            )
+            XCTFail("开启后应到达故意失败的 Fixture 网络层")
+        } catch {
+            XCTAssertEqual(
+                error as? ContentSubmissionError,
+                .business(code: 7, message: "操作频繁，请稍后再试。")
+            )
+        }
+    }
+
+    func testCoordinatorNeverBlocksNewThreadWhenRepliesAreDisabled() async throws {
+        let defaults = try scratchDefaults()
+        let store = ContentSubmissionSettingsStore(defaults: defaults, key: "replies-enabled")
+        let coordinator = ContentSubmissionCoordinator(
+            api: FixtureTiebaAPI(scenario: .submissionFailure),
+            allowsSubmission: { store.allowsSubmission(kind: $0) }
+        )
+        let request = ContentSubmissionRequest(
+            target: .newThread(in: FixtureTiebaAPI.forum),
+            title: "新主题不受回帖开关影响",
+            body: "用于证明请求已经到达 Fixture 网络层。",
+            images: []
+        )
+
+        do {
+            _ = try await coordinator.submit(account: FixtureTiebaAPI.account, request: request)
+            XCTFail("Fixture 应返回预设业务错误")
+        } catch {
+            XCTAssertEqual(
+                error as? ContentSubmissionError,
+                .business(code: 7, message: "操作频繁，请稍后再试。")
+            )
+        }
+    }
+
+    func testInlineTextTapTargetDistinguishesPlainGlyphLinkAndWhitespace() {
+        let textView = InlineContentTextView()
+        textView.frame = CGRect(x: 0, y: 0, width: 260, height: 120)
+        let text = NSMutableAttributedString(
+            string: "普通文字  用户链接",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
+        text.addAttribute(
+            .link,
+            value: URL(string: "https://tieba.baidu.com/home/main?id=1")!,
+            range: (text.string as NSString).range(of: "用户链接")
+        )
+        textView.apply(
+            attributedText: text,
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+        textView.layoutIfNeeded()
+
+        XCTAssertEqual(textView.tapTarget(at: point(forCharacter: 1, in: textView)), .plainText)
+        let linkIndex = (text.string as NSString).range(of: "用户链接").location
+        XCTAssertEqual(textView.tapTarget(at: point(forCharacter: linkIndex, in: textView)), .link)
+        XCTAssertEqual(
+            textView.tapTarget(at: CGPoint(x: textView.bounds.maxX - 2, y: textView.bounds.maxY - 2)),
+            .outsideText
+        )
+    }
+
+    private func replyRequests() -> [ContentSubmissionRequest] {
+        let thread = FixtureTiebaAPI.threads[0]
+        let post = Post(
+            id: 2_002,
+            threadID: thread.id,
+            floor: 2,
+            author: FixtureTiebaAPI.author,
+            blocks: [.text("楼层正文")],
+            subpostCount: 1,
+            likeCount: 0,
+            previewSubposts: []
+        )
+        let subpost = Subpost(
+            id: 3_051,
+            floor: 1,
+            author: FixtureTiebaAPI.replyTarget,
+            blocks: [.text("楼中楼正文")],
+            likeCount: 0
+        )
+        return [
+            ContentSubmissionRequest(
+                target: .threadReply(thread: thread, forum: FixtureTiebaAPI.forum),
+                title: "",
+                body: "普通回帖",
+                images: []
+            ),
+            ContentSubmissionRequest(
+                target: .postReply(thread: thread, forum: FixtureTiebaAPI.forum, post: post),
+                title: "",
+                body: "回复楼层",
+                images: []
+            ),
+            ContentSubmissionRequest(
+                target: .subpostReply(
+                    thread: thread,
+                    forum: FixtureTiebaAPI.forum,
+                    parentPost: post,
+                    subpost: subpost
+                ),
+                title: "",
+                body: "回复楼中楼",
+                images: []
+            )
+        ]
+    }
+
+    private func point(
+        forCharacter characterIndex: Int,
+        in textView: InlineContentTextView
+    ) -> CGPoint {
+        textView.layoutManager.ensureLayout(for: textView.textContainer)
+        let glyphIndex = textView.layoutManager.glyphIndexForCharacter(at: characterIndex)
+        let rect = textView.layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyphIndex, length: 1),
+            in: textView.textContainer
+        )
+        return CGPoint(
+            x: rect.midX + textView.textContainerInset.left - textView.contentOffset.x,
+            y: rect.midY + textView.textContainerInset.top - textView.contentOffset.y
+        )
+    }
+
+    private func scratchDefaults() throws -> UserDefaults {
+        let suiteName = "dev.infinityf4p.tiebapure.reply-feature-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/TiebaPureTests/ContentSubmissionCoordinatorTests.swift
+++ b/TiebaPureTests/ContentSubmissionCoordinatorTests.swift
@@ -168,6 +168,111 @@ final class ContentSubmissionCoordinatorTests: XCTestCase {
         XCTAssertEqual(submissionCount, 1)
     }
 
+    func testAccountInvalidationCancelsAndDrainsRegisteredProfileOrDeleteWrite() async throws {
+        let coordinator = ContentSubmissionCoordinator(
+            api: SubmissionAPISpy(delayNanoseconds: 0)
+        )
+        let account = makeAccount()
+        let started = expectation(description: "account mutation started")
+        let caller = Task {
+            try await coordinator.performAccountWrite(account: account, target: .profile) {
+                started.fulfill()
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+            }
+        }
+        await fulfillment(of: [started], timeout: 1)
+
+        await coordinator.beginInvalidation(accountID: account.id)
+
+        do {
+            try await caller.value
+            XCTFail("账号失效前应取消资料修改或删帖写操作")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertTrue(coordinator.isInvalidating(accountID: account.id))
+
+        do {
+            try await coordinator.performAccountWrite(account: account, target: .profile) {}
+            XCTFail("屏障释放前不应接受新的账号写操作")
+        } catch {
+            XCTAssertEqual(error as? ContentSubmissionCoordinatorError, .sessionTransition)
+        }
+        coordinator.endInvalidation(accountID: account.id)
+        try await coordinator.performAccountWrite(account: account, target: .profile) {}
+    }
+
+    func testConcurrentDeleteForSameAccountAndThreadSharesOneWrite() async throws {
+        let coordinator = ContentSubmissionCoordinator(
+            api: SubmissionAPISpy(delayNanoseconds: 0)
+        )
+        let account = makeAccount()
+        let write = ControlledAccountWriteSpy()
+
+        let first = Task {
+            try await coordinator.performAccountWrite(
+                account: account,
+                target: .deleteThread(1_001),
+                coalescesConcurrentCalls: true
+            ) {
+                try await write.run()
+            }
+        }
+        await write.waitForFirstWrite()
+
+        let secondStarted = expectation(description: "second delete caller entered coordinator")
+        let second = Task {
+            secondStarted.fulfill()
+            try await coordinator.performAccountWrite(
+                account: account,
+                target: .deleteThread(1_001),
+                coalescesConcurrentCalls: true
+            ) {
+                await write.recordAdditionalWrite()
+            }
+        }
+        await fulfillment(of: [secondStarted], timeout: 1)
+        let countWhileFirstWriteIsPending = await write.writeCount()
+        XCTAssertEqual(countWhileFirstWriteIsPending, 1)
+
+        await write.releaseFirstWrite()
+        try await first.value
+        try await second.value
+        let finalWriteCount = await write.writeCount()
+        XCTAssertEqual(finalWriteCount, 1)
+    }
+
+    func testConcurrentProfileWritesAreRejectedInsteadOfCoalesced() async throws {
+        let coordinator = ContentSubmissionCoordinator(
+            api: SubmissionAPISpy(delayNanoseconds: 0)
+        )
+        let account = makeAccount()
+        let write = ControlledAccountWriteSpy()
+
+        let first = Task {
+            try await coordinator.performAccountWrite(account: account, target: .profile) {
+                try await write.run()
+            }
+        }
+        await write.waitForFirstWrite()
+
+        do {
+            try await coordinator.performAccountWrite(account: account, target: .profile) {
+                try await write.run()
+            }
+            XCTFail("资料写入不能把内容不同的并发操作合并为同一次请求")
+        } catch {
+            XCTAssertEqual(error as? ContentSubmissionCoordinatorError, .operationInProgress)
+        }
+        var writeCount = await write.writeCount()
+        XCTAssertEqual(writeCount, 1)
+
+        await write.releaseFirstWrite()
+        try await first.value
+        writeCount = await write.writeCount()
+        XCTAssertEqual(writeCount, 1)
+    }
+
     func testAccountInvalidationBlocksOnlyMatchingAccountUntilReleased() async throws {
         let api = SubmissionAPISpy(delayNanoseconds: 0)
         let coordinator = ContentSubmissionCoordinator(api: api)
@@ -261,6 +366,61 @@ final class ContentSubmissionCoordinatorTests: XCTestCase {
         _ = try await coordinator.submit(account: account, request: reentrantRequest)
         let finalCount = await api.submissionCount()
         XCTAssertEqual(finalCount, 2)
+    }
+
+    func testTwoPhaseBarrierRejectsSocialWriteWhileContentDrainIsBlocked() async throws {
+        let api = ControlledSubmissionAPISpy()
+        let contentCoordinator = ContentSubmissionCoordinator(api: api)
+        let socialState = SocialRelationshipState()
+        let socialCoordinator = SocialMutationCoordinator(api: api, state: socialState)
+        let account = makeAccount()
+        let request = makeRequest(body: "注销时正在发送")
+        let user = UserSummary(
+            id: 99,
+            name: "fixture_user",
+            displayName: "合成用户",
+            portrait: "fixture.portrait"
+        )
+        let submission = Task {
+            try await contentCoordinator.submit(account: account, request: request)
+        }
+        await api.waitForFirstSubmission()
+
+        socialCoordinator.establishInvalidationBarrier()
+        contentCoordinator.establishInvalidationBarrier()
+        let socialDrain = Task { @MainActor in
+            await socialCoordinator.drainInvalidatedOperations()
+        }
+        let contentDrain = Task { @MainActor in
+            await contentCoordinator.drainInvalidatedOperations()
+        }
+        await Task.yield()
+
+        XCTAssertTrue(contentCoordinator.isInvalidating(accountID: account.id))
+        XCTAssertTrue(socialCoordinator.isInvalidating(session: account.sessionIdentity))
+        do {
+            try await socialCoordinator.setUserFollowed(
+                account: account,
+                user: user,
+                followed: true
+            )
+            XCTFail("内容排空仍被阻塞时，社交写入口也必须已经关闭")
+        } catch {
+            XCTAssertEqual(error as? SocialMutationCoordinatorError, .sessionTransition)
+        }
+        XCTAssertFalse(socialState.isUserMutationPending(accountID: account.id, user: user))
+
+        await api.releaseFirstSubmission()
+        await socialDrain.value
+        await contentDrain.value
+        do {
+            _ = try await submission.value
+            XCTFail("排空的旧内容写操作应收到取消")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        contentCoordinator.endInvalidation()
+        socialCoordinator.endInvalidation()
     }
 
     @MainActor
@@ -386,6 +546,43 @@ final class ContentSubmissionCoordinatorTests: XCTestCase {
             body: body,
             images: []
         )
+    }
+}
+
+private actor ControlledAccountWriteSpy {
+    private var count = 0
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func run() async throws {
+        count += 1
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+        try Task.checkCancellation()
+    }
+
+    func waitForFirstWrite() async {
+        guard count == 0 else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstWrite() {
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func recordAdditionalWrite() {
+        count += 1
+    }
+
+    func writeCount() -> Int {
+        count
     }
 }
 

--- a/TiebaPureTests/ContentSubmissionNetworkTests.swift
+++ b/TiebaPureTests/ContentSubmissionNetworkTests.swift
@@ -1,42 +1,35 @@
 import Foundation
-import SwiftProtobuf
 import XCTest
 @testable import TiebaPure
 
 final class ContentSubmissionRequestFactoryTests: XCTestCase {
-    func testThreadReplyOmitsEveryFloorTargetAndCarriesImageTag() throws {
-        let request = try TiebaContentSubmissionRequestFactory.addPost(
+    func testThreadReplyWebFieldsOmitEveryFloorTargetAndPreserveImageInfo() throws {
+        let fields = try TiebaContentSubmissionRequestFactory.webReplyFields(
             account: Self.account,
             tbs: "fresh-tbs",
             request: Self.request(target: Self.target(kind: .threadReply)),
-            uploadedImages: [TiebaAppUploadedImage(
-                picID: "fixture_pic_1",
-                pixelWidth: 640,
-                pixelHeight: 480
-            )],
-            bootstrap: Self.bootstrap,
-            requestBuilder: Self.requestBuilder,
-            now: Self.now
+            uploadedImageInfo: "fixture-image-info",
+            timestamp: Self.timestamp
         )
-        let data = request.data
 
-        XCTAssertTrue(request.hasData)
-        XCTAssertEqual(data.content, "正文\n#(pic,fixture_pic_1,640,480)")
-        XCTAssertEqual(data.takephotoNum, "1")
-        XCTAssertEqual(data.isPictxt, "1")
-        XCTAssertTrue(data.hasBarrageTime)
-        XCTAssertEqual(data.barrageTime, "0")
-        XCTAssertTrue(data.hasPostFrom)
-        XCTAssertEqual(data.postFrom, "3")
-        XCTAssertFalse(data.hasQuoteID)
-        XCTAssertFalse(data.hasRepostid)
-        XCTAssertFalse(data.hasReplyUid)
-        XCTAssertFalse(data.hasSubPostID)
-        XCTAssertEqual(data.common.tbs, "fresh-tbs")
+        XCTAssertEqual(fields, [
+            "co": "正文",
+            "_t": "1700000000000",
+            "tag": "11",
+            "upload_img_info": "fixture-image-info",
+            "fid": "100",
+            "src": "1",
+            "word": "fixture",
+            "tbs": "fresh-tbs",
+            "z": "1001",
+            "lp": "6026",
+            "nick_name": "夹具账号",
+            "_BSK": "1700000000000"
+        ])
     }
 
-    func testPostReplySetsParentAndReplyUserButOmitsSubpostTarget() throws {
-        let request = try TiebaContentSubmissionRequestFactory.addPost(
+    func testPostReplyWebFieldsSetParentAndFloorButOmitSubpostTarget() throws {
+        let fields = try TiebaContentSubmissionRequestFactory.webReplyFields(
             account: Self.account,
             tbs: "fresh-tbs",
             request: Self.request(target: Self.target(
@@ -44,27 +37,18 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
                 parentPostID: 2002,
                 replyUserID: 42
             )),
-            uploadedImages: [],
-            bootstrap: Self.bootstrap,
-            requestBuilder: Self.requestBuilder,
-            now: Self.now
+            uploadedImageInfo: "",
+            timestamp: Self.timestamp
         )
-        let data = request.data
 
-        XCTAssertTrue(data.hasQuoteID)
-        XCTAssertEqual(data.quoteID, "2002")
-        XCTAssertTrue(data.hasRepostid)
-        XCTAssertEqual(data.repostid, "2002")
-        XCTAssertTrue(data.hasReplyUid)
-        XCTAssertEqual(data.replyUid, "42")
-        XCTAssertTrue(data.hasPostFrom)
-        XCTAssertEqual(data.postFrom, "0")
-        XCTAssertFalse(data.hasSubPostID)
-        XCTAssertFalse(data.hasBarrageTime)
+        XCTAssertEqual(fields["pid"], "2002")
+        XCTAssertEqual(fields["floor"], "2")
+        XCTAssertNil(fields["lzl_id"])
+        XCTAssertEqual(fields["co"], "正文")
     }
 
-    func testSubpostReplyEncodesGoldenReplyTargetAndRoundTripsWireFields() throws {
-        let request = try TiebaContentSubmissionRequestFactory.addPost(
+    func testSubpostReplyWebFieldsCarryGoldenTargetAndPlainReplyPrefix() throws {
+        let fields = try TiebaContentSubmissionRequestFactory.webReplyFields(
             account: Self.account,
             tbs: "fresh-tbs",
             request: Self.request(target: Self.target(
@@ -73,52 +57,30 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
                 subpostID: 3002,
                 replyUserID: 43
             )),
-            uploadedImages: [],
-            bootstrap: Self.bootstrap,
-            requestBuilder: Self.requestBuilder,
-            now: Self.now
+            uploadedImageInfo: "",
+            timestamp: Self.timestamp
         )
-        let data = request.data
 
-        XCTAssertTrue(data.hasQuoteID)
-        XCTAssertEqual(data.quoteID, "2002")
-        XCTAssertTrue(data.hasRepostid)
-        XCTAssertEqual(data.repostid, "2002")
-        XCTAssertTrue(data.hasReplyUid)
-        XCTAssertEqual(data.replyUid, "43")
-        XCTAssertTrue(data.hasSubPostID)
-        XCTAssertEqual(data.subPostID, "3002")
-        XCTAssertFalse(data.hasPostFrom)
-        XCTAssertFalse(data.hasBarrageTime)
-        XCTAssertEqual(data.content, "回复 #(reply, tb.1.reply-target, 被回复用户) :正文")
-
-        let decoded = try Tieba_AddPostRequest(serializedBytes: request.serializedData())
-        XCTAssertEqual(decoded.data.content, data.content)
-        XCTAssertEqual(decoded.data.replyUid, "43")
-        XCTAssertEqual(decoded.data.subPostID, "3002")
-
-        var prefix = Tieba_PbContent()
-        prefix.type = 0
-        prefix.text = "回复 "
-        var replyTarget = Tieba_PbContent()
-        replyTarget.type = 4
-        replyTarget.uid = 43
-        replyTarget.text = "被回复用户"
-        var suffix = Tieba_PbContent()
-        suffix.type = 0
-        suffix.text = " :正文"
-        XCTAssertEqual(
-            PostMapper.subpostBlocks(from: [prefix, replyTarget, suffix], usersByID: [:]),
-            [
-                .text("回复 "),
-                .mention(userID: 43, text: "被回复用户"),
-                .text(" :正文")
-            ]
-        )
+        XCTAssertEqual(fields["pid"], "2002")
+        XCTAssertEqual(fields["floor"], "2")
+        XCTAssertEqual(fields["lzl_id"], "3002")
+        XCTAssertEqual(fields["co"], "回复 被回复用户 : 正文")
     }
 
-    func testNewThreadCarriesExplicitPublishingFieldsAndPreservesTextExactly() throws {
-        let protobuf = try TiebaContentSubmissionRequestFactory.addThread(
+    func testWebReplyFieldsRejectHeaderInjectingUploadedImageInfo() {
+        XCTAssertThrowsError(try TiebaContentSubmissionRequestFactory.webReplyFields(
+            account: Self.account,
+            tbs: "fresh-tbs",
+            request: Self.request(target: Self.target(kind: .threadReply)),
+            uploadedImageInfo: "fixture\r\nCookie: injected",
+            timestamp: Self.timestamp
+        )) { error in
+            XCTAssertEqual(error as? ContentSubmissionValidationError, .invalidImage)
+        }
+    }
+
+    func testWebThreadFieldsAndHeadersPreserveTextAndMinimizeCookies() throws {
+        let fields = try TiebaContentSubmissionRequestFactory.webThreadFields(
             account: Self.account,
             tbs: "fresh-tbs",
             request: ContentSubmissionRequest(
@@ -127,43 +89,32 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
                 body: "  新主题正文\n第二行  ",
                 images: []
             ),
-            bootstrap: Self.bootstrap,
-            requestBuilder: Self.requestBuilder,
             now: Self.now
         )
-        let data = protobuf.data
+        XCTAssertEqual(fields, [
+            "ie": "utf-8",
+            "fid": "100",
+            "kw": "fixture",
+            "tbs": "fresh-tbs",
+            "title": "  新主题\n副标题  ",
+            "content": "  新主题正文\n第二行  ",
+            "nick_name": "夹具账号",
+            "bsk": "1700000000000"
+        ])
 
-        XCTAssertTrue(protobuf.hasData)
-        XCTAssertEqual(data.title, "  新主题\n副标题  ")
-        XCTAssertEqual(data.content, "  新主题正文\n第二行  ")
-        XCTAssertEqual(data.fid, "100")
-        XCTAssertEqual(data.kw, "fixture")
-        XCTAssertEqual(data.nameShow, "夹具账号")
-        XCTAssertTrue(data.hasEntranceType)
-        XCTAssertEqual(data.entranceType, "1")
-        XCTAssertTrue(data.hasCallFrom)
-        XCTAssertEqual(data.callFrom, "2")
-        XCTAssertTrue(data.hasTakephotoNum)
-        XCTAssertEqual(data.takephotoNum, "0")
-        XCTAssertTrue(data.hasIsHide)
-        XCTAssertTrue(data.hasIsRepostToDynamic)
-        XCTAssertTrue(data.hasIsNtitle)
-        XCTAssertTrue(data.hasIsLinkThread)
-        XCTAssertTrue(data.hasIsForumBusinessAccount)
-        XCTAssertTrue(data.hasIsPictxt)
-        XCTAssertTrue(data.hasIsArticle)
-        XCTAssertTrue(data.hasShowCustomFigure)
-        XCTAssertTrue(data.hasIsQuestion)
-        XCTAssertTrue(data.hasIsXiuxiuThread)
-        XCTAssertTrue(data.hasIsShowBless)
-        XCTAssertTrue(data.hasExt)
-        XCTAssertEqual(data.ext, #"{"need_image":0,"is_hide":0,"need_follow_forum":0}"#)
-        XCTAssertEqual(data.common.tbs, "fresh-tbs")
+        let headers = try TiebaContentSubmissionRequestFactory.webThreadHeaders(
+            account: Self.account,
+            forumName: "fixture"
+        )
+        XCTAssertEqual(headers["Cookie"], "BDUSS=bduss; STOKEN=stoken")
+        XCTAssertFalse(headers["Cookie", default: ""].contains("BAIDUID"))
+        XCTAssertEqual(headers["Origin"], "https://tieba.baidu.com")
+        XCTAssertEqual(headers["Referer"], "https://tieba.baidu.com/f?kw=fixture")
     }
 
     func testReplyBodyPreservesLeadingTrailingWhitespaceAndLineBreaks() throws {
         let body = "  第一行\n\n第二行  "
-        let request = try TiebaContentSubmissionRequestFactory.addPost(
+        let fields = try TiebaContentSubmissionRequestFactory.webReplyFields(
             account: Self.account,
             tbs: "fresh-tbs",
             request: ContentSubmissionRequest(
@@ -172,13 +123,11 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
                 body: body,
                 images: []
             ),
-            uploadedImages: [],
-            bootstrap: Self.bootstrap,
-            requestBuilder: Self.requestBuilder,
-            now: Self.now
+            uploadedImageInfo: "",
+            timestamp: Self.timestamp
         )
 
-        XCTAssertEqual(request.data.content, body)
+        XCTAssertEqual(fields["co"], body)
     }
 
     func testLegacySubpostTargetWithoutPortraitKeepsReplyAttribution() throws {
@@ -200,54 +149,70 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
         let target = try JSONDecoder().decode(ContentSubmissionTarget.self, from: legacyJSON)
         XCTAssertNil(target.replyUserPortrait)
 
-        let request = try TiebaContentSubmissionRequestFactory.addPost(
+        let fields = try TiebaContentSubmissionRequestFactory.webReplyFields(
             account: Self.account,
             tbs: "fresh-tbs",
             request: Self.request(target: target),
-            uploadedImages: [],
-            bootstrap: Self.bootstrap,
-            requestBuilder: Self.requestBuilder,
-            now: Self.now
+            uploadedImageInfo: "",
+            timestamp: Self.timestamp
         )
 
-        XCTAssertEqual(request.data.replyUid, "43")
-        XCTAssertEqual(request.data.content, "回复 #(reply, , 被回复用户) :正文")
+        XCTAssertEqual(fields["lzl_id"], "3002")
+        XCTAssertEqual(fields["co"], "回复 被回复用户 : 正文")
     }
 
-    func testUploadResponseRequiresExplicitSuccessCode() throws {
-        let response = try decodeUpload(#"{"picId":"fixture_pic_1"}"#)
-        XCTAssertThrowsError(try response.validatedPicID()) { error in
-            XCTAssertEqual(
-                error as? ContentSubmissionError,
-                .business(code: -1, message: "图片上传响应缺少状态码。")
-            )
-        }
+    func testWebUploadResponseAcceptsSnakeAndCamelImageInfo() throws {
+        let snake = try decodeWebUpload(
+            #"{"error_code":0,"image_info":"fixture-image-info"}"#
+        )
+        let camel = try decodeWebUpload(
+            #"{"err_code":"0","imageInfo":"fixture-image-info-2"}"#
+        )
+        XCTAssertEqual(try snake.validatedImageInfo(), "fixture-image-info")
+        XCTAssertEqual(try camel.validatedImageInfo(), "fixture-image-info-2")
     }
 
-    func testUploadResponseRejectsPicIDInjectionEvenWithSuccessCode() throws {
-        for value in ["fixture|second", "fixture\r\nCookie: injected", "../fixture", "fixture pic"] {
+    func testWebUploadResponseRejectsEmptyOrHeaderInjectingImageInfo() throws {
+        for value in ["", "fixture\r\nCookie: injected"] {
             let payload = try JSONSerialization.data(withJSONObject: [
                 "error_code": 0,
-                "picId": value
+                "image_info": value
             ])
-            let response = try JSONDecoder().decode(TiebaImageUploadResponseDTO.self, from: payload)
-            XCTAssertThrowsError(try response.validatedPicID(), "Unexpectedly accepted \(value)") { error in
+            let response = try JSONDecoder().decode(TiebaWebUploadPictureResponseDTO.self, from: payload)
+            XCTAssertThrowsError(try response.validatedImageInfo(), "Unexpectedly accepted \(value)") { error in
                 XCTAssertEqual(
                     error as? ContentSubmissionError,
-                    .business(code: -1, message: "贴吧没有返回有效的图片标识。")
+                    .business(code: -1, message: "贴吧没有返回有效的图片信息。")
                 )
             }
         }
     }
 
-    func testUploadResponseRejectsNonzeroCodeEvenWhenPicIDExists() throws {
-        let response = try decodeUpload(
-            #"{"error_code":7,"error_msg":"上传被拒绝","picId":"fixture_pic_1"}"#
+    func testWebUploadResponseRejectsNonzeroAndConflictingCodes() throws {
+        let rejected = try decodeWebUpload(
+            #"{"error_code":7,"error_msg":"上传被拒绝","image_info":"fixture"}"#
         )
-        XCTAssertThrowsError(try response.validatedPicID()) { error in
+        XCTAssertThrowsError(try rejected.validatedImageInfo()) { error in
             XCTAssertEqual(
                 error as? ContentSubmissionError,
                 .business(code: 7, message: "上传被拒绝")
+            )
+        }
+
+        let session = try decodeWebUpload(
+            #"{"error_code":110001,"error_msg":"用户未登录","image_info":"fixture"}"#
+        )
+        XCTAssertThrowsError(try session.validatedImageInfo()) { error in
+            XCTAssertEqual(error as? ContentSubmissionError, .sessionExpired)
+        }
+
+        let conflict = try decodeWebUpload(
+            #"{"error_code":0,"err_code":7,"error_msg":"状态冲突","image_info":"fixture"}"#
+        )
+        XCTAssertThrowsError(try conflict.validatedImageInfo()) { error in
+            XCTAssertEqual(
+                error as? ContentSubmissionError,
+                .business(code: -1, message: "图片上传响应状态无效。")
             )
         }
     }
@@ -263,26 +228,8 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
         tbs: "tbs"
     )
 
-    private static let requestBuilder = TiebaRequestBuilder(
-        screenScale: 3,
-        screenWidth: 1179,
-        screenHeight: 2556,
-        clientID: "request-builder-client"
-    )
-
-    private static let bootstrap = TiebaPostingBootstrapResult(
-        identity: TiebaPostingIdentity(
-            androidID: "0123456789abcdef",
-            uuid: "00112233-4455-4677-8899-aabbccddeeff",
-            cuidGalaxy2: "fixture-cuid-galaxy2",
-            c3AID: "fixture-c3-aid"
-        ),
-        clientID: "fixture-client-id",
-        sampleID: "fixture-sample-id",
-        zID: "fixture-z-id"
-    )
-
     private static let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let timestamp: Int64 = 1_700_000_000_000
 
     private static func target(
         kind: ContentSubmissionKind,
@@ -310,8 +257,8 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
         ContentSubmissionRequest(target: target, title: "", body: "正文", images: [])
     }
 
-    private func decodeUpload(_ json: String) throws -> TiebaImageUploadResponseDTO {
-        try JSONDecoder().decode(TiebaImageUploadResponseDTO.self, from: Data(json.utf8))
+    private func decodeWebUpload(_ json: String) throws -> TiebaWebUploadPictureResponseDTO {
+        try JSONDecoder().decode(TiebaWebUploadPictureResponseDTO.self, from: Data(json.utf8))
     }
 }
 
@@ -524,123 +471,535 @@ final class FixtureContentSubmissionTests: XCTestCase {
 #endif
 
 final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
-    func testProtobufSuccessReturnsReceipt() async throws {
-        let response = try Self.addPostResponse(tid: "1001", pid: "9001")
-        let harness = makeAPI(mode: .finalResponse(response))
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
+    func testAllReplyTargetsUseExactWebFormAndNeverBootstrapOrFallback() async throws {
+        let cases: [(ContentSubmissionKind, Set<String>, String)] = [
+            (
+                .threadReply,
+                Set(["co", "_t", "tag", "upload_img_info", "fid", "src", "word", "tbs", "z", "lp", "nick_name", "_BSK"]),
+                "离线提交测试"
+            ),
+            (
+                .postReply,
+                Set(["co", "_t", "tag", "upload_img_info", "fid", "src", "word", "tbs", "z", "lp", "nick_name", "_BSK", "pid", "floor"]),
+                "离线提交测试"
+            ),
+            (
+                .subpostReply,
+                Set(["co", "_t", "tag", "upload_img_info", "fid", "src", "word", "tbs", "z", "lp", "nick_name", "_BSK", "pid", "floor", "lzl_id"]),
+                "回复 被回复用户 : 离线提交测试"
+            )
+        ]
 
-        let receipt = try await harness.api.submitContent(
-            account: Self.account,
-            request: Self.textReply
-        )
+        for (kind, expectedKeys, expectedBody) in cases {
+            let response = Data(#"{"no":0,"error":"","data":{"pid":9001,"tid":1001}}"#.utf8)
+            let bootstrap = CountingSubmissionPostingBootstrap(result: Self.bootstrap)
+            let harness = makeAPI(mode: .finalResponse(response), postingBootstrap: bootstrap)
+            let request = Self.replyRequest(kind: kind)
+            do {
+                let receipt = try await harness.api.submitContent(
+                    account: Self.account,
+                    request: request
+                )
+                XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: 9001))
+                XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
+                    "/c/s/login",
+                    "/mo/q/apubpost"
+                ])
+                let bootstrapCalls = await bootstrap.callCount()
+                XCTAssertEqual(bootstrapCalls, 0)
 
-        XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: 9001))
-        XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
-            "/c/s/login",
-            "/c/c/post/add"
-        ])
+                let mutation = try XCTUnwrap(SubmissionURLProtocol.records(id: harness.id).last)
+                XCTAssertEqual(mutation.scheme, "https")
+                XCTAssertEqual(mutation.host, "tieba.baidu.com")
+                XCTAssertEqual(mutation.method, "POST")
+                XCTAssertEqual(mutation.header(named: "Host"), "tieba.baidu.com")
+                XCTAssertEqual(
+                    mutation.header(named: "Cookie"),
+                    "BDUSS=fixture-bduss; STOKEN=fixture-stoken"
+                )
+                XCTAssertFalse(mutation.header(named: "Cookie")?.contains("BAIDUID") ?? true)
+                XCTAssertEqual(mutation.header(named: "Origin"), "https://tieba.baidu.com")
+                XCTAssertEqual(
+                    mutation.header(named: "Referer"),
+                    "https://tieba.baidu.com/p/1001?lp=5028&mo_device=1&is_jingpost=0&pn=1&"
+                )
+                XCTAssertEqual(mutation.header(named: "X-Requested-With"), "XMLHttpRequest")
+                XCTAssertEqual(mutation.header(named: "Accept"), "application/json, text/plain, */*")
+                XCTAssertTrue(
+                    mutation.header(named: "User-Agent")?
+                        .hasSuffix("tieba/11.10.8.6 skin/default") == true
+                )
+
+                let fields = try Self.formFields(from: mutation)
+                XCTAssertEqual(Set(fields.keys), expectedKeys)
+                XCTAssertEqual(fields["co"], expectedBody)
+                XCTAssertEqual(fields["tag"], "11")
+                XCTAssertEqual(fields["upload_img_info"], "")
+                XCTAssertEqual(fields["fid"], "100")
+                XCTAssertEqual(fields["src"], "1")
+                XCTAssertEqual(fields["word"], "fixture")
+                XCTAssertEqual(fields["tbs"], "fresh-tbs")
+                XCTAssertEqual(fields["z"], "1001")
+                XCTAssertEqual(fields["lp"], "6026")
+                XCTAssertEqual(fields["nick_name"], "夹具账号")
+
+                let queryFields = Self.queryFields(from: mutation)
+                let timestamp = try XCTUnwrap(queryFields["_t"])
+                XCTAssertEqual(Set(queryFields.keys), ["_t"])
+                XCTAssertEqual(fields["_t"], timestamp)
+                XCTAssertEqual(fields["_BSK"], timestamp)
+                XCTAssertNotNil(Int64(timestamp))
+
+                switch kind {
+                case .threadReply:
+                    XCTAssertNil(fields["pid"])
+                    XCTAssertNil(fields["floor"])
+                    XCTAssertNil(fields["lzl_id"])
+                case .postReply:
+                    XCTAssertEqual(fields["pid"], "2002")
+                    XCTAssertEqual(fields["floor"], "2")
+                    XCTAssertNil(fields["lzl_id"])
+                case .subpostReply:
+                    XCTAssertEqual(fields["pid"], "2002")
+                    XCTAssertEqual(fields["floor"], "2")
+                    XCTAssertEqual(fields["lzl_id"], "3002")
+                case .newThread:
+                    XCTFail("Unexpected new-thread case")
+                }
+
+                XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+                XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+                XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/s/uploadPicture", id: harness.id), 0)
+            } catch {
+                SubmissionURLProtocol.remove(id: harness.id)
+                throw error
+            }
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
     }
 
-    func testNewThreadProtobufSuccessReturnsReceipt() async throws {
-        let response = try Self.addThreadResponse(tid: "7001", pid: "7002")
-        let harness = makeAPI(mode: .finalResponse(response))
+    func testNewThreadUsesSingleHTTPSWebFormWithMinimalCookies() async throws {
+        let response = Data(#"{"result":"1","tid":"7001","pid":"7002"}"#.utf8)
+        let bootstrap = CountingSubmissionPostingBootstrap(result: Self.bootstrap)
+        let harness = makeAPI(mode: .finalResponse(response), postingBootstrap: bootstrap)
         defer { SubmissionURLProtocol.remove(id: harness.id) }
-        let request = ContentSubmissionRequest(
-            target: ContentSubmissionTarget(
-                kind: .newThread,
-                forumID: 100,
-                forumName: "fixture",
-                forumDisplayName: "夹具吧",
-                threadID: nil,
-                threadTitle: nil,
-                parentPostID: nil,
-                parentFloor: nil,
-                subpostID: nil,
-                replyUserID: nil,
-                replyUserDisplayName: nil
-            ),
-            title: "新主题",
-            body: "新主题正文",
-            images: []
+        let request = Self.newThreadRequest(
+            title: "  新主题\n副标题  ",
+            body: "  新主题正文\n第二行  "
         )
+        let earliestBSK = Int64(Date().timeIntervalSince1970 * 1_000)
 
         let receipt = try await harness.api.submitContent(account: Self.account, request: request)
+        let latestBSK = Int64(Date().timeIntervalSince1970 * 1_000)
 
         XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 7001, postID: 7002))
         XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
             "/c/s/login",
-            "/c/c/thread/add"
+            "/f/commit/thread/add"
         ])
+        let bootstrapCalls = await bootstrap.callCount()
+        XCTAssertEqual(bootstrapCalls, 0)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id), 0)
+
+        let mutation = try XCTUnwrap(SubmissionURLProtocol.records(id: harness.id).last)
+        XCTAssertEqual(mutation.scheme, "https")
+        XCTAssertEqual(mutation.host, "tieba.baidu.com")
+        XCTAssertEqual(mutation.method, "POST")
+        XCTAssertNil(mutation.query)
+        XCTAssertEqual(
+            mutation.header(named: "Cookie"),
+            "BDUSS=fixture-bduss; STOKEN=fixture-stoken"
+        )
+        XCTAssertFalse(mutation.header(named: "Cookie")?.contains("BAIDUID") ?? true)
+        XCTAssertTrue(
+            mutation.header(named: "Content-Type")?
+                .hasPrefix("application/x-www-form-urlencoded") == true
+        )
+        let fields = try Self.formFields(from: mutation)
+        XCTAssertEqual(Set(fields.keys), Set([
+            "ie", "fid", "kw", "tbs", "title", "content", "nick_name", "bsk"
+        ]))
+        XCTAssertEqual(fields["ie"], "utf-8")
+        XCTAssertEqual(fields["fid"], "100")
+        XCTAssertEqual(fields["kw"], "fixture")
+        XCTAssertEqual(fields["tbs"], "fresh-tbs")
+        XCTAssertEqual(fields["title"], request.title)
+        XCTAssertEqual(fields["content"], request.body)
+        XCTAssertEqual(fields["nick_name"], "夹具账号")
+        let bskString = try XCTUnwrap(fields["bsk"])
+        let bsk = try XCTUnwrap(Int64(bskString))
+        XCTAssertGreaterThanOrEqual(bsk, earliestBSK)
+        XCTAssertLessThanOrEqual(bsk, latestBSK)
     }
 
-    func testProtobufBusinessErrorIsTyped() async throws {
-        let response = try Self.addPostResponse(errorCode: 7, userMessage: "操作频繁")
-        let harness = makeAPI(mode: .finalResponse(response))
+    func testWebThreadSuccessStatusAndIdentifierShapes() async throws {
+        let cases: [(String, ContentSubmissionReceipt)] = [
+            (
+                #"{"result":1,"tid":7001,"pid":7002}"#,
+                ContentSubmissionReceipt(threadID: 7001, postID: 7002)
+            ),
+            (
+                #"{"error_code":"0","data":{"tid":"7003","pid":"7004"}}"#,
+                ContentSubmissionReceipt(threadID: 7003, postID: 7004)
+            ),
+            (
+                #"{"err_code":0,"tid":"7005","data":{"pid":7006}}"#,
+                ContentSubmissionReceipt(threadID: 7005, postID: 7006)
+            ),
+            (
+                #"{"result":1,"tid":"7007","pid":"7008","data":{"tid":7007,"pid":7008}}"#,
+                ContentSubmissionReceipt(threadID: 7007, postID: 7008)
+            )
+        ]
+
+        for (payload, expected) in cases {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                let receipt = try await harness.api.submitContent(
+                    account: Self.account,
+                    request: Self.newThreadRequest()
+                )
+                XCTAssertEqual(receipt, expected)
+                XCTAssertEqual(
+                    SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                    1
+                )
+                XCTAssertEqual(
+                    SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id),
+                    0
+                )
+            } catch {
+                SubmissionURLProtocol.remove(id: harness.id)
+                throw error
+            }
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadConflictingTopLevelAndNestedIdentifiersHaveUnknownOutcome() async {
+        let payloads = [
+            #"{"result":1,"tid":7001,"data":{"tid":7002,"pid":7003}}"#,
+            #"{"result":1,"tid":7001,"pid":7002,"data":{"pid":7003}}"#
+        ]
+
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.newThreadRequest(),
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                1
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id),
+                0
+            )
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadMalformedTopLevelOrNestedIdentifiersHaveUnknownOutcome() async {
+        let payloads = [
+            #"{"result":1,"tid":{"value":7001},"data":{"tid":7001}}"#,
+            #"{"result":1,"tid":7001,"pid":true}"#,
+            #"{"result":1,"tid":7001.0}"#,
+            #"{"result":1,"tid":7001,"data":{"pid":"not-a-post-id"}}"#,
+            #"{"result":1,"tid":7001,"data":{"tid":""}}"#
+        ]
+
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.newThreadRequest(),
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                1
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id),
+                0
+            )
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadExplicitErrorsRemainTyped() async throws {
+        let cases: [(String, ContentSubmissionError)] = [
+            (
+                #"{"error_code":"7","error_msg":"操作频繁"}"#,
+                .business(code: 7, message: "操作频繁")
+            ),
+            (
+                #"{"err_code":110001,"err_msg":"用户未登录"}"#,
+                .sessionExpired
+            ),
+            (
+                #"{"result":0,"err_code":40,"err_msg":"请完成安全验证","data":{"vcode_md5":"fixture-md5"}}"#,
+                .verificationRequired(message: "请完成安全验证")
+            )
+        ]
+
+        for (payload, expected) in cases {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.newThreadRequest(),
+                equals: expected
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                1
+            )
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadAmbiguousResponsesHaveUnknownOutcomeWithoutFallbackOrRetry() async {
+        let payloads = [
+            #"{"result":1,"pid":7002}"#,
+            #"{"result":1,"error_code":7,"tid":7001}"#,
+            #"{"tid":7001}"#,
+            #"{"error_code":{"value":0},"tid":7001}"#
+        ]
+
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.newThreadRequest(),
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                1
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id),
+                0
+            )
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadMalformedTopLevelOrNestedStatusFieldsHaveUnknownOutcome() async {
+        let payloads = [
+            #"{"result":true,"tid":7001}"#,
+            #"{"error_code":false,"tid":7001}"#,
+            #"{"result":1.0,"tid":7001}"#,
+            #"{"error_code":{"value":0},"tid":7001}"#,
+            #"{"err_code":null,"tid":7001}"#,
+            #"{"result":1,"tid":7001,"data":{"result":true}}"#,
+            #"{"result":1,"tid":7001,"data":{"error_code":false}}"#,
+            #"{"result":1,"tid":7001,"data":{"result":1.0}}"#,
+            #"{"result":1,"tid":7001,"data":{"err_code":{"value":0}}}"#,
+            #"{"result":1,"tid":7001,"data":{"error_code":null}}"#,
+            #"{"result":1,"tid":7001,"data":true}"#,
+            #"{"result":1,"tid":7001,"data":[]}"#
+        ]
+
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.newThreadRequest(),
+                equals: .outcomeUnknown,
+                context: payload
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                1
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id),
+                0
+            )
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadTransportAndDecodeFailuresHaveUnknownOutcomeWithoutRetry() async {
+        for mode in [SubmissionStubMode.finalTransportFailure, .finalDecodeFailure] {
+            let harness = makeAPI(mode: mode)
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.newThreadRequest(),
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(
+                SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id),
+                1
+            )
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testWebThreadCancellationAfterDispatchHasUnknownOutcomeWithoutRetry() async throws {
+        let harness = makeAPI(mode: .holdFinalRequestUntilCancellation)
         defer { SubmissionURLProtocol.remove(id: harness.id) }
+        let submission = Task {
+            try await harness.api.submitContent(
+                account: Self.account,
+                request: Self.newThreadRequest()
+            )
+        }
 
-        await assertSubmissionError(
-            from: harness.api,
-            request: Self.textReply,
-            equals: .business(code: 7, message: "操作频繁")
-        )
+        try await waitForRequest(path: "/f/commit/thread/add", id: harness.id)
+        submission.cancel()
+
+        do {
+            _ = try await submission.value
+            XCTFail("Expected cancellation after dispatch to have an unknown outcome")
+        } catch let error as ContentSubmissionError {
+            XCTAssertEqual(error, .outcomeUnknown)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id), 0)
     }
 
-    func testProtobufSessionErrorIsTyped() async throws {
-        let response = try Self.addPostResponse(errorCode: 4, userMessage: "登录已失效")
-        let harness = makeAPI(mode: .finalResponse(response))
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
+    func testWebReplyBusinessSessionVerificationAndAmbiguousResponsesStayTyped() async {
+        let cases: [(String, ContentSubmissionError)] = [
+            (
+                #"{"no":7,"error":"操作频繁"}"#,
+                .business(code: 7, message: "操作频繁")
+            ),
+            (
+                #"{"errno":110001,"error":"用户未登录"}"#,
+                .sessionExpired
+            ),
+            (
+                #"{"error_code":40,"error_msg":"请完成安全验证"}"#,
+                .verificationRequired(message: "请完成安全验证")
+            ),
+            (
+                #"{"no":0,"error_code":7,"error":"状态冲突"}"#,
+                .outcomeUnknown
+            ),
+            (
+                #"{"result":1,"no":7,"error":"状态冲突"}"#,
+                .outcomeUnknown
+            ),
+            (
+                #"{"data":{"tid":1001,"pid":9001}}"#,
+                .outcomeUnknown
+            ),
+            (
+                #"{"no":{"value":0},"data":{"tid":1001,"pid":9001}}"#,
+                .outcomeUnknown
+            ),
+            (
+                #"{"no":0,"data":{"tid":9999,"pid":9001}}"#,
+                .outcomeUnknown
+            ),
+            (
+                #"{"no":0,"pid":9001,"data":{"tid":1001,"pid":9002}}"#,
+                .outcomeUnknown
+            )
+        ]
 
-        await assertSubmissionError(
-            from: harness.api,
-            request: Self.textReply,
-            equals: .sessionExpired
-        )
+        for (payload, expected) in cases {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.textReply,
+                equals: expected
+            )
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
     }
 
-    func testProtobufVerificationResponseIsTyped() async throws {
-        let response = try Self.addPostResponse(
-            message: "请完成安全验证",
-            needsVerification: true
-        )
-        let harness = makeAPI(mode: .finalResponse(response))
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
+    func testWebReplyMalformedTopLevelOrNestedStatusFieldsHaveUnknownOutcome() async {
+        let payloads = [
+            #"{"result":true,"tid":1001,"pid":9001}"#,
+            #"{"no":false,"tid":1001,"pid":9001}"#,
+            #"{"error_code":0.0,"tid":1001,"pid":9001}"#,
+            #"{"err_code":{"value":0},"tid":1001,"pid":9001}"#,
+            #"{"errno":null,"tid":1001,"pid":9001}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":{"result":true}}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":{"no":false}}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":{"error_code":0.0}}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":{"err_code":{"value":0}}}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":{"errno":null}}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":true}"#,
+            #"{"no":0,"tid":1001,"pid":9001,"data":[]}"#
+        ]
 
-        await assertSubmissionError(
-            from: harness.api,
-            request: Self.textReply,
-            equals: .verificationRequired(message: "请完成安全验证")
-        )
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.textReply,
+                equals: .outcomeUnknown,
+                context: payload
+            )
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
     }
 
-    func testEmptyProtobufResponseHasUnknownOutcome() async throws {
-        let response = try Tieba_AddPostResponse().serializedData()
-        let harness = makeAPI(mode: .finalResponse(response))
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
+    func testWebReplyMalformedTopLevelOrNestedIdentifiersHaveUnknownOutcome() async {
+        let payloads = [
+            #"{"no":0,"tid":true,"data":{"tid":1001,"pid":9001}}"#,
+            #"{"no":0,"tid":{"value":1001},"data":{"tid":1001,"pid":9001}}"#,
+            #"{"no":0,"tid":1001,"pid":"","data":{"pid":9001}}"#,
+            #"{"no":0,"tid":1001,"post_id":null,"data":{"pid":9001}}"#,
+            #"{"no":0,"data":{"tid":"","pid":9001}}"#,
+            #"{"no":0,"data":{"tid":1001,"pid":false}}"#,
+            #"{"no":0,"data":{"tid":1001,"post_id":{"value":9001}}}"#,
+            #"{"no":0,"data":{"tid":0,"pid":9001}}"#,
+            #"{"no":0,"data":{"tid":1001,"pid":-1}}"#,
+            #"{"no":0,"data":{"tid":1001,"pid":1.5}}"#,
+            #"{"no":0,"data":{"tid":1001,"pid":9001.0}}"#
+        ]
 
-        await assertSubmissionError(
-            from: harness.api,
-            request: Self.textReply,
-            equals: .outcomeUnknown
-        )
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.textReply,
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
     }
 
-    func testExplicitZeroErrorWithoutDataIsMinimalSuccess() async throws {
-        let response = try Self.addPostResponse()
-        let harness = makeAPI(mode: .finalResponse(response))
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
+    func testWebReplyConflictingIdentifierAliasesHaveUnknownOutcome() async {
+        let payloads = [
+            #"{"no":0,"tid":1001,"pid":9001,"post_id":9002}"#,
+            #"{"no":0,"tid":1001,"data":{"tid":1002,"pid":9001}}"#,
+            #"{"no":0,"tid":1001,"post_id":9001,"data":{"post_id":9002}}"#
+        ]
 
-        let receipt = try await harness.api.submitContent(
-            account: Self.account,
-            request: Self.textReply
-        )
-
-        XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: nil))
-        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 1)
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.textReply,
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
     }
 
-    func testUploadThenStrictTBSRefreshThenMutationUsesActualImageDimensions() async throws {
-        let response = try Self.addPostResponse(tid: "1001", pid: "9001")
-        let harness = makeAPI(mode: .finalResponse(response))
+    func testWebImageUploadFeedsExactImageInfoIntoReplyWithoutLegacyUpload() async throws {
+        let response = Data(#"{"no":0,"data":{"tid":1001,"pid":9001}}"#.utf8)
+        let bootstrap = CountingSubmissionPostingBootstrap(result: Self.bootstrap)
+        let harness = makeAPI(mode: .finalResponse(response), postingBootstrap: bootstrap)
         defer { SubmissionURLProtocol.remove(id: harness.id) }
         let imageData = try XCTUnwrap(Data(base64Encoded: Self.onePixelPNGBase64))
         let request = ContentSubmissionRequest(
@@ -660,47 +1019,88 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: 9001))
         let records = SubmissionURLProtocol.records(id: harness.id)
         XCTAssertEqual(records.map(\.path), [
-            "/c/s/uploadPicture",
+            "/mo/q/cooluploadpic",
             "/c/s/login",
-            "/c/c/post/add"
+            "/mo/q/apubpost"
         ])
+        let bootstrapCalls = await bootstrap.callCount()
+        XCTAssertEqual(bootstrapCalls, 0)
 
         let upload = try XCTUnwrap(records.first)
-        let uploadParts = try Self.multipartParts(from: upload)
-        XCTAssertEqual(try Self.textPart(named: "width", in: uploadParts), "1")
-        XCTAssertEqual(try Self.textPart(named: "height", in: uploadParts), "1")
-        XCTAssertEqual(try XCTUnwrap(uploadParts.first(where: { $0.name == "chunk" })).body, imageData)
+        XCTAssertEqual(upload.scheme, "https")
+        XCTAssertEqual(upload.host, "tieba.baidu.com")
+        XCTAssertEqual(upload.method, "POST")
+        XCTAssertEqual(upload.header(named: "Host"), "tieba.baidu.com")
+        XCTAssertEqual(Self.queryFields(from: upload)["type"], "ajax")
+        XCTAssertFalse(Self.queryFields(from: upload)["r", default: ""].isEmpty)
+        XCTAssertEqual(
+            upload.header(named: "Cookie"),
+            "BDUSS=fixture-bduss; STOKEN=fixture-stoken"
+        )
+        XCTAssertFalse(upload.header(named: "Cookie")?.contains("BAIDUID") ?? true)
+        XCTAssertEqual(upload.header(named: "Origin"), "https://tieba.baidu.com")
+        XCTAssertNil(upload.header(named: "Referer"))
+        XCTAssertEqual(upload.header(named: "X-Requested-With"), "XMLHttpRequest")
+        XCTAssertEqual(upload.header(named: "Accept"), "application/json, text/plain, */*")
+        XCTAssertTrue(
+            upload.header(named: "User-Agent")?
+                .hasSuffix("tieba/11.10.8.6 skin/default") == true
+        )
+        let uploadFields = try Self.formFields(from: upload)
+        XCTAssertEqual(Set(uploadFields.keys), ["pic"])
+        XCTAssertEqual(uploadFields["pic"], imageData.base64EncodedString())
 
         let login = try XCTUnwrap(records.first(where: { $0.path == "/c/s/login" }))
         let loginFields = try Self.formFields(from: login)
-        XCTAssertEqual(loginFields["bdusstoken"], "fixture-bduss|")
-        XCTAssertEqual(loginFields["stoken"], "fixture-stoken")
+        XCTAssertEqual(loginFields["_client_version"], "22.5.1.0")
+        XCTAssertEqual(loginFields["bdusstoken"], "fixture-bduss")
+        XCTAssertEqual(Set(loginFields.keys), Set(["_client_version", "bdusstoken", "sign"]))
 
-        let mutation = try XCTUnwrap(records.first(where: { $0.path == "/c/c/post/add" }))
-        let mutationParts = try Self.multipartParts(from: mutation)
-        XCTAssertEqual(mutationParts.map(\.name), ["data"])
-        let protobufData = try XCTUnwrap(mutationParts.first?.body)
-        let protobuf = try Tieba_AddPostRequest(serializedBytes: protobufData)
-        XCTAssertEqual(protobuf.data.common.tbs, "fresh-tbs")
-        XCTAssertNotEqual(protobuf.data.common.tbs, Self.account.tbs)
-        XCTAssertEqual(protobuf.data.content, "带图回复\n#(pic,fixture_pic_1,1,1)")
-        XCTAssertEqual(protobuf.data.takephotoNum, "1")
-        XCTAssertEqual(protobuf.data.isPictxt, "1")
+        let mutation = try XCTUnwrap(records.last)
+        let mutationFields = try Self.formFields(from: mutation)
+        XCTAssertEqual(mutationFields["co"], "带图回复")
+        XCTAssertEqual(mutationFields["upload_img_info"], Self.fixtureImageInfo)
+        XCTAssertEqual(mutationFields["tbs"], "fresh-tbs")
+        XCTAssertNotEqual(mutationFields["tbs"], Self.account.tbs)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/cooluploadpic", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/s/uploadPicture", id: harness.id), 0)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+    }
 
-        XCTAssertNil(mutation.header(named: "Cookie"))
-        for record in records where record.path != "/c/s/login" {
-            let cookie = record.header(named: "Cookie") ?? ""
-            XCTAssertFalse(cookie.localizedCaseInsensitiveContains("BDUSS="))
-            XCTAssertFalse(cookie.localizedCaseInsensitiveContains("STOKEN="))
-            XCTAssertFalse(cookie.localizedCaseInsensitiveContains("BAIDUID="))
+    func testWebUploadFailuresRemainTypedAndStopBeforeTBSOrFinalMutation() async throws {
+        let cases: [(SubmissionStubMode, ContentSubmissionError)] = [
+            (
+                .uploadResponse(Data(#"{"error_code":7,"error_msg":"上传被拒绝"}"#.utf8)),
+                .business(code: 7, message: "上传被拒绝")
+            ),
+            (
+                .uploadResponse(Data(#"{"error_code":110001,"error_msg":"用户未登录"}"#.utf8)),
+                .sessionExpired
+            ),
+            (
+                .uploadTransportFailure,
+                .business(code: -1, message: "图片上传失败，请检查网络后重试。")
+            )
+        ]
+
+        for (mode, expected) in cases {
+            let harness = makeAPI(mode: mode)
+            await assertSubmissionError(
+                from: harness.api,
+                request: try Self.imageReplyRequest(),
+                equals: expected
+            )
+            XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), ["/mo/q/cooluploadpic"])
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/s/login", id: harness.id), 0)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 0)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+            SubmissionURLProtocol.remove(id: harness.id)
         }
-        let loginCookie = login.header(named: "Cookie") ?? ""
-        XCTAssertFalse(loginCookie.localizedCaseInsensitiveContains("BDUSS="))
-        XCTAssertFalse(loginCookie.localizedCaseInsensitiveContains("STOKEN="))
     }
 
     func testMalformedFloorTargetsAreRejectedBeforeBootstrapOrNetwork() async throws {
-        let response = try Self.addPostResponse(tid: "1001", pid: "9001")
+        let response = Data(#"{"no":0,"data":{"tid":1001,"pid":9001}}"#.utf8)
         let bootstrap = CountingSubmissionPostingBootstrap(result: Self.bootstrap)
         let harness = makeAPI(mode: .finalResponse(response), postingBootstrap: bootstrap)
         defer { SubmissionURLProtocol.remove(id: harness.id) }
@@ -755,64 +1155,24 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         XCTAssertTrue(SubmissionURLProtocol.records(id: harness.id).isEmpty)
     }
 
-    func testBootstrapSessionErrorsAreTypedAndNeverUploadOrMutate() async throws {
-        let imageData = try XCTUnwrap(Data(base64Encoded: Self.onePixelPNGBase64))
-        let request = ContentSubmissionRequest(
-            target: Self.target,
-            title: "",
-            body: "bootstrap 失败后不得继续",
-            images: [ContentSubmissionImage(
-                data: imageData,
-                pixelWidth: 1,
-                pixelHeight: 1,
-                mimeType: "image/png"
-            )]
-        )
-        let errors: [TiebaPostingBootstrapError] = [
-            .invalidCredential,
-            .server(code: 4, message: "登录失效"),
-            .server(code: 110001, message: "登录失效"),
-            .server(code: 110002, message: "登录失效"),
-            .server(code: 110003, message: "登录失效"),
-            .server(code: 110004, message: "登录失效")
-        ]
-
-        for error in errors {
-            let harness = makeAPI(
-                mode: .finalResponse(try Self.addPostResponse(tid: "1001", pid: "9001")),
-                postingBootstrap: FailingSubmissionPostingBootstrap(error: error)
-            )
-            defer { SubmissionURLProtocol.remove(id: harness.id) }
-
-            await assertSubmissionError(
-                from: harness.api,
-                request: request,
-                equals: .sessionExpired
-            )
-            XCTAssertTrue(
-                SubmissionURLProtocol.records(id: harness.id).isEmpty,
-                "Bootstrap error \(error) must stop before upload, TBS refresh, and mutation"
-            )
-        }
-    }
-
-    func testUnrelatedBootstrapServerErrorRemainsRetryableAndNeverMutates() async throws {
+    func testReplyDoesNotConsultPostingBootstrapEvenWhenItWouldFail() async throws {
         let error = TiebaPostingBootstrapError.server(code: 340006, message: "sync rejected")
         let harness = makeAPI(
-            mode: .finalResponse(try Self.addPostResponse(tid: "1001", pid: "9001")),
+            mode: .finalResponse(Data(#"{"no":0,"data":{"tid":1001,"pid":9001}}"#.utf8)),
             postingBootstrap: FailingSubmissionPostingBootstrap(error: error)
         )
         defer { SubmissionURLProtocol.remove(id: harness.id) }
 
-        do {
-            _ = try await harness.api.submitContent(account: Self.account, request: Self.textReply)
-            XCTFail("Expected bootstrap failure")
-        } catch let actual as TiebaPostingBootstrapError {
-            XCTAssertEqual(actual, error)
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-        XCTAssertTrue(SubmissionURLProtocol.records(id: harness.id).isEmpty)
+        let receipt = try await harness.api.submitContent(
+            account: Self.account,
+            request: Self.textReply
+        )
+
+        XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: 9001))
+        XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
+            "/c/s/login",
+            "/mo/q/apubpost"
+        ])
     }
 
     func testStrictTBSRefreshFailureNeverSendsFinalMutation() async {
@@ -827,44 +1187,34 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
-            "/c/s/login",
-            "/mo/q/newmoindex"
+            "/c/s/login"
         ])
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 0)
         XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
     }
 
-    func testFinalTransportFailureHasUnknownOutcomeAndIsNotRetried() async {
-        let harness = makeAPI(mode: .finalTransportFailure)
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
-
-        await assertSubmissionError(
-            from: harness.api,
-            request: Self.textReply,
-            equals: .outcomeUnknown
-        )
-        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 1)
+    func testWebReplyFinalTransportAndDecodeFailuresHaveUnknownOutcomeWithoutRetry() async {
+        for mode in [SubmissionStubMode.finalTransportFailure, .finalDecodeFailure] {
+            let harness = makeAPI(mode: mode)
+            await assertSubmissionError(
+                from: harness.api,
+                request: Self.textReply,
+                equals: .outcomeUnknown
+            )
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
+            SubmissionURLProtocol.remove(id: harness.id)
+        }
     }
 
-    func testFinalDecodeFailureHasUnknownOutcomeAndIsNotRetried() async {
-        let harness = makeAPI(mode: .finalDecodeFailure)
-        defer { SubmissionURLProtocol.remove(id: harness.id) }
-
-        await assertSubmissionError(
-            from: harness.api,
-            request: Self.textReply,
-            equals: .outcomeUnknown
-        )
-        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 1)
-    }
-
-    func testCancellationAfterFinalDispatchHasUnknownOutcomeAndIsNotRetried() async throws {
+    func testWebReplyCancellationAfterFinalDispatchHasUnknownOutcomeWithoutRetry() async throws {
         let harness = makeAPI(mode: .holdFinalRequestUntilCancellation)
         defer { SubmissionURLProtocol.remove(id: harness.id) }
         let submission = Task {
             try await harness.api.submitContent(account: Self.account, request: Self.textReply)
         }
 
-        try await waitForRequest(path: "/c/c/post/add", id: harness.id)
+        try await waitForRequest(path: "/mo/q/apubpost", id: harness.id)
         submission.cancel()
 
         do {
@@ -875,7 +1225,8 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
-        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
     }
 
     private func makeAPI(mode: SubmissionStubMode) -> (api: TiebaAPI, id: String) {
@@ -917,138 +1268,42 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         from api: TiebaAPI,
         request: ContentSubmissionRequest,
         equals expected: ContentSubmissionError,
+        context: String = "",
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {
+        let contextSuffix = context.isEmpty ? "" : " for response: \(context)"
         do {
             _ = try await api.submitContent(account: Self.account, request: request)
-            XCTFail("Expected submission to fail", file: file, line: line)
+            XCTFail("Expected submission to fail\(contextSuffix)", file: file, line: line)
         } catch let error as ContentSubmissionError {
-            XCTAssertEqual(error, expected, file: file, line: line)
+            XCTAssertEqual(
+                error,
+                expected,
+                "Unexpected submission error\(contextSuffix)",
+                file: file,
+                line: line
+            )
         } catch {
-            XCTFail("Unexpected error: \(error)", file: file, line: line)
+            XCTFail("Unexpected error: \(error)\(contextSuffix)", file: file, line: line)
         }
-    }
-
-    private static func addPostResponse(
-        errorCode: Int32 = 0,
-        userMessage: String = "",
-        tid: String? = nil,
-        pid: String? = nil,
-        message: String = "",
-        needsVerification: Bool = false
-    ) throws -> Data {
-        var response = Tieba_AddPostResponse()
-        var error = Tieba_Error()
-        error.errorCode = errorCode
-        error.userMsg = userMessage
-        response.error = error
-        if tid != nil || pid != nil || message.isEmpty == false || needsVerification {
-            var data = Tieba_AddPostResponse.DataMessage()
-            data.tid = tid ?? ""
-            data.pid = pid ?? ""
-            data.msg = message
-            if needsVerification {
-                var info = Tieba_SubmissionVerificationInfo()
-                info.needVcode = "1"
-                info.vcodeMd5 = "fixture-md5"
-                info.vcodeType = "2"
-                data.info = info
-            }
-            response.data = data
-        }
-        return try response.serializedData()
-    }
-
-    private static func addThreadResponse(tid: String, pid: String) throws -> Data {
-        var response = Tieba_AddThreadResponse()
-        response.error = Tieba_Error()
-        var data = Tieba_AddThreadResponse.DataMessage()
-        data.tid = tid
-        data.pid = pid
-        response.data = data
-        return try response.serializedData()
-    }
-
-    private static func multipartParts(from request: SubmissionRecordedRequest) throws -> [MultipartPart] {
-        let contentType = try XCTUnwrap(request.header(named: "Content-Type"))
-        let boundaryPrefix = "boundary="
-        let boundary = try XCTUnwrap(
-            contentType.components(separatedBy: ";")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .first { $0.hasPrefix(boundaryPrefix) }
-                .map { String($0.dropFirst(boundaryPrefix.count)).trimmingCharacters(in: CharacterSet(charactersIn: "\"")) }
-        )
-        let body = try XCTUnwrap(request.body)
-        let delimiter = Data("--\(boundary)".utf8)
-        let headerTerminator = Data("\r\n\r\n".utf8)
-        let contentTerminator = Data("\r\n--\(boundary)".utf8)
-        var parts: [MultipartPart] = []
-        var searchStart = body.startIndex
-
-        while let delimiterRange = body.range(
-            of: delimiter,
-            options: [],
-            in: searchStart..<body.endIndex
-        ) {
-            let suffixStart = delimiterRange.upperBound
-            guard suffixStart + 2 <= body.endIndex else { break }
-            if body[suffixStart..<(suffixStart + 2)].elementsEqual(Data("--".utf8)) {
-                break
-            }
-            guard body[suffixStart..<(suffixStart + 2)].elementsEqual(Data("\r\n".utf8)) else {
-                throw MultipartTestError.malformed
-            }
-            let headerStart = suffixStart + 2
-            guard let headerRange = body.range(
-                of: headerTerminator,
-                options: [],
-                in: headerStart..<body.endIndex
-            ) else {
-                throw MultipartTestError.malformed
-            }
-            let contentStart = headerRange.upperBound
-            guard let contentRange = body.range(
-                of: contentTerminator,
-                options: [],
-                in: contentStart..<body.endIndex
-            ) else {
-                throw MultipartTestError.malformed
-            }
-            guard let headers = String(data: body[headerStart..<headerRange.lowerBound], encoding: .utf8),
-                  let disposition = headers.components(separatedBy: "\r\n")
-                    .first(where: { $0.lowercased().hasPrefix("content-disposition:") }),
-                  let name = Self.dispositionValue(named: "name", in: disposition) else {
-                throw MultipartTestError.malformed
-            }
-            parts.append(MultipartPart(
-                name: name,
-                filename: Self.dispositionValue(named: "filename", in: disposition),
-                body: Data(body[contentStart..<contentRange.lowerBound])
-            ))
-            searchStart = contentRange.lowerBound + 2
-        }
-        return parts
-    }
-
-    private static func dispositionValue(named key: String, in disposition: String) -> String? {
-        let prefix = "\(key)=\""
-        guard let startRange = disposition.range(of: prefix) else { return nil }
-        let valueStart = startRange.upperBound
-        guard let valueEnd = disposition[valueStart...].firstIndex(of: "\"") else { return nil }
-        return String(disposition[valueStart..<valueEnd])
-    }
-
-    private static func textPart(named name: String, in parts: [MultipartPart]) throws -> String {
-        let part = try XCTUnwrap(parts.first(where: { $0.name == name }))
-        return try XCTUnwrap(String(data: part.body, encoding: .utf8))
     }
 
     private static func formFields(from request: SubmissionRecordedRequest) throws -> [String: String] {
         let body = try XCTUnwrap(request.body)
         let text = try XCTUnwrap(String(data: body, encoding: .utf8))
         var components = URLComponents()
-        components.percentEncodedQuery = text
+        // application/x-www-form-urlencoded represents spaces as '+'. A
+        // literal plus is already escaped as %2B by the production encoder.
+        components.percentEncodedQuery = text.replacingOccurrences(of: "+", with: "%20")
+        return Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map {
+            ($0.name, $0.value ?? "")
+        })
+    }
+
+    private static func queryFields(from request: SubmissionRecordedRequest) -> [String: String] {
+        var components = URLComponents()
+        components.percentEncodedQuery = request.query
         return Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map {
             ($0.name, $0.value ?? "")
         })
@@ -1086,6 +1341,89 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         images: []
     )
 
+    private static func replyRequest(kind: ContentSubmissionKind) -> ContentSubmissionRequest {
+        let target: ContentSubmissionTarget
+        switch kind {
+        case .threadReply:
+            target = Self.target
+        case .postReply:
+            target = ContentSubmissionTarget(
+                kind: .postReply,
+                forumID: 100,
+                forumName: "fixture",
+                forumDisplayName: "夹具吧",
+                threadID: 1001,
+                threadTitle: "夹具主题",
+                parentPostID: 2002,
+                parentFloor: 2,
+                subpostID: nil,
+                replyUserID: 42,
+                replyUserDisplayName: "被回复用户"
+            )
+        case .subpostReply:
+            target = ContentSubmissionTarget(
+                kind: .subpostReply,
+                forumID: 100,
+                forumName: "fixture",
+                forumDisplayName: "夹具吧",
+                threadID: 1001,
+                threadTitle: "夹具主题",
+                parentPostID: 2002,
+                parentFloor: 2,
+                subpostID: 3002,
+                replyUserID: 43,
+                replyUserDisplayName: "被回复用户"
+            )
+        case .newThread:
+            target = Self.target
+        }
+        return ContentSubmissionRequest(
+            target: target,
+            title: "",
+            body: "离线提交测试",
+            images: []
+        )
+    }
+
+    private static func imageReplyRequest() throws -> ContentSubmissionRequest {
+        let imageData = try XCTUnwrap(Data(base64Encoded: onePixelPNGBase64))
+        return ContentSubmissionRequest(
+            target: target,
+            title: "",
+            body: "带图回复",
+            images: [ContentSubmissionImage(
+                data: imageData,
+                pixelWidth: 1,
+                pixelHeight: 1,
+                mimeType: "image/png"
+            )]
+        )
+    }
+
+    private static func newThreadRequest(
+        title: String = "新主题",
+        body: String = "新主题正文"
+    ) -> ContentSubmissionRequest {
+        ContentSubmissionRequest(
+            target: ContentSubmissionTarget(
+                kind: .newThread,
+                forumID: 100,
+                forumName: "fixture",
+                forumDisplayName: "夹具吧",
+                threadID: nil,
+                threadTitle: nil,
+                parentPostID: nil,
+                parentFloor: nil,
+                subpostID: nil,
+                replyUserID: nil,
+                replyUserDisplayName: nil
+            ),
+            title: title,
+            body: body,
+            images: []
+        )
+    }
+
     private static let requestBuilder = TiebaRequestBuilder(
         screenScale: 3,
         screenWidth: 1179,
@@ -1107,6 +1445,7 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
 
     private static let onePixelPNGBase64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    private static let fixtureImageInfo = "fixture-image-info"
 }
 
 private struct SubmissionPostingBootstrapStub: TiebaPostingBootstrapping {
@@ -1143,6 +1482,8 @@ private actor CountingSubmissionPostingBootstrap: TiebaPostingBootstrapping {
 
 private enum SubmissionStubMode: Sendable {
     case finalResponse(Data)
+    case uploadResponse(Data)
+    case uploadTransportFailure
     case tbsRefreshFailure
     case finalTransportFailure
     case finalDecodeFailure
@@ -1151,22 +1492,16 @@ private enum SubmissionStubMode: Sendable {
 
 private struct SubmissionRecordedRequest: Sendable {
     let path: String
+    let scheme: String
+    let host: String
+    let method: String
+    let query: String?
     let headers: [String: String]
     let body: Data?
 
     func header(named name: String) -> String? {
         headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
     }
-}
-
-private struct MultipartPart: Equatable {
-    let name: String
-    let filename: String?
-    let body: Data
-}
-
-private enum MultipartTestError: Error {
-    case malformed
 }
 
 private final class SubmissionURLProtocol: URLProtocol {
@@ -1221,6 +1556,20 @@ private final class SubmissionURLProtocol: URLProtocol {
         }
 
         switch url.path {
+        case "/mo/q/cooluploadpic":
+            switch mode {
+            case let .uploadResponse(payload):
+                respond(statusCode: 200, payload: payload, contentType: "application/json")
+            case .uploadTransportFailure:
+                client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+            default:
+                respond(
+                    statusCode: 200,
+                    payload: Data(#"{"error_code":0,"image_info":"fixture-image-info"}"#.utf8),
+                    contentType: "application/json"
+                )
+            }
+
         case "/c/s/uploadPicture":
             respond(
                 statusCode: 200,
@@ -1242,7 +1591,7 @@ private final class SubmissionURLProtocol: URLProtocol {
         case "/mo/q/newmoindex":
             respond(statusCode: 503, payload: Data("unavailable".utf8))
 
-        case "/c/c/post/add", "/c/c/thread/add":
+        case "/mo/q/apubpost", "/c/c/post/add", "/f/commit/thread/add":
             switch mode {
             case let .finalResponse(payload):
                 respond(statusCode: 200, payload: payload)
@@ -1252,7 +1601,7 @@ private final class SubmissionURLProtocol: URLProtocol {
                 respond(statusCode: 200, payload: Data([0x0f]))
             case .holdFinalRequestUntilCancellation:
                 break
-            case .tbsRefreshFailure:
+            case .tbsRefreshFailure, .uploadResponse, .uploadTransportFailure:
                 client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
             }
 
@@ -1266,6 +1615,10 @@ private final class SubmissionURLProtocol: URLProtocol {
     private static func record(request: URLRequest, id: String) -> SubmissionStubMode? {
         let record = SubmissionRecordedRequest(
             path: request.url?.path ?? "",
+            scheme: request.url?.scheme ?? "",
+            host: request.url?.host ?? "",
+            method: request.httpMethod ?? "",
+            query: request.url?.query,
             headers: request.allHTTPHeaderFields ?? [:],
             body: requestBody(request)
         )

--- a/TiebaPureTests/MultipartFormDataTests.swift
+++ b/TiebaPureTests/MultipartFormDataTests.swift
@@ -47,6 +47,30 @@ final class MultipartFormDataTests: XCTestCase {
         XCTAssertTrue(text.contains("name=\"data\"; filename=\"file\""))
     }
 
+    func testRequestBuilderCanMatchProtobufPartWithoutMIMEHeader() throws {
+        let builder = TiebaRequestBuilder(
+            screenScale: 3,
+            screenWidth: 1179,
+            screenHeight: 2556,
+            clientID: "client"
+        )
+        var request = Tieba_CommonRequest()
+        request.clientType = 2
+
+        let multipart = try builder.multipart(
+            protobuf: request,
+            account: nil,
+            includeSToken: false,
+            fileContentType: nil
+        )
+        let expectedHeader = Data(
+            "Content-Disposition: form-data; name=\"data\"; filename=\"file\"\r\n\r\n".utf8
+        )
+
+        XCTAssertNotNil(multipart.body.range(of: expectedHeader))
+        XCTAssertNil(multipart.body.range(of: Data("Content-Type:".utf8)))
+    }
+
     func testCommonRequestCopiesAccountAndDeviceFields() {
         let builder = TiebaRequestBuilder(
             screenScale: 3,

--- a/TiebaPureTests/SecurityRegressionTests.swift
+++ b/TiebaPureTests/SecurityRegressionTests.swift
@@ -14,16 +14,22 @@ final class SecurityRegressionTests: XCTestCase {
     }
 
     func testKeychainUpdatesExistingItemWithoutDeleteFirst() async throws {
+        let securityOperations = InMemoryKeychainSecurityOperations()
         let service = KeychainAccountStoreService(
             service: "dev.infinityf4p.tiebapure.tests.\(UUID().uuidString)",
-            account: "update"
+            account: "update",
+            securityOperations: securityOperations
         )
-        try? await service.clearData()
         try await service.saveData(Data("first".utf8))
         try await service.saveData(Data("second".utf8))
         let loaded = try await service.loadData()
+
         XCTAssertEqual(loaded, Data("second".utf8))
+        XCTAssertEqual(securityOperations.calls, [.update, .add, .update, .copy])
+        XCTAssertFalse(securityOperations.calls.contains(.delete))
+
         try await service.clearData()
+        XCTAssertEqual(securityOperations.calls.last, .delete)
     }
 
     func testAccountEncodingDoesNotPersistCompleteCookieField() throws {
@@ -358,6 +364,22 @@ final class SecurityRegressionTests: XCTestCase {
         XCTAssertThrowsError(try TiebaResponseValidator.validate(code: 12, message: "业务错误")) {
             XCTAssertEqual($0 as? TiebaAPIError, .response(code: 12, message: "业务错误"))
         }
+        XCTAssertThrowsError(
+            try TiebaResponseValidator.validate(code: 4, message: "贴子可能已被删除")
+        ) {
+            XCTAssertEqual(
+                $0 as? TiebaAPIError,
+                .response(code: 4, message: "贴子可能已被删除")
+            )
+        }
+        XCTAssertThrowsError(
+            try TiebaResponseValidator.validate(code: 4, message: "登录已失效")
+        ) {
+            XCTAssertEqual(
+                $0 as? TiebaAPIError,
+                .sessionExpired(code: 4, message: "登录已失效")
+            )
+        }
         XCTAssertThrowsError(try TiebaResponseValidator.validate(code: 110001, message: "登录失效")) {
             XCTAssertEqual($0 as? TiebaAPIError, .sessionExpired(code: 110001, message: "登录失效"))
         }
@@ -405,6 +427,68 @@ final class SecurityRegressionTests: XCTestCase {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [SecurityURLProtocol.self]
         return URLSession(configuration: configuration)
+    }
+}
+
+private final class InMemoryKeychainSecurityOperations: KeychainSecurityOperating, @unchecked Sendable {
+    enum Call: Equatable {
+        case copy
+        case update
+        case add
+        case delete
+    }
+
+    private let lock = NSLock()
+    private var storedData: Data?
+    private var recordedCalls: [Call] = []
+
+    var calls: [Call] {
+        lock.withLock { recordedCalls }
+    }
+
+    func copyMatching(
+        _ query: CFDictionary,
+        result: UnsafeMutablePointer<CFTypeRef?>?
+    ) -> OSStatus {
+        lock.withLock {
+            recordedCalls.append(.copy)
+            guard let storedData else { return errSecItemNotFound }
+            result?.pointee = storedData as CFData
+            return errSecSuccess
+        }
+    }
+
+    func update(_ query: CFDictionary, attributes: CFDictionary) -> OSStatus {
+        lock.withLock {
+            recordedCalls.append(.update)
+            guard storedData != nil else { return errSecItemNotFound }
+            guard let data = (attributes as NSDictionary)[kSecValueData] as? Data else {
+                return errSecParam
+            }
+            storedData = data
+            return errSecSuccess
+        }
+    }
+
+    func add(_ attributes: CFDictionary) -> OSStatus {
+        lock.withLock {
+            recordedCalls.append(.add)
+            guard storedData == nil else { return errSecDuplicateItem }
+            guard let data = (attributes as NSDictionary)[kSecValueData] as? Data else {
+                return errSecParam
+            }
+            storedData = data
+            return errSecSuccess
+        }
+    }
+
+    func delete(_ query: CFDictionary) -> OSStatus {
+        lock.withLock {
+            recordedCalls.append(.delete)
+            let status: OSStatus = storedData == nil ? errSecItemNotFound : errSecSuccess
+            storedData = nil
+            return status
+        }
     }
 }
 

--- a/TiebaPureTests/SocialRelationshipStateTests.swift
+++ b/TiebaPureTests/SocialRelationshipStateTests.swift
@@ -118,6 +118,296 @@ final class SocialRelationshipStateTests: XCTestCase {
         XCTAssertFalse(state.isForumMutationPending(accountID: account.id, forum: forum))
     }
 
+    func testSameUIDCredentialReplacementCancelsOldMutationAndRejectsItsLateResult() async throws {
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI()
+        let coordinator = SocialMutationCoordinator(api: api, state: state)
+        let oldAccount = makeAccount(credential: "old")
+        let replacementAccount = makeAccount(credential: "replacement")
+        let user = makeUser(id: 99)
+
+        let oldMutation = Task {
+            try await coordinator.setUserFollowed(
+                account: oldAccount,
+                user: user,
+                followed: true
+            )
+        }
+        await api.waitForFirstUserMutation()
+
+        let invalidation = Task {
+            await coordinator.beginInvalidation(session: oldAccount.sessionIdentity)
+        }
+        await waitForInvalidation(coordinator, session: oldAccount.sessionIdentity)
+
+        do {
+            try await coordinator.setUserFollowed(
+                account: oldAccount,
+                user: user,
+                followed: true
+            )
+            XCTFail("旧会话处于切换屏障时不应接受新的社交写操作")
+        } catch {
+            XCTAssertEqual(error as? SocialMutationCoordinatorError, .sessionTransition)
+        }
+
+        await api.releaseFirstUserMutation()
+        await invalidation.value
+        do {
+            try await oldMutation.value
+            XCTFail("忽略网络取消后晚到的旧会话结果不应成功返回")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertNil(state.userFollowState(accountID: oldAccount.id, user: user))
+        XCTAssertFalse(state.isUserMutationPending(accountID: oldAccount.id, user: user))
+
+        coordinator.endInvalidation(session: oldAccount.sessionIdentity)
+        try await coordinator.setUserFollowed(
+            account: replacementAccount,
+            user: user,
+            followed: true
+        )
+        XCTAssertEqual(state.userFollowState(accountID: replacementAccount.id, user: user), true)
+        let sessions = await api.userMutationSessions()
+        XCTAssertEqual(sessions, [oldAccount.sessionIdentity, replacementAccount.sessionIdentity])
+    }
+
+    func testLogoutDrainsSocialMutationAndKeepsGlobalBarrierUntilNewSessionIsVisible() async throws {
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI()
+        let coordinator = SocialMutationCoordinator(api: api, state: state)
+        let account = makeAccount(credential: "logout")
+        let replacementAccount = makeAccount(credential: "replacement")
+        let user = makeUser(id: 99)
+        let store = AccountStore(service: MemoryAccountStoreService())
+        try await store.save(account)
+        let cleaner = SocialMutationAwareArtifactCleaner {
+            state.isUserMutationPending(accountID: account.id, user: user) == false
+        }
+        let logout = LogoutCoordinator(
+            accountStore: store,
+            artifactCleaner: cleaner,
+            beginWriteInvalidation: { await coordinator.beginInvalidation() },
+            endWriteInvalidation: { coordinator.endInvalidation() }
+        )
+
+        let mutation = Task {
+            try await coordinator.setUserFollowed(account: account, user: user, followed: true)
+        }
+        await api.waitForFirstUserMutation()
+        let logoutTask = Task {
+            try await logout.logOut()
+        }
+        await waitForInvalidation(coordinator, session: account.sessionIdentity)
+
+        await api.releaseFirstUserMutation()
+        try await logoutTask.value
+        XCTAssertTrue(cleaner.observedNoActiveMutation)
+        let storedAccount = try await store.load()
+        XCTAssertNil(storedAccount)
+        do {
+            try await mutation.value
+            XCTFail("注销排空的旧社交写操作应收到取消")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertNil(state.userFollowState(accountID: account.id, user: user))
+
+        do {
+            try await coordinator.setUserFollowed(
+                account: replacementAccount,
+                user: user,
+                followed: true
+            )
+            XCTFail("注销成功后、新会话显示前应保持全局社交写屏障")
+        } catch {
+            XCTAssertEqual(error as? SocialMutationCoordinatorError, .sessionTransition)
+        }
+
+        coordinator.endInvalidation()
+        try await coordinator.setUserFollowed(
+            account: replacementAccount,
+            user: user,
+            followed: true
+        )
+        XCTAssertEqual(state.userFollowState(accountID: account.id, user: user), true)
+    }
+
+    func testLogoutFailureReleasesGlobalSocialBarrier() async throws {
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI(blocksFirstUserMutation: false)
+        let coordinator = SocialMutationCoordinator(api: api, state: state)
+        let account = makeAccount(credential: "failure")
+        let user = makeUser(id: 99)
+        let store = AccountStore(service: MemoryAccountStoreService())
+        try await store.save(account)
+        let logout = LogoutCoordinator(
+            accountStore: store,
+            artifactCleaner: FailingSocialArtifactCleaner(),
+            beginWriteInvalidation: { await coordinator.beginInvalidation() },
+            endWriteInvalidation: { coordinator.endInvalidation() }
+        )
+
+        do {
+            try await logout.logOut()
+            XCTFail("清理失败时注销应失败")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .cannotRemoveFile)
+        }
+
+        try await coordinator.setUserFollowed(account: account, user: user, followed: true)
+        XCTAssertEqual(state.userFollowState(accountID: account.id, user: user), true)
+        let storedAccount = try await store.load()
+        XCTAssertEqual(storedAccount, account)
+    }
+
+    func testNestedInvalidationRequiresMatchingRelease() async throws {
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI(blocksFirstUserMutation: false)
+        let coordinator = SocialMutationCoordinator(api: api, state: state)
+        let account = makeAccount(credential: "nested")
+        let user = makeUser(id: 99)
+
+        await coordinator.beginInvalidation(session: account.sessionIdentity)
+        await coordinator.beginInvalidation(session: account.sessionIdentity)
+        coordinator.endInvalidation(session: account.sessionIdentity)
+
+        do {
+            try await coordinator.setUserFollowed(account: account, user: user, followed: true)
+            XCTFail("嵌套会话屏障尚未完全释放")
+        } catch {
+            XCTAssertEqual(error as? SocialMutationCoordinatorError, .sessionTransition)
+        }
+
+        coordinator.endInvalidation(session: account.sessionIdentity)
+        coordinator.endInvalidation(session: account.sessionIdentity)
+        try await coordinator.setUserFollowed(account: account, user: user, followed: true)
+        XCTAssertEqual(state.userFollowState(accountID: account.id, user: user), true)
+    }
+
+    func testAccountTransitionPolicyInvalidatesExactOldSessionOnlyForCredentialChanges() {
+        let oldAccount = makeAccount(credential: "old")
+        var metadataUpdate = oldAccount
+        metadataUpdate.displayName = "新昵称"
+        metadataUpdate.tbs = "refreshed-tbs"
+        let replacementAccount = makeAccount(credential: "replacement")
+
+        XCTAssertNil(AccountTransitionPolicy.invalidatedSession(
+            previous: oldAccount,
+            next: metadataUpdate
+        ))
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedSession(
+            previous: oldAccount,
+            next: replacementAccount
+        ), oldAccount.sessionIdentity)
+        XCTAssertNotEqual(oldAccount.sessionIdentity, replacementAccount.sessionIdentity)
+    }
+
+    func testGlobalInvalidationRejectsLateForumAndLikeResults() async throws {
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI(blocksFirstUserMutation: false)
+        let coordinator = SocialMutationCoordinator(api: api, state: state)
+        let account = makeAccount(credential: "global")
+        let forum = makeForum(id: 73)
+
+        let forumMutation = Task {
+            try await coordinator.setForumFollowed(
+                account: account,
+                forum: forum,
+                followed: true
+            )
+        }
+        let likeMutation = Task {
+            try await coordinator.setPostLiked(
+                account: account,
+                threadID: 1_001,
+                postID: 9_001,
+                objectType: .post,
+                liked: true
+            )
+        }
+        await api.waitForFirstForumMutation()
+        await api.waitForFirstLikeMutation()
+
+        let invalidation = Task {
+            await coordinator.beginInvalidation()
+        }
+        await waitForInvalidation(coordinator, session: account.sessionIdentity)
+        await api.releaseFirstForumMutation()
+        await api.releaseFirstLikeMutation()
+        await invalidation.value
+
+        do {
+            _ = try await forumMutation.value
+            XCTFail("全局屏障不应提交晚到的吧关注结果")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        do {
+            try await likeMutation.value
+            XCTFail("全局屏障不应接受晚到的点赞结果")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertNil(state.forumFollowState(accountID: account.id, forum: forum))
+        XCTAssertFalse(state.isForumMutationPending(accountID: account.id, forum: forum))
+        coordinator.endInvalidation()
+    }
+
+    func testTwoPhaseBarrierRejectsContentWriteWhileSocialDrainIsBlocked() async throws {
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI()
+        let socialCoordinator = SocialMutationCoordinator(api: api, state: state)
+        let contentCoordinator = ContentSubmissionCoordinator(api: api)
+        let account = makeAccount(credential: "two-phase")
+        let user = makeUser(id: 99)
+        let mutation = Task {
+            try await socialCoordinator.setUserFollowed(
+                account: account,
+                user: user,
+                followed: true
+            )
+        }
+        await api.waitForFirstUserMutation()
+
+        socialCoordinator.establishInvalidationBarrier()
+        contentCoordinator.establishInvalidationBarrier()
+        let socialDrain = Task { @MainActor in
+            await socialCoordinator.drainInvalidatedOperations()
+        }
+        let contentDrain = Task { @MainActor in
+            await contentCoordinator.drainInvalidatedOperations()
+        }
+        await Task.yield()
+
+        XCTAssertTrue(socialCoordinator.isInvalidating(session: account.sessionIdentity))
+        XCTAssertTrue(contentCoordinator.isInvalidating(accountID: account.id))
+        do {
+            try await contentCoordinator.performAccountWrite(
+                account: account,
+                target: .profile
+            ) {
+                XCTFail("屏障建立后不应启动新的内容写任务")
+            }
+            XCTFail("社交排空仍被阻塞时，内容写入口也必须已经关闭")
+        } catch {
+            XCTAssertEqual(error as? ContentSubmissionCoordinatorError, .sessionTransition)
+        }
+
+        await api.releaseFirstUserMutation()
+        await socialDrain.value
+        await contentDrain.value
+        do {
+            try await mutation.value
+            XCTFail("排空的旧社交写操作应收到取消")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        contentCoordinator.endInvalidation()
+        socialCoordinator.endInvalidation()
+    }
+
     private func makeForum(id: Int64) -> Forum {
         Forum(
             id: id,
@@ -137,4 +427,162 @@ final class SocialRelationshipStateTests: XCTestCase {
             portrait: "fixture.portrait"
         )
     }
+
+    private func makeAccount(credential: String) -> Account {
+        Account(
+            uid: "42",
+            name: "fixture_user",
+            displayName: "合成账号",
+            portrait: "fixture.portrait",
+            bduss: "bduss-\(credential)",
+            stoken: "stoken-\(credential)",
+            baiduID: "baiduid-\(credential)",
+            tbs: "tbs-\(credential)"
+        )
+    }
+
+    private func waitForInvalidation(
+        _ coordinator: SocialMutationCoordinator,
+        session: AccountSessionIdentity
+    ) async {
+        for _ in 0..<100 where coordinator.isInvalidating(session: session) == false {
+            await Task.yield()
+        }
+        XCTAssertTrue(coordinator.isInvalidating(session: session))
+    }
+}
+
+@MainActor
+private final class SocialMutationAwareArtifactCleaner: SessionArtifactCleaning {
+    private let noActiveMutation: () -> Bool
+    private(set) var observedNoActiveMutation = false
+
+    init(noActiveMutation: @escaping () -> Bool) {
+        self.noActiveMutation = noActiveMutation
+    }
+
+    func clear() async throws {
+        observedNoActiveMutation = noActiveMutation()
+    }
+}
+
+@MainActor
+private struct FailingSocialArtifactCleaner: SessionArtifactCleaning {
+    func clear() async throws {
+        throw URLError(.cannotRemoveFile)
+    }
+}
+
+private actor ControlledSocialMutationAPI: TiebaAPIService {
+    private let blocksFirstUserMutation: Bool
+    private var userSessions: [AccountSessionIdentity] = []
+    private var firstUserContinuation: CheckedContinuation<Void, Never>?
+    private var firstUserWaiters: [CheckedContinuation<Void, Never>] = []
+    private var forumMutationStarted = false
+    private var firstForumContinuation: CheckedContinuation<Void, Never>?
+    private var firstForumWaiters: [CheckedContinuation<Void, Never>] = []
+    private var likeMutationStarted = false
+    private var firstLikeContinuation: CheckedContinuation<Void, Never>?
+    private var firstLikeWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(blocksFirstUserMutation: Bool = true) {
+        self.blocksFirstUserMutation = blocksFirstUserMutation
+    }
+
+    func waitForFirstUserMutation() async {
+        guard userSessions.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            firstUserWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstUserMutation() {
+        firstUserContinuation?.resume()
+        firstUserContinuation = nil
+    }
+
+    func userMutationSessions() -> [AccountSessionIdentity] {
+        userSessions
+    }
+
+    func waitForFirstForumMutation() async {
+        guard forumMutationStarted == false else { return }
+        await withCheckedContinuation { continuation in
+            firstForumWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstForumMutation() {
+        firstForumContinuation?.resume()
+        firstForumContinuation = nil
+    }
+
+    func waitForFirstLikeMutation() async {
+        guard likeMutationStarted == false else { return }
+        await withCheckedContinuation { continuation in
+            firstLikeWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstLikeMutation() {
+        firstLikeContinuation?.resume()
+        firstLikeContinuation = nil
+    }
+
+    func setUserFollowed(account: Account, user: UserSummary, followed: Bool) async throws {
+        _ = user
+        _ = followed
+        userSessions.append(account.sessionIdentity)
+        let callNumber = userSessions.count
+        let waiters = firstUserWaiters
+        firstUserWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        if blocksFirstUserMutation, callNumber == 1 {
+            // Deliberately ignore task cancellation to prove the coordinator's
+            // commit barrier rejects a late success from the stale session.
+            await withCheckedContinuation { continuation in
+                firstUserContinuation = continuation
+            }
+        }
+    }
+
+    func validateLogin(cookies: BaiduCookies) async throws -> Account { fatalError("unused") }
+    func personalizedThreads(account: Account?, page: Int, loadType: Int) async throws -> [ThreadSummary] { fatalError("unused") }
+    func followedForums(account: Account) async throws -> [Forum] { fatalError("unused") }
+    func forumThreads(account: Account?, forumName: String, page: Int, category: ForumThreadCategory) async throws -> [ThreadSummary] { fatalError("unused") }
+    func searchThreads(keyword: String, page: Int, sortType: Int, filterType: Int, forumName: String?, pageSize: Int) async throws -> SearchResultsPage { fatalError("unused") }
+    func resolveUser(named name: String) async throws -> UserSummary { fatalError("unused") }
+    func threadPage(account: Account?, threadID: Int64, page: Int, forumID: Int64?, postID: UInt64?, seeLz: Bool, sortType: ThreadReplySort) async throws -> ThreadPage { fatalError("unused") }
+    func subposts(account: Account?, threadID: Int64, postID: UInt64, forumID: Int64, page: Int, subpostID: UInt64) async throws -> [Subpost] { fatalError("unused") }
+    func userProfile(account: Account?, user: UserSummary) async throws -> UserProfile { fatalError("unused") }
+    func userThreads(account: Account?, userID: Int64, page: Int) async throws -> UserThreadsPage { fatalError("unused") }
+    func userRelationships(account: Account?, userID: Int64, kind: UserRelationshipKind, page: Int) async throws -> UserRelationshipPage { fatalError("unused") }
+    func forumMembership(account: Account, forum: Forum) async throws -> ForumMembership { fatalError("unused") }
+    func setForumFollowed(account: Account, forum: Forum, followed: Bool) async throws -> ForumMembership {
+        _ = account
+        forumMutationStarted = true
+        let waiters = firstForumWaiters
+        firstForumWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            firstForumContinuation = continuation
+        }
+        return ForumMembership(forumID: forum.id, isFollowed: followed)
+    }
+    func messages(account: Account, kind: MessageKind, page: Int) async throws -> MessagesPage { fatalError("unused") }
+    func setPostLiked(account: Account, threadID: Int64, postID: UInt64, objectType: TiebaLikeObjectType, liked: Bool) async throws {
+        _ = account
+        _ = threadID
+        _ = postID
+        _ = objectType
+        _ = liked
+        likeMutationStarted = true
+        let waiters = firstLikeWaiters
+        firstLikeWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            firstLikeContinuation = continuation
+        }
+    }
+    func submitContent(account: Account, request: ContentSubmissionRequest) async throws -> ContentSubmissionReceipt { fatalError("unused") }
 }

--- a/TiebaPureTests/SocialRelationshipStateTests.swift
+++ b/TiebaPureTests/SocialRelationshipStateTests.swift
@@ -355,6 +355,49 @@ final class SocialRelationshipStateTests: XCTestCase {
         coordinator.endInvalidation()
     }
 
+    func testLikeSettingRejectsBeforeNetworkAndObservesLiveValue() async throws {
+        var likesEnabled = false
+        let state = SocialRelationshipState()
+        let api = ControlledSocialMutationAPI(blocksFirstUserMutation: false)
+        let coordinator = SocialMutationCoordinator(
+            api: api,
+            state: state,
+            allowsLikes: { likesEnabled }
+        )
+        let account = makeAccount(credential: "like-setting")
+
+        do {
+            try await coordinator.setPostLiked(
+                account: account,
+                threadID: 1_001,
+                postID: 9_001,
+                objectType: .post,
+                liked: true
+            )
+            XCTFail("关闭点赞开关后不应进入网络层")
+        } catch {
+            XCTAssertEqual(error as? SocialMutationCoordinatorError, .likesDisabled)
+        }
+        let didStartWhileDisabled = await api.hasStartedLikeMutation()
+        XCTAssertFalse(didStartWhileDisabled)
+
+        likesEnabled = true
+        let mutation = Task {
+            try await coordinator.setPostLiked(
+                account: account,
+                threadID: 1_001,
+                postID: 9_001,
+                objectType: .post,
+                liked: true
+            )
+        }
+        await api.waitForFirstLikeMutation()
+        let didStartAfterEnabling = await api.hasStartedLikeMutation()
+        XCTAssertTrue(didStartAfterEnabling)
+        await api.releaseFirstLikeMutation()
+        try await mutation.value
+    }
+
     func testTwoPhaseBarrierRejectsContentWriteWhileSocialDrainIsBlocked() async throws {
         let state = SocialRelationshipState()
         let api = ControlledSocialMutationAPI()
@@ -522,6 +565,10 @@ private actor ControlledSocialMutationAPI: TiebaAPIService {
         await withCheckedContinuation { continuation in
             firstLikeWaiters.append(continuation)
         }
+    }
+
+    func hasStartedLikeMutation() -> Bool {
+        likeMutationStarted
     }
 
     func releaseFirstLikeMutation() {

--- a/TiebaPureTests/StateRegressionTests.swift
+++ b/TiebaPureTests/StateRegressionTests.swift
@@ -265,6 +265,11 @@ final class StateRegressionTests: XCTestCase {
 
         let reloaded = RecentForumStore(defaults: defaults, limit: 30, modelContainer: container)
         XCTAssertEqual(reloaded.items, store.items)
+
+        XCTAssertTrue(store.clear())
+        XCTAssertTrue(store.items.isEmpty)
+        let cleared = RecentForumStore(defaults: defaults, limit: 30, modelContainer: container)
+        XCTAssertTrue(cleared.items.isEmpty)
     }
 
     @MainActor

--- a/TiebaPureTests/TiebaPostingBootstrapTests.swift
+++ b/TiebaPureTests/TiebaPostingBootstrapTests.swift
@@ -19,6 +19,44 @@ final class TiebaPostingBootstrapTests: XCTestCase {
         super.tearDown()
     }
 
+    func testLiveAccountCredentialShape() async throws {
+        guard ProcessInfo.processInfo.environment["TIEBAPURE_RUN_LIVE_CREDENTIAL_CHECK"] == "1" else {
+            throw XCTSkip("真实账号凭证形态检查仅在显式启用时运行。")
+        }
+
+        let store = AccountStore(service: KeychainAccountStoreService())
+        let loadedAccount = try await store.load()
+        let account = try XCTUnwrap(loadedAccount)
+        let bdussBytes = account.bduss.utf8.count
+        let stokenBytes = account.stoken.utf8.count
+        print("TIEBAPURE_LIVE_CREDENTIAL_SHAPE bduss_bytes=\(bdussBytes) stoken_bytes=\(stokenBytes)")
+        XCTAssertEqual(bdussBytes, 192, "发布协议要求 192 字节的传统 BDUSS。")
+        XCTAssertEqual(stokenBytes, 64, "发布协议要求 64 字节的 STOKEN。")
+    }
+
+    func testLivePostingTBSRefresh() async throws {
+        guard ProcessInfo.processInfo.environment["TIEBAPURE_RUN_LIVE_CREDENTIAL_CHECK"] == "1" else {
+            throw XCTSkip("真实账号发布校验仅在显式启用时运行。")
+        }
+
+        let store = AccountStore(service: KeychainAccountStoreService())
+        let loadedAccount = try await store.load()
+        let account = try XCTUnwrap(loadedAccount)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.urlCache = nil
+        let api = TiebaAPI(client: TiebaHTTPClient(session: SecureRemoteURLSession.make(
+            configuration: configuration,
+            redirectScope: .baiduHTTPS
+        )))
+
+        let tbs = try await api.strictlyRefreshedPostingTBS(for: account)
+        print("TIEBAPURE_LIVE_POSTING_TBS tbs_bytes=\(tbs.utf8.count)")
+        XCTAssertFalse(tbs.isEmpty)
+    }
+
     func testIdentityMatchesPinnedAiotieba471Vectors() throws {
         let identity = try TiebaPostingBootstrap.deriveIdentity(from: Self.vectorSeed)
 
@@ -185,6 +223,30 @@ final class TiebaPostingBootstrapTests: XCTestCase {
         }
     }
 
+    func testSyncResponseLargerThanLegacyLimitIsAcceptedWithinBound() async throws {
+        let store = PostingBootstrapMemoryStore(data: try JSONEncoder().encode(Self.vectorSeed))
+        PostingBootstrapURLProtocol.handler = { request in
+            if request.url?.path == "/c/s/sync" {
+                let padding = String(repeating: "x", count: 128 * 1_024)
+                return .json(
+                    #"{"error_code":0,"client":{"client_id":"fixture-client"},"wl_config":{"sample_id":"fixture-sample"},"unused":"\#(padding)"}"#
+                )
+            }
+            return try Self.zIDResponse(for: request, token: "fixture-zid")
+        }
+        let bootstrap = TiebaPostingBootstrap(
+            store: store,
+            transport: makeURLSessionTransport(),
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let result = try await bootstrap.bootstrap(bduss: "fixture-bduss")
+
+        XCTAssertEqual(result.clientID, "fixture-client")
+        XCTAssertEqual(result.sampleID, "fixture-sample")
+        XCTAssertEqual(result.zID, "fixture-zid")
+    }
+
     func testStreamedOversizedResponseIsRejected() async throws {
         let store = PostingBootstrapMemoryStore(data: try JSONEncoder().encode(Self.vectorSeed))
         PostingBootstrapURLProtocol.handler = { request in
@@ -214,13 +276,35 @@ final class TiebaPostingBootstrapTests: XCTestCase {
         }
     }
 
-    func testZIDResponseDigestTamperingIsRejected() async throws {
+    func testZIDResponseOpaqueSuffixDoesNotRejectValidPayload() async throws {
         let store = PostingBootstrapMemoryStore(data: try JSONEncoder().encode(Self.vectorSeed))
         PostingBootstrapURLProtocol.handler = { request in
             if request.url?.path == "/c/s/sync" {
                 return .json(#"{"error_code":0,"client":{"client_id":"fixture"},"wl_config":{"sample_id":"fixture"}}"#)
             }
-            return try Self.zIDResponse(for: request, token: "fixture-zid", validDigest: false)
+            return try Self.zIDResponse(
+                for: request,
+                token: "fixture-zid",
+                responseSuffix: Data(repeating: 0, count: 16)
+            )
+        }
+        let bootstrap = TiebaPostingBootstrap(
+            store: store,
+            transport: makeURLSessionTransport(),
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let result = try await bootstrap.bootstrap(bduss: "fixture-bduss")
+        XCTAssertEqual(result.zID, "fixture-zid")
+    }
+
+    func testZIDResponseInvalidPaddingIsRejected() async throws {
+        let store = PostingBootstrapMemoryStore(data: try JSONEncoder().encode(Self.vectorSeed))
+        PostingBootstrapURLProtocol.handler = { request in
+            if request.url?.path == "/c/s/sync" {
+                return .json(#"{"error_code":0,"client":{"client_id":"fixture"},"wl_config":{"sample_id":"fixture"}}"#)
+            }
+            return try Self.zIDResponse(for: request, token: "fixture-zid", validPadding: false)
         }
         let bootstrap = TiebaPostingBootstrap(
             store: store,
@@ -230,7 +314,7 @@ final class TiebaPostingBootstrapTests: XCTestCase {
 
         do {
             _ = try await bootstrap.bootstrap(bduss: "fixture-bduss")
-            XCTFail("被篡改的加密响应不得被接受")
+            XCTFail("无效的 PKCS#7 填充必须被拒绝")
         } catch {
             XCTAssertEqual(error as? TiebaPostingBootstrapError, .invalidCiphertext)
         }
@@ -275,7 +359,8 @@ final class TiebaPostingBootstrapTests: XCTestCase {
     private static func zIDResponse(
         for request: URLRequest,
         token: String,
-        validDigest: Bool = true
+        responseSuffix: Data? = nil,
+        validPadding: Bool = true
     ) throws -> PostingBootstrapFixtureResponse {
         let deviceID = try XCTUnwrap(request.value(forHTTPHeaderField: "x-device-id"))
         XCTAssertEqual(deviceID, "bfa38d90556047524f41f88c6e6f6ea7")
@@ -303,8 +388,13 @@ final class TiebaPostingBootstrapTests: XCTestCase {
             input: responseKey
         )
         let json = Data("{\"token\":\"\(token)\"}".utf8)
-        let responseDigest = validDigest ? TiebaPostingCrypto.md5(json) : Data(repeating: 0, count: 16)
-        let responsePlaintext = TiebaPostingCrypto.addPKCS7Padding(json) + responseDigest
+        var paddedJSON = TiebaPostingCrypto.addPKCS7Padding(json)
+        if validPadding == false {
+            paddedJSON[paddedJSON.index(before: paddedJSON.endIndex)] = 0
+        }
+        let suffix = responseSuffix ?? TiebaPostingCrypto.md5(json)
+        XCTAssertEqual(suffix.count, 16)
+        let responsePlaintext = paddedJSON + suffix
         let responseCiphertext = try TiebaPostingCrypto.aesCBCEncryptRaw(responsePlaintext, key: responseKey)
         let responseObject = [
             "skey": responseWrappedKey.base64EncodedString(),

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -2693,6 +2693,15 @@ final class TiebaPureSmokeTests: XCTestCase {
     }
 
     func testThreadReplyMetadataMatchesCompactFooterStyle() throws {
+        XCTAssertEqual(ThreadReplyLayout.bodyStackSpacing, 0)
+        XCTAssertEqual(ThreadReplyLayout.metadataTopSpacing, 4)
+        XCTAssertEqual(ThreadReplyLayout.metadataVisualHeight, 28)
+        XCTAssertEqual(ThreadReplyLayout.metadataHitHeight, 44)
+        XCTAssertEqual(
+            ThreadReplyLayout.metadataVisualHeight + ThreadReplyLayout.metadataHitExpansion * 2,
+            ThreadReplyLayout.metadataHitHeight
+        )
+
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
         let now = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 13, hour: 16)))

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -462,10 +462,17 @@ final class TiebaPureSmokeTests: XCTestCase {
                 threadCount: 0
             )
         )
+        let deletionTarget = OwnThreadDeletionTarget(
+            forumID: 7,
+            forumName: "测试",
+            threadID: 123,
+            firstPostID: 456
+        )
         let route = ReaderSplitThreadRoute(
             threadID: 123,
             forumID: 7,
-            initialPostID: 456
+            initialPostID: 456,
+            ownThreadDeletionTarget: deletionTarget
         )
 
         let compact = ForumHubSplitDetailBridgePolicy.state(
@@ -482,7 +489,60 @@ final class TiebaPureSmokeTests: XCTestCase {
             splitDetail: compact.splitDetail
         )
         XCTAssertEqual(regular.splitDetail, route)
+        XCTAssertEqual(regular.splitDetail?.ownThreadDeletionTarget, deletionTarget)
         XCTAssertEqual(regular.navigationPath, [.forum(forum)])
+    }
+
+    func testReaderSplitThreadRoutePreservesValidatedOwnThreadDeletionTarget() {
+        let target = OwnThreadDeletionTarget(
+            forumID: 7,
+            forumName: "测试",
+            threadID: 123,
+            firstPostID: 456
+        )
+        let route = ReaderSplitThreadRoute(
+            threadID: 123,
+            forumID: 7,
+            ownThreadDeletionTarget: target
+        )
+
+        XCTAssertEqual(route.ownThreadDeletionTarget, target)
+        XCTAssertNotEqual(
+            route,
+            ReaderSplitThreadRoute(threadID: 123, forumID: 7)
+        )
+    }
+
+    func testHomeDetailBridgePreservesFullReaderDestinationAcrossSizeClasses() {
+        let target = OwnThreadDeletionTarget(
+            forumID: 7,
+            forumName: "测试",
+            threadID: 123,
+            firstPostID: 456
+        )
+        let readerRoute = ReaderSplitThreadRoute(
+            threadID: 123,
+            forumID: 7,
+            initialPostID: 456,
+            ownThreadDeletionTarget: target
+        )
+        let compact = HomeSplitDetailBridgePolicy.state(
+            changingTo: .compact,
+            navigationPath: [],
+            splitDetail: readerRoute
+        )
+        XCTAssertNil(compact.splitDetail)
+        XCTAssertEqual(compact.navigationPath, [.thread(readerRoute)])
+
+        let regular = HomeSplitDetailBridgePolicy.state(
+            changingTo: .regular,
+            navigationPath: compact.navigationPath,
+            splitDetail: compact.splitDetail
+        )
+        XCTAssertEqual(regular.navigationPath, [])
+        XCTAssertEqual(regular.splitDetail, readerRoute)
+        XCTAssertEqual(regular.splitDetail?.initialPostID, 456)
+        XCTAssertEqual(regular.splitDetail?.ownThreadDeletionTarget, target)
     }
 
     func testForumHubDetailBridgePreservesExistingDestinationWithoutAWidthChange() {

--- a/TiebaPureTests/UserProfileMutationTests.swift
+++ b/TiebaPureTests/UserProfileMutationTests.swift
@@ -1,0 +1,1370 @@
+import Foundation
+import XCTest
+@testable import TiebaPure
+
+final class UserProfileMutationTests: XCTestCase {
+    func testLiveReadExactThreadDetail() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["TIEBAPURE_RUN_LIVE_ACCOUNT_DELETE"] == "1" else {
+            throw XCTSkip("真实账号帖子详情预检仅在显式启用时运行。")
+        }
+        guard let threadIDText = environment["TIEBAPURE_LIVE_DELETE_THREAD_ID"],
+              let threadID = Int64(threadIDText),
+              threadID > 0 else {
+            XCTFail("真实账号帖子详情预检缺少精确主题 ID。")
+            return
+        }
+        let forumID = environment["TIEBAPURE_LIVE_DELETE_FORUM_ID"]
+            .flatMap(Int64.init)
+
+        let accountStore = AccountStore(service: KeychainAccountStoreService())
+        let loadedAccount = try await accountStore.load()
+        let account = try XCTUnwrap(loadedAccount)
+        let api = Self.makeLiveAPI()
+
+        do {
+            let page = try await api.threadPage(
+                account: account,
+                threadID: threadID,
+                page: 1,
+                forumID: forumID
+            )
+            XCTAssertEqual(page.thread.id, threadID)
+        } catch {
+            XCTFail("精确帖子详情读取失败：\(String(reflecting: error))")
+        }
+    }
+
+    func testLiveReadExactOwnThreadVisibility() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["TIEBAPURE_RUN_LIVE_ACCOUNT_DELETE"] == "1" else {
+            throw XCTSkip("真实账号删除预检仅在显式启用时运行。")
+        }
+        guard let threadIDText = environment["TIEBAPURE_LIVE_DELETE_THREAD_ID"],
+              let threadID = Int64(threadIDText),
+              threadID > 0 else {
+            XCTFail("真实账号删除预检缺少精确主题 ID。")
+            return
+        }
+
+        let accountStore = AccountStore(service: KeychainAccountStoreService())
+        let loadedAccount = try await accountStore.load()
+        let account = try XCTUnwrap(loadedAccount)
+        let userID = try XCTUnwrap(Int64(account.uid))
+        let api = Self.makeLiveAPI()
+
+        var visibleTarget: OwnThreadDeletionTarget?
+        for page in 1...3 where visibleTarget == nil {
+            let result = try await api.userThreads(
+                account: account,
+                userID: userID,
+                page: page
+            )
+            visibleTarget = result.deletionTargetsByThreadID[threadID]
+        }
+
+        XCTAssertNotNil(
+            visibleTarget,
+            "精确目标不在当前账号最近三页发帖中，禁止继续删除。"
+        )
+    }
+
+    func testLiveDeleteExactOwnThread() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["TIEBAPURE_RUN_LIVE_ACCOUNT_DELETE"] == "1" else {
+            throw XCTSkip("真实账号删除测试仅在显式启用时运行。")
+        }
+        let forumName = (environment["TIEBAPURE_LIVE_DELETE_FORUM_NAME"] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let forumIDText = environment["TIEBAPURE_LIVE_DELETE_FORUM_ID"],
+              let forumID = Int64(forumIDText),
+              forumID > 0,
+              forumName.isEmpty == false,
+              let threadIDText = environment["TIEBAPURE_LIVE_DELETE_THREAD_ID"],
+              let threadID = Int64(threadIDText),
+              threadID > 0,
+              let firstPostIDText = environment["TIEBAPURE_LIVE_DELETE_FIRST_POST_ID"],
+              let firstPostID = UInt64(firstPostIDText),
+              firstPostID > 0 else {
+            XCTFail("真实账号删除测试缺少完整的精确目标。")
+            return
+        }
+
+        let accountStore = AccountStore(service: KeychainAccountStoreService())
+        let loadedAccount = try await accountStore.load()
+        let account = try XCTUnwrap(loadedAccount)
+        let api = Self.makeLiveAPI()
+
+        try await api.deleteOwnThread(
+            account: account,
+            target: OwnThreadDeletionTarget(
+                forumID: forumID,
+                forumName: forumName,
+                threadID: threadID,
+                firstPostID: firstPostID
+            )
+        )
+    }
+
+    func testLiveUpdateOwnProfileWithCurrentValues() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["TIEBAPURE_RUN_LIVE_PROFILE_UPDATE"] == "1" else {
+            throw XCTSkip("真实账号资料原值回写仅在显式启用时运行。")
+        }
+
+        let accountStore = AccountStore(service: KeychainAccountStoreService())
+        let loadedAccount = try await accountStore.load()
+        let account = try XCTUnwrap(loadedAccount)
+        let accountUserID = try XCTUnwrap(
+            Int64(account.uid).flatMap { $0 > 0 ? $0 : nil }
+        )
+
+        let currentUser = UserSummary(
+            id: accountUserID,
+            name: account.name,
+            displayName: account.displayName,
+            portrait: account.portrait
+        )
+        let api = Self.makeLiveAPI()
+        let profileBeforeUpdate = try await api.userProfile(
+            account: account,
+            user: currentUser
+        )
+        guard profileBeforeUpdate.isCurrentUser,
+              profileBeforeUpdate.user.id == accountUserID,
+              UserProfileManagementPolicy.canEdit(
+                  profile: profileBeforeUpdate,
+                  account: account
+              ) else {
+            XCTFail("资料响应不属于当前账号，禁止发送原值回写请求。")
+            return
+        }
+
+        let unchangedRequest = UserProfileEditRequest(
+            nickname: profileBeforeUpdate.user.displayName,
+            introduction: profileBeforeUpdate.intro,
+            sex: profileBeforeUpdate.sex
+        )
+        guard unchangedRequest.normalizedNickname.isEmpty == false else {
+            XCTFail("当前资料缺少昵称，禁止发送原值回写请求。")
+            return
+        }
+
+        try await api.updateOwnProfile(
+            account: account,
+            request: unchangedRequest
+        )
+
+        let profileAfterUpdate = try await api.userProfile(
+            account: account,
+            user: currentUser
+        )
+        XCTAssertTrue(profileAfterUpdate.isCurrentUser)
+        XCTAssertEqual(profileAfterUpdate.user.id, accountUserID)
+        XCTAssertEqual(
+            profileAfterUpdate.user.displayName,
+            profileBeforeUpdate.user.displayName
+        )
+        XCTAssertEqual(profileAfterUpdate.intro, profileBeforeUpdate.intro)
+        XCTAssertEqual(profileAfterUpdate.sex, profileBeforeUpdate.sex)
+    }
+
+    private static func makeLiveAPI() -> TiebaAPI {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return TiebaAPI(client: TiebaHTTPClient(session: SecureRemoteURLSession.make(
+            configuration: configuration,
+            redirectScope: .baiduHTTPS
+        )))
+    }
+
+    func testProfileEditFactoryMatchesPinnedAiotiebaShape() throws {
+        let fields = try UserProfileRequestFactory.profileEditFields(
+            account: Self.account,
+            request: UserProfileEditRequest(
+                nickname: "  新昵称  ",
+                introduction: "  第一行\n第二行  ",
+                sex: .female
+            )
+        )
+
+        XCTAssertEqual(fields, [
+            "BDUSS": "fixture-bduss",
+            "intro": "  第一行\n第二行  ",
+            "nick_name": "新昵称",
+            "sex": "2"
+        ])
+        XCTAssertEqual(TiebaEndpoint.modifyProfile.url.host, "tiebac.baidu.com")
+        XCTAssertEqual(TiebaEndpoint.modifyProfile.url.path, "/c/c/profile/modify")
+    }
+
+    func testProfileEditFactoryOmitsUnsetSexToPreserveServerValue() throws {
+        let fields = try UserProfileRequestFactory.profileEditFields(
+            account: Self.account,
+            request: UserProfileEditRequest(
+                nickname: "夹具账号",
+                introduction: "保持简介",
+                sex: .unspecified
+            )
+        )
+
+        XCTAssertEqual(fields, [
+            "BDUSS": "fixture-bduss",
+            "intro": "保持简介",
+            "nick_name": "夹具账号"
+        ])
+        XCTAssertNil(fields["sex"])
+    }
+
+    func testDeleteFactoryRequiresCompleteTargetAndMatchesOfficialV12Shape() throws {
+        let fields = try UserProfileRequestFactory.deleteThreadFields(
+            account: Self.account,
+            tbs: "  fresh-tbs  ",
+            target: Self.deletionTarget,
+            requestBuilder: Self.requestBuilder,
+            timestamp: 1_234
+        )
+
+        var expected = Self.requestBuilder.officialCommonFields(
+            bduss: Self.account.bduss,
+            baiduID: Self.account.baiduID,
+            clientVersion: UserProfileRequestFactory.ownThreadDeleteClientVersion,
+            timestamp: 1_234
+        )
+        expected.merge([
+            "delete_my_thread": "1",
+            "fid": "73",
+            "is_frs_mask": "0",
+            "is_vipdel": "0",
+            "src": "1",
+            "tbs": "fresh-tbs",
+            "word": "夹具",
+            "z": "1001"
+        ], uniquingKeysWith: { _, new in new })
+        XCTAssertEqual(fields, expected)
+        XCTAssertNil(fields["post_id"])
+        XCTAssertNil(fields["delete_my_post"])
+        XCTAssertEqual(fields["_client_version"], "12.25.1.0")
+        XCTAssertEqual(TiebaEndpoint.deleteOwnThread.url.host, "c.tieba.baidu.com")
+        XCTAssertEqual(TiebaEndpoint.deleteOwnThread.url.path, "/c/c/bawu/delthread")
+
+        let invalidTargets: [(OwnThreadDeletionTarget, UserProfileMutationError)] = [
+            (OwnThreadDeletionTarget(forumID: 0, forumName: "夹具", threadID: 1001, firstPostID: 2001), .invalidForumID),
+            (OwnThreadDeletionTarget(forumID: 73, forumName: "  ", threadID: 1001, firstPostID: 2001), .invalidForumName),
+            (OwnThreadDeletionTarget(forumID: 73, forumName: "夹具", threadID: 0, firstPostID: 2001), .invalidThreadID),
+            (OwnThreadDeletionTarget(forumID: 73, forumName: "夹具", threadID: 1001, firstPostID: 0), .invalidFirstPostID)
+        ]
+        for (target, expected) in invalidTargets {
+            XCTAssertThrowsError(
+                try UserProfileRequestFactory.deleteThreadFields(
+                    account: Self.account,
+                    tbs: "fresh-tbs",
+                    target: target,
+                    requestBuilder: Self.requestBuilder
+                )
+            ) { error in
+                XCTAssertEqual(error as? UserProfileMutationError, expected)
+            }
+        }
+    }
+
+    func testUserThreadMapperKeepsFirstPostIDForExplicitDeletion() {
+        var item = Tiebapure_Profile_UserThreadItem()
+        item.forumID = 73
+        item.threadID = 1001
+        item.postID = 2001
+        item.forumName = "夹具"
+        item.title = "本人主题"
+        item.userID = 42
+        item.userName = "fixture"
+        item.nameShow = "夹具账号"
+
+        var data = Tiebapure_Profile_UserThreadsResponseData()
+        data.postList = [item]
+        var response = Tiebapure_Profile_UserThreadsResponse()
+        response.data = data
+
+        let page = UserProfileMapper.threadsPage(from: response, page: 1)
+
+        XCTAssertEqual(page.threads.map(\.id), [1001])
+        XCTAssertEqual(page.deletionTargetsByThreadID[1001], Self.deletionTarget)
+
+        item.postID = 0
+        data.postList = [item]
+        response.data = data
+        let incompletePage = UserProfileMapper.threadsPage(from: response, page: 1)
+        XCTAssertEqual(incompletePage.threads.map(\.id), [1001])
+        XCTAssertNil(incompletePage.deletionTargetsByThreadID[1001])
+    }
+
+    func testProfileEditSendsOneSignedRequestWithNoExtraFields() async throws {
+        let harness = makeAPI(mode: .success)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+
+        try await harness.api.updateOwnProfile(
+            account: Self.account,
+            request: UserProfileEditRequest(
+                nickname: "新昵称",
+                introduction: "新简介",
+                sex: .male
+            )
+        )
+
+        let records = ProfileMutationURLProtocol.records(id: harness.id)
+        XCTAssertEqual(records.map(\.path), ["/c/c/profile/modify"])
+        let request = try XCTUnwrap(records.first)
+        let fields = try Self.formFields(request.body)
+        XCTAssertEqual(
+            Set(fields.keys),
+            Set(["BDUSS", "intro", "nick_name", "sex", "sign"])
+        )
+        XCTAssertEqual(fields["BDUSS"], "fixture-bduss")
+        XCTAssertEqual(fields["intro"], "新简介")
+        XCTAssertEqual(fields["nick_name"], "新昵称")
+        XCTAssertEqual(fields["sex"], "1")
+        XCTAssertNotNil(fields["sign"])
+        XCTAssertEqual(request.host, "tiebac.baidu.com")
+        XCTAssertEqual(request.userAgent, "tieba/\(TiebaClientVersion.v22.rawValue)")
+    }
+
+    func testProfileBusinessAndSessionErrorsRemainSpecificAndAreNotRetried() async {
+        let cases: [(ProfileMutationStubMode, TiebaAPIError)] = [
+            (.businessError, .response(code: 220034, message: "tbs校验失败")),
+            (.sessionExpired, .sessionExpired(code: 110001, message: "登录已失效"))
+        ]
+
+        for (mode, expected) in cases {
+            let harness = makeAPI(mode: mode)
+            do {
+                try await harness.api.updateOwnProfile(
+                    account: Self.account,
+                    request: Self.profileEditRequest
+                )
+                XCTFail("Expected a typed profile mutation error")
+            } catch let error as TiebaAPIError {
+                XCTAssertEqual(error, expected)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/profile/modify",
+                id: harness.id
+            ), 1)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testProfileMalformedStatusTypesHaveUnknownOutcomeWithoutRetry() async {
+        for payload in Self.malformedMutationResponses {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                try await harness.api.updateOwnProfile(
+                    account: Self.account,
+                    request: Self.profileEditRequest
+                )
+                XCTFail("Expected unknown profile mutation outcome for \(payload)")
+            } catch let error as UserProfileMutationError {
+                XCTAssertEqual(error, .outcomeUnknown, payload)
+            } catch {
+                XCTFail("Unexpected error for \(payload): \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/profile/modify",
+                id: harness.id
+            ), 1, payload)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testProfileNestedFailureAliasesRemainSpecificAndAreNotRetried() async {
+        let cases: [(String, TiebaAPIError)] = [
+            (
+                #"{"data":{"err_code":220034,"err_msg":"tbs校验失败"}}"#,
+                .response(code: 220034, message: "tbs校验失败")
+            ),
+            (
+                #"{"error":{"errno":"110001","errmsg":"登录已失效"}}"#,
+                .sessionExpired(code: 110001, message: "登录已失效")
+            )
+        ]
+
+        for (payload, expected) in cases {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                try await harness.api.updateOwnProfile(
+                    account: Self.account,
+                    request: Self.profileEditRequest
+                )
+                XCTFail("Expected a nested profile mutation error")
+            } catch let error as TiebaAPIError {
+                XCTAssertEqual(error, expected, payload)
+            } catch {
+                XCTFail("Unexpected error for \(payload): \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/profile/modify",
+                id: harness.id
+            ), 1, payload)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testProfileConflictingStatusAliasesHaveUnknownOutcomeWithoutRetry() async {
+        let payloads = [
+            #"{"error_code":0,"data":{"err_code":220034,"err_msg":"tbs校验失败"}}"#,
+            #"{"result":0,"error":{"errno":110001,"errmsg":"登录已失效"}}"#,
+            #"{"error_code":7,"err_code":8,"error_msg":"状态冲突"}"#,
+            #"{"error_code":0,"error":"请求失败"}"#
+        ]
+
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                try await harness.api.updateOwnProfile(
+                    account: Self.account,
+                    request: Self.profileEditRequest
+                )
+                XCTFail("Expected unknown profile mutation outcome for \(payload)")
+            } catch let error as UserProfileMutationError {
+                XCTAssertEqual(error, .outcomeUnknown, payload)
+            } catch {
+                XCTFail("Unexpected error for \(payload): \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/profile/modify",
+                id: harness.id
+            ), 1, payload)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testDeleteRefreshesTBSThenSendsExactlyOneFinalMutation() async throws {
+        let harness = makeAPI(mode: .success)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+
+        try await harness.api.deleteOwnThread(
+            account: Self.account,
+            target: Self.deletionTarget
+        )
+
+        let records = ProfileMutationURLProtocol.records(id: harness.id)
+        XCTAssertEqual(records.map(\.path), ["/c/s/login", "/c/c/bawu/delthread"])
+        let request = try XCTUnwrap(records.last)
+        let fields = try Self.formFields(request.body)
+        XCTAssertEqual(
+            Set(fields.keys),
+            Set(Self.requestBuilder.officialCommonFields(
+                bduss: Self.account.bduss,
+                baiduID: Self.account.baiduID,
+                clientVersion: UserProfileRequestFactory.ownThreadDeleteClientVersion
+            ).keys)
+                .union(["delete_my_thread", "fid", "is_frs_mask", "is_vipdel", "sign", "src", "tbs", "word", "z"])
+        )
+        XCTAssertEqual(fields["_client_version"], "12.25.1.0")
+        XCTAssertEqual(fields["from"], "tieba")
+        XCTAssertEqual(fields["delete_my_thread"], "1")
+        XCTAssertEqual(fields["is_frs_mask"], "0")
+        XCTAssertEqual(fields["fid"], "73")
+        XCTAssertEqual(fields["is_vipdel"], "0")
+        XCTAssertEqual(fields["src"], "1")
+        XCTAssertEqual(fields["tbs"], "fresh-tbs")
+        XCTAssertEqual(fields["word"], "夹具")
+        XCTAssertEqual(fields["z"], "1001")
+        XCTAssertNil(fields["post_id"])
+        XCTAssertNil(fields["delete_my_post"])
+        XCTAssertEqual(request.userAgent, "bdtb for Android 12.25.1.0")
+        XCTAssertEqual(request.host, "c.tieba.baidu.com")
+        XCTAssertEqual(fields["sign"], fields["sign"]?.uppercased())
+        XCTAssertTrue(request.cookie?.contains("BAIDUID=fixture-baiduid") == true)
+        XCTAssertEqual(ProfileMutationURLProtocol.count(
+            path: "/c/c/bawu/delthread",
+            id: harness.id
+        ), 1)
+    }
+
+    func testDeleteBusinessErrorRemainsSpecificAndIsNotRetried() async {
+        let harness = makeAPI(mode: .businessError)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+
+        do {
+            try await harness.api.deleteOwnThread(
+                account: Self.account,
+                target: Self.deletionTarget
+            )
+            XCTFail("Expected business error")
+        } catch let error as TiebaAPIError {
+            XCTAssertEqual(error, .response(code: 220034, message: "tbs校验失败"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(ProfileMutationURLProtocol.count(
+            path: "/c/c/bawu/delthread",
+            id: harness.id
+        ), 1)
+    }
+
+    func testDeleteSessionErrorRemainsSessionExpiredAndIsNotRetried() async {
+        let harness = makeAPI(mode: .sessionExpired)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+
+        do {
+            try await harness.api.deleteOwnThread(
+                account: Self.account,
+                target: Self.deletionTarget
+            )
+            XCTFail("Expected session-expired error")
+        } catch let error as TiebaAPIError {
+            XCTAssertEqual(
+                error,
+                .sessionExpired(code: 110001, message: "登录已失效")
+            )
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(ProfileMutationURLProtocol.count(
+            path: "/c/c/bawu/delthread",
+            id: harness.id
+        ), 1)
+    }
+
+    func testIncompleteDeletionTargetStopsBeforeTBSRefresh() async {
+        let harness = makeAPI(mode: .success)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+
+        do {
+            try await harness.api.deleteOwnThread(
+                account: Self.account,
+                target: OwnThreadDeletionTarget(
+                    forumID: 73,
+                    forumName: "夹具",
+                    threadID: 1001,
+                    firstPostID: 0
+                )
+            )
+            XCTFail("Expected an incomplete target error")
+        } catch let error as UserProfileMutationError {
+            XCTAssertEqual(error, .invalidFirstPostID)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertTrue(ProfileMutationURLProtocol.records(id: harness.id).isEmpty)
+    }
+
+    func testDeleteTransportAndDecodeFailuresHaveUnknownOutcomeWithoutRetry() async {
+        for mode in [ProfileMutationStubMode.transportFailure, .decodeFailure] {
+            let harness = makeAPI(mode: mode)
+            defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+
+            do {
+                try await harness.api.deleteOwnThread(
+                    account: Self.account,
+                    target: Self.deletionTarget
+                )
+                XCTFail("Expected unknown outcome")
+            } catch let error as UserProfileMutationError {
+                XCTAssertEqual(error, .outcomeUnknown)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/bawu/delthread",
+                id: harness.id
+            ), 1)
+        }
+    }
+
+    func testDeleteMalformedStatusTypesHaveUnknownOutcomeWithoutRetry() async {
+        for payload in Self.malformedMutationResponses {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                try await harness.api.deleteOwnThread(
+                    account: Self.account,
+                    target: Self.deletionTarget
+                )
+                XCTFail("Expected unknown deletion outcome for \(payload)")
+            } catch let error as UserProfileMutationError {
+                XCTAssertEqual(error, .outcomeUnknown, payload)
+            } catch {
+                XCTFail("Unexpected error for \(payload): \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/bawu/delthread",
+                id: harness.id
+            ), 1, payload)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testDeleteNestedFailureAliasesRemainSpecificAndAreNotRetried() async {
+        let cases: [(String, TiebaAPIError)] = [
+            (
+                #"{"data":{"error_no":220034,"error_msg":"tbs校验失败"}}"#,
+                .response(code: 220034, message: "tbs校验失败")
+            ),
+            (
+                #"{"error":{"no":110001,"errmsg":"登录已失效"}}"#,
+                .sessionExpired(code: 110001, message: "登录已失效")
+            )
+        ]
+
+        for (payload, expected) in cases {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                try await harness.api.deleteOwnThread(
+                    account: Self.account,
+                    target: Self.deletionTarget
+                )
+                XCTFail("Expected a nested deletion error")
+            } catch let error as TiebaAPIError {
+                XCTAssertEqual(error, expected, payload)
+            } catch {
+                XCTFail("Unexpected error for \(payload): \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/bawu/delthread",
+                id: harness.id
+            ), 1, payload)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testDeleteConflictingStatusAliasesHaveUnknownOutcomeWithoutRetry() async {
+        let payloads = [
+            #"{"error_code":0,"data":{"error_no":220034,"error_msg":"tbs校验失败"}}"#,
+            #"{"result":0,"error":{"no":110001,"errmsg":"登录已失效"}}"#,
+            #"{"errno":7,"no":8,"error_msg":"状态冲突"}"#,
+            #"{"error_code":0,"error":"请求失败"}"#
+        ]
+
+        for payload in payloads {
+            let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+            do {
+                try await harness.api.deleteOwnThread(
+                    account: Self.account,
+                    target: Self.deletionTarget
+                )
+                XCTFail("Expected unknown deletion outcome for \(payload)")
+            } catch let error as UserProfileMutationError {
+                XCTAssertEqual(error, .outcomeUnknown, payload)
+            } catch {
+                XCTFail("Unexpected error for \(payload): \(error)")
+            }
+            XCTAssertEqual(ProfileMutationURLProtocol.count(
+                path: "/c/c/bawu/delthread",
+                id: harness.id
+            ), 1, payload)
+            ProfileMutationURLProtocol.remove(id: harness.id)
+        }
+    }
+
+    func testCancellationBeforeDeleteDispatchMakesNoNetworkRequest() async {
+        let harness = makeAPI(mode: .success)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+        let operation = Task {
+            withUnsafeCurrentTask { task in
+                task?.cancel()
+            }
+            try await harness.api.deleteOwnThread(
+                account: Self.account,
+                target: Self.deletionTarget
+            )
+        }
+
+        do {
+            try await operation.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected before even the read-only TBS refresh.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertTrue(ProfileMutationURLProtocol.records(id: harness.id).isEmpty)
+    }
+
+    func testCancellationAfterDeleteDispatchHasUnknownOutcomeWithoutRetry() async throws {
+        let harness = makeAPI(mode: .holdFinalRequest)
+        defer { ProfileMutationURLProtocol.remove(id: harness.id) }
+        let operation = Task {
+            try await harness.api.deleteOwnThread(
+                account: Self.account,
+                target: Self.deletionTarget
+            )
+        }
+
+        try await waitForRequest(path: "/c/c/bawu/delthread", id: harness.id)
+        operation.cancel()
+
+        do {
+            try await operation.value
+            XCTFail("Expected unknown outcome")
+        } catch let error as UserProfileMutationError {
+            XCTAssertEqual(error, .outcomeUnknown)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(ProfileMutationURLProtocol.count(
+            path: "/c/c/bawu/delthread",
+            id: harness.id
+        ), 1)
+    }
+
+    func testSameUIDMetadataUpdateDoesNotInvalidateAccountScopedState() {
+        var updated = Self.account
+        updated.name = "new-account-name"
+        updated.displayName = "已修改昵称"
+        updated.portrait = "new-portrait"
+        updated.tbs = "refreshed-tbs"
+
+        XCTAssertNil(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: updated
+        ))
+    }
+
+    func testSameUIDCredentialReplacementInvalidatesAccountScopedState() {
+        var replacedBDUSS = Self.account
+        replacedBDUSS.bduss = "replacement-bduss"
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: replacedBDUSS
+        ), "42")
+
+        var replacedSTOKEN = Self.account
+        replacedSTOKEN.stoken = "replacement-stoken"
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: replacedSTOKEN
+        ), "42")
+
+        var replacedBAIDUID = Self.account
+        replacedBAIDUID.baiduID = "replacement-baiduid"
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: replacedBAIDUID
+        ), "42")
+
+        replacedBAIDUID.baiduID = nil
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: replacedBAIDUID
+        ), "42")
+    }
+
+    func testLogoutOrDifferentUIDInvalidatesPreviousAccountScopedState() {
+
+        var replacement = Self.account
+        replacement.uid = "99"
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: replacement
+        ), "42")
+        XCTAssertEqual(AccountTransitionPolicy.invalidatedAccountID(
+            previous: Self.account,
+            next: nil
+        ), "42")
+    }
+
+    func testOnlyLoggedOutToLoggedInTransitionReleasesGlobalWriteBarrier() {
+        XCTAssertTrue(AccountTransitionPolicy.shouldReleaseGlobalInvalidation(
+            previous: nil,
+            next: Self.account
+        ))
+
+        var metadataUpdate = Self.account
+        metadataUpdate.displayName = "新昵称"
+        XCTAssertFalse(AccountTransitionPolicy.shouldReleaseGlobalInvalidation(
+            previous: Self.account,
+            next: metadataUpdate
+        ))
+        XCTAssertFalse(AccountTransitionPolicy.shouldReleaseGlobalInvalidation(
+            previous: Self.account,
+            next: nil
+        ))
+        XCTAssertFalse(AccountTransitionPolicy.shouldReleaseGlobalInvalidation(
+            previous: nil,
+            next: nil
+        ))
+    }
+
+    func testManagementPolicyExposesEditingAndDeletionOnlyForMatchingCurrentUser() throws {
+        let profile = Self.currentUserProfile
+        let target = Self.deletionTarget
+
+        XCTAssertTrue(UserProfileManagementPolicy.canEdit(
+            profile: profile,
+            account: Self.account
+        ))
+        XCTAssertEqual(UserProfileManagementPolicy.deletionTarget(
+            profile: profile,
+            account: Self.account,
+            threadID: target.threadID,
+            targetsByThreadID: [target.threadID: target]
+        ), target)
+
+        var otherProfile = profile
+        otherProfile.isCurrentUser = false
+        XCTAssertFalse(UserProfileManagementPolicy.canEdit(
+            profile: otherProfile,
+            account: Self.account
+        ))
+        XCTAssertNil(UserProfileManagementPolicy.deletionTarget(
+            profile: otherProfile,
+            account: Self.account,
+            threadID: target.threadID,
+            targetsByThreadID: [target.threadID: target]
+        ))
+
+        var mismatchedAccount = Self.account
+        mismatchedAccount.uid = "99"
+        XCTAssertFalse(UserProfileManagementPolicy.canEdit(
+            profile: profile,
+            account: mismatchedAccount
+        ))
+    }
+
+    func testThreadDetailDerivesDeletionTargetOnlyForExactCurrentAuthor() {
+        let page = Self.ownThreadPage
+
+        XCTAssertEqual(
+            UserProfileManagementPolicy.threadDetailDeletionTarget(
+                account: Self.account,
+                threadID: page.thread.id,
+                page: page,
+                explicitTarget: nil
+            ),
+            Self.deletionTarget
+        )
+
+        var otherAccount = Self.account
+        otherAccount.uid = "99"
+        XCTAssertNil(UserProfileManagementPolicy.threadDetailDeletionTarget(
+            account: otherAccount,
+            threadID: page.thread.id,
+            page: page,
+            explicitTarget: nil
+        ))
+        XCTAssertNil(UserProfileManagementPolicy.threadDetailDeletionTarget(
+            account: nil,
+            threadID: page.thread.id,
+            page: page,
+            explicitTarget: Self.deletionTarget
+        ))
+    }
+
+    func testThreadDetailRejectsIncompleteOrMismatchedDeletionMetadata() {
+        var page = Self.ownThreadPage
+        page.forum.id = 0
+        XCTAssertNil(UserProfileManagementPolicy.threadDetailDeletionTarget(
+            account: Self.account,
+            threadID: page.thread.id,
+            page: page,
+            explicitTarget: nil
+        ))
+
+        var mismatchedTarget = Self.deletionTarget
+        mismatchedTarget.firstPostID += 1
+        XCTAssertNil(UserProfileManagementPolicy.threadDetailDeletionTarget(
+            account: Self.account,
+            threadID: page.thread.id,
+            page: page,
+            explicitTarget: mismatchedTarget
+        ))
+    }
+
+    func testManagementPolicyAppliesProfileEditWithoutChangingAccountIdentityOrCredentials() {
+        let request = UserProfileEditRequest(
+            nickname: "  新昵称  ",
+            introduction: "新的个人简介",
+            sex: .female
+        )
+
+        let updatedAccount = UserProfileManagementPolicy.updatedAccount(
+            Self.account,
+            applying: request
+        )
+        XCTAssertEqual(updatedAccount.uid, Self.account.uid)
+        XCTAssertEqual(updatedAccount.name, Self.account.name)
+        XCTAssertEqual(updatedAccount.displayName, "新昵称")
+        XCTAssertEqual(updatedAccount.bduss, Self.account.bduss)
+        XCTAssertEqual(updatedAccount.stoken, Self.account.stoken)
+        XCTAssertEqual(updatedAccount.baiduID, Self.account.baiduID)
+
+        let updatedProfile = UserProfileManagementPolicy.updatedProfile(
+            Self.currentUserProfile,
+            applying: request
+        )
+        XCTAssertEqual(updatedProfile.user.displayName, "新昵称")
+        XCTAssertEqual(updatedProfile.intro, "新的个人简介")
+        XCTAssertEqual(updatedProfile.sex, .female)
+
+        var maleProfile = Self.currentUserProfile
+        maleProfile.sex = .male
+        let preservingRequest = UserProfileEditRequest(
+            nickname: "原昵称",
+            introduction: "原简介",
+            sex: .unspecified
+        )
+        XCTAssertEqual(
+            UserProfileManagementPolicy.updatedProfile(
+                maleProfile,
+                applying: preservingRequest
+            ).sex,
+            .male
+        )
+    }
+
+    func testMutationPresentationRequiresReadOnlyRefreshForUnknownOutcome() {
+        XCTAssertEqual(
+            UserProfileMutationPresentationPolicy.failure(
+                for: UserProfileMutationError.outcomeUnknown
+            ),
+            .resultPending
+        )
+        XCTAssertEqual(
+            UserProfileMutationPresentationPolicy.failure(
+                for: UserProfileMutationError.missingNickname
+            ),
+            .retryable(message: "昵称不能为空。")
+        )
+    }
+
+    func testProfileConfirmationRequiresMatchingServerValues() {
+        let request = UserProfileEditRequest(
+            nickname: "  新昵称  ",
+            introduction: "新的个人简介",
+            sex: .female
+        )
+        var confirmed = Self.currentUserProfile
+        confirmed.user.displayName = "新昵称"
+        confirmed.intro = "新的个人简介"
+        confirmed.sex = .female
+
+        XCTAssertTrue(UserProfileManagementPolicy.profile(confirmed, confirms: request))
+
+        var staleNickname = confirmed
+        staleNickname.user.displayName = "旧昵称"
+        XCTAssertFalse(UserProfileManagementPolicy.profile(staleNickname, confirms: request))
+
+        var staleIntro = confirmed
+        staleIntro.intro = "旧简介"
+        XCTAssertFalse(UserProfileManagementPolicy.profile(staleIntro, confirms: request))
+
+        var staleSex = confirmed
+        staleSex.sex = .male
+        XCTAssertFalse(UserProfileManagementPolicy.profile(staleSex, confirms: request))
+    }
+
+    func testProfileConfirmationTreatsUnspecifiedSexAsPreserveExistingValue() {
+        var profile = Self.currentUserProfile
+        profile.user.displayName = "现有昵称"
+        profile.intro = "现有简介"
+        profile.sex = .male
+
+        XCTAssertTrue(UserProfileManagementPolicy.profile(
+            profile,
+            confirms: UserProfileEditRequest(
+                nickname: "现有昵称",
+                introduction: "现有简介",
+                sex: .unspecified
+            )
+        ))
+    }
+
+    func testDeletionDispatchPolicyNeverResubmitsAfterUnknownOutcome() {
+        XCTAssertTrue(OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: true,
+            isSubmitting: false,
+            hasUnconfirmedOutcome: false
+        ))
+        XCTAssertFalse(OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: false,
+            isSubmitting: false,
+            hasUnconfirmedOutcome: false
+        ))
+        XCTAssertFalse(OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: true,
+            isSubmitting: true,
+            hasUnconfirmedOutcome: false
+        ))
+        XCTAssertFalse(OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: true,
+            isSubmitting: false,
+            hasUnconfirmedOutcome: true
+        ))
+    }
+
+    @MainActor
+    func testUnknownDeletionStateSurvivesDetailRecreationUntilConfirmedDeleted() {
+        let state = OwnThreadMutationState()
+
+        state.publish(accountID: "42", threadID: 9001, outcome: .needsRefresh)
+
+        XCTAssertTrue(state.hasUnconfirmedDeletion(accountID: "42", threadID: 9001))
+        XCTAssertFalse(state.hasUnconfirmedDeletion(accountID: "42", threadID: 9002))
+        XCTAssertFalse(state.hasUnconfirmedDeletion(accountID: "84", threadID: 9001))
+        XCTAssertFalse(OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: true,
+            isSubmitting: false,
+            hasUnconfirmedOutcome: state.hasUnconfirmedDeletion(
+                accountID: "42",
+                threadID: 9001
+            )
+        ))
+
+        state.publish(accountID: "42", threadID: 9001, outcome: .deleted)
+
+        XCTAssertFalse(state.hasUnconfirmedDeletion(accountID: "42", threadID: 9001))
+        XCTAssertTrue(OwnThreadDeletionDispatchPolicy.canSubmit(
+            hasValidatedTarget: true,
+            isSubmitting: false,
+            hasUnconfirmedOutcome: state.hasUnconfirmedDeletion(
+                accountID: "42",
+                threadID: 9001
+            )
+        ))
+    }
+
+#if DEBUG
+    func testFixturePersistsProfileEditAndRemovesDeletedThreadOnReadOnlyReload() async throws {
+        let api = FixtureTiebaAPI()
+        let account = FixtureTiebaAPI.account
+        let user = UserSummary(
+            id: Int64(account.uid) ?? 0,
+            name: account.name,
+            displayName: account.displayName,
+            portrait: account.portrait
+        )
+        let request = UserProfileEditRequest(
+            nickname: "夹具新昵称",
+            introduction: "夹具新简介",
+            sex: .male
+        )
+
+        try await api.updateOwnProfile(account: account, request: request)
+        let editedProfile = try await api.userProfile(account: account, user: user)
+        XCTAssertEqual(editedProfile.user.displayName, "夹具新昵称")
+        XCTAssertEqual(editedProfile.intro, "夹具新简介")
+        XCTAssertEqual(editedProfile.sex, .male)
+
+        let beforeDeletion = try await api.userThreads(
+            account: account,
+            userID: user.id,
+            page: 1
+        )
+        let threadID = try XCTUnwrap(beforeDeletion.threads.first?.id)
+        let target = try XCTUnwrap(beforeDeletion.deletionTargetsByThreadID[threadID])
+        try await api.deleteOwnThread(account: account, target: target)
+
+        let afterDeletion = try await api.userThreads(
+            account: account,
+            userID: user.id,
+            page: 1
+        )
+        XCTAssertFalse(afterDeletion.threads.contains { $0.id == threadID })
+        XCTAssertNil(afterDeletion.deletionTargetsByThreadID[threadID])
+    }
+#endif
+
+    private func makeAPI(mode: ProfileMutationStubMode) -> (api: TiebaAPI, id: String) {
+        let id = UUID().uuidString
+        ProfileMutationURLProtocol.register(mode: mode, id: id)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ProfileMutationURLProtocol.self]
+        configuration.httpAdditionalHeaders = [ProfileMutationURLProtocol.testIDHeader: id]
+        return (
+            TiebaAPI(
+                client: TiebaHTTPClient(session: URLSession(configuration: configuration)),
+                requestBuilder: Self.requestBuilder
+            ),
+            id
+        )
+    }
+
+    private func waitForRequest(path: String, id: String) async throws {
+        for _ in 0..<200 {
+            if ProfileMutationURLProtocol.count(path: path, id: id) == 1 { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTFail("Timed out waiting for \(path)")
+    }
+
+    private static func formFields(_ data: Data?) throws -> [String: String] {
+        let body = try XCTUnwrap(data)
+        let text = try XCTUnwrap(String(data: body, encoding: .utf8))
+        var components = URLComponents()
+        components.percentEncodedQuery = text
+        return Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map {
+            ($0.name, $0.value ?? "")
+        })
+    }
+
+    private static let account = Account(
+        uid: "42",
+        name: "fixture",
+        displayName: "夹具账号",
+        portrait: "fixture-portrait",
+        bduss: "fixture-bduss",
+        stoken: "fixture-stoken",
+        baiduID: "fixture-baiduid",
+        tbs: "stale-tbs"
+    )
+
+    private static let profileEditRequest = UserProfileEditRequest(
+        nickname: "新昵称",
+        introduction: "新简介",
+        sex: .female
+    )
+
+    private static let malformedMutationResponses = [
+        #"{"error_code":false,"error_msg":""}"#,
+        #"{"error_code":0.0,"error_msg":""}"#,
+        #"{"error_code":{"value":0},"error_msg":""}"#,
+        #"{"error_code":null,"error_msg":""}"#,
+        #"{"error_code":0,"result":true,"error_msg":""}"#,
+        #"{"error_code":0,"data":{"error_code":false},"error_msg":""}"#,
+        #"{"error_code":0,"data":{"result":0.0},"error_msg":""}"#,
+        #"{"error_code":0,"data":{"err_code":{"value":0}},"error_msg":""}"#,
+        #"{"error_code":0,"data":{"errno":null},"error_msg":""}"#,
+        #"{"error_code":0,"error":{"errno":0.0,"errmsg":""},"error_msg":""}"#,
+        #"{"error_code":0,"data":true,"error_msg":""}"#,
+        #"{"error_code":0,"data":[],"error_msg":""}"#,
+        #"{"error_code":0,"data":null,"error_msg":""}"#
+    ]
+
+    private static let deletionTarget = OwnThreadDeletionTarget(
+        forumID: 73,
+        forumName: "夹具",
+        threadID: 1001,
+        firstPostID: 2001
+    )
+
+    private static let ownThreadPage = ThreadPage(
+        thread: ThreadSummary(
+            id: 1001,
+            forumID: 73,
+            title: "本人主题",
+            author: UserSummary(
+                id: 42,
+                name: "fixture",
+                displayName: "夹具账号",
+                portrait: "fixture-portrait"
+            ),
+            forumName: "夹具",
+            replyCount: 0,
+            viewCount: 0,
+            blocks: [],
+            isTop: false,
+            isGood: false,
+            hasVideo: false
+        ),
+        forum: Forum(
+            id: 73,
+            name: "夹具",
+            displayName: "夹具吧",
+            avatarURL: nil,
+            memberCount: 0,
+            threadCount: 0
+        ),
+        mainPost: Post(
+            id: 2001,
+            threadID: 1001,
+            floor: 1,
+            author: UserSummary(
+                id: 42,
+                name: "fixture",
+                displayName: "夹具账号",
+                portrait: "fixture-portrait"
+            ),
+            ipAddress: nil,
+            createdAt: nil,
+            blocks: [],
+            subpostCount: 0,
+            likeCount: 0,
+            previewSubposts: []
+        ),
+        posts: [],
+        currentPage: 1,
+        totalPage: 1,
+        hasMore: false
+    )
+
+    private static let currentUserProfile = UserProfile(
+        user: UserSummary(
+            id: 42,
+            name: "fixture",
+            displayName: "夹具账号",
+            portrait: "fixture-portrait"
+        ),
+        isCurrentUser: true,
+        isFollowed: false,
+        tiebaID: "42",
+        tiebaAge: "1年",
+        sex: .unspecified,
+        location: nil,
+        intro: "原简介",
+        backgroundURL: nil,
+        agreeCount: 0,
+        followingCount: 0,
+        followerCount: 0,
+        threadCount: 1,
+        followedForumCount: 0,
+        followedForums: [],
+        followedForumsVisibility: .visible
+    )
+
+    private static let requestBuilder = TiebaRequestBuilder(
+        screenScale: 3,
+        screenWidth: 1179,
+        screenHeight: 2556,
+        clientID: "profile-mutation-test"
+    )
+}
+
+private enum ProfileMutationStubMode: Sendable {
+    case success
+    case businessError
+    case sessionExpired
+    case finalResponse(Data)
+    case transportFailure
+    case decodeFailure
+    case holdFinalRequest
+}
+
+private struct ProfileMutationRecordedRequest: Sendable {
+    var host: String
+    var path: String
+    var userAgent: String?
+    var cookie: String?
+    var body: Data?
+}
+
+private final class ProfileMutationURLProtocol: URLProtocol {
+    static let testIDHeader = "X-TiebaPure-Profile-Mutation-Test-ID"
+
+    private struct Context {
+        var mode: ProfileMutationStubMode
+        var records: [ProfileMutationRecordedRequest]
+    }
+
+    private static let lock = NSLock()
+    private static var contexts: [String: Context] = [:]
+
+    static func register(mode: ProfileMutationStubMode, id: String) {
+        lock.lock()
+        contexts[id] = Context(mode: mode, records: [])
+        lock.unlock()
+    }
+
+    static func remove(id: String) {
+        lock.lock()
+        contexts.removeValue(forKey: id)
+        lock.unlock()
+    }
+
+    static func records(id: String) -> [ProfileMutationRecordedRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return contexts[id]?.records ?? []
+    }
+
+    static func count(path: String, id: String) -> Int {
+        records(id: id).count { $0.path == path }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.value(forHTTPHeaderField: testIDHeader) != nil
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url,
+              let id = request.value(forHTTPHeaderField: Self.testIDHeader),
+              let mode = Self.record(request: request, id: id) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        switch url.path {
+        case "/c/s/login":
+            respond(Data(#"{"error_code":"0","anti":{"tbs":"fresh-tbs"}}"#.utf8))
+        case "/c/c/profile/modify", "/c/c/bawu/delthread":
+            switch mode {
+            case .success:
+                respond(Data(#"{"error_code":0,"error_msg":""}"#.utf8))
+            case .businessError:
+                respond(Data(#"{"error_code":220034,"error_msg":"tbs校验失败"}"#.utf8))
+            case .sessionExpired:
+                respond(Data(#"{"error_code":110001,"error_msg":"登录已失效"}"#.utf8))
+            case .finalResponse(let data):
+                respond(data)
+            case .transportFailure:
+                client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+            case .decodeFailure:
+                respond(Data("{".utf8))
+            case .holdFinalRequest:
+                break
+            }
+        default:
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func record(request: URLRequest, id: String) -> ProfileMutationStubMode? {
+        let record = ProfileMutationRecordedRequest(
+            host: request.url?.host ?? "",
+            path: request.url?.path ?? "",
+            userAgent: request.value(forHTTPHeaderField: "User-Agent"),
+            cookie: request.value(forHTTPHeaderField: "Cookie"),
+            body: requestBody(request)
+        )
+        lock.lock()
+        defer { lock.unlock() }
+        guard var context = contexts[id] else { return nil }
+        context.records.append(record)
+        contexts[id] = context
+        return context.mode
+    }
+
+    private static func requestBody(_ request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            result.append(contentsOf: buffer.prefix(count))
+        }
+        return result
+    }
+
+    private func respond(_ data: Data) {
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: [
+                      "Content-Type": "application/json",
+                      "Content-Length": "\(data.count)"
+                  ]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}

--- a/TiebaPureTests/VideoPreviewTests.swift
+++ b/TiebaPureTests/VideoPreviewTests.swift
@@ -33,6 +33,197 @@ final class VideoPreviewTests: XCTestCase {
         ))
     }
 
+    func testDismissGestureClaimsOnlyRightwardHorizontalAndVerticalIntent() {
+        XCTAssertEqual(
+            VideoPreviewDismissGesturePolicy.axis(
+                velocity: CGPoint(x: 900, y: 40)
+            ),
+            .horizontalRight
+        )
+        XCTAssertNil(VideoPreviewDismissGesturePolicy.axis(
+            velocity: CGPoint(x: -900, y: 40)
+        ))
+        XCTAssertEqual(
+            VideoPreviewDismissGesturePolicy.axis(
+                velocity: CGPoint(x: 80, y: -900)
+            ),
+            .vertical
+        )
+        XCTAssertEqual(
+            VideoPreviewDismissGesturePolicy.axis(
+                velocity: CGPoint(x: 80, y: 900)
+            ),
+            .vertical
+        )
+        XCTAssertNil(VideoPreviewDismissGesturePolicy.axis(velocity: .zero))
+    }
+
+    func testDismissGestureUsesDistanceOrIntentionalFlickAndNeverMovesLeft() {
+        let viewport = CGSize(width: 390, height: 844)
+
+        XCTAssertEqual(
+            VideoPreviewDismissGesturePolicy.adjustedTranslation(
+                CGPoint(x: -40, y: 24),
+                for: .horizontalRight
+            ),
+            CGPoint(x: 0, y: 24)
+        )
+        XCTAssertFalse(VideoPreviewDismissGesturePolicy.shouldDismiss(
+            translation: CGPoint(x: 60, y: 0),
+            velocity: CGPoint(x: 400, y: 0),
+            axis: .horizontalRight,
+            viewportSize: viewport
+        ))
+        XCTAssertTrue(VideoPreviewDismissGesturePolicy.shouldDismiss(
+            translation: CGPoint(x: 100, y: 0),
+            velocity: CGPoint(x: 400, y: 0),
+            axis: .horizontalRight,
+            viewportSize: viewport
+        ))
+        XCTAssertFalse(VideoPreviewDismissGesturePolicy.shouldDismiss(
+            translation: CGPoint(x: 0, y: 100),
+            velocity: CGPoint(x: 0, y: 400),
+            axis: .vertical,
+            viewportSize: viewport
+        ))
+        XCTAssertTrue(VideoPreviewDismissGesturePolicy.shouldDismiss(
+            translation: CGPoint(x: 0, y: -160),
+            velocity: CGPoint(x: 0, y: -400),
+            axis: .vertical,
+            viewportSize: viewport
+        ))
+        XCTAssertTrue(VideoPreviewDismissGesturePolicy.shouldDismiss(
+            translation: CGPoint(x: 0, y: 65),
+            velocity: CGPoint(x: 0, y: 1_100),
+            axis: .vertical,
+            viewportSize: viewport
+        ))
+    }
+
+    func testDismissGestureBackgroundOpacityIsBoundedAndDistanceSensitive() {
+        let viewport = CGSize(width: 390, height: 844)
+        let resting = VideoPreviewDismissGesturePolicy.backgroundOpacity(
+            translation: .zero,
+            viewportSize: viewport
+        )
+        let dragged = VideoPreviewDismissGesturePolicy.backgroundOpacity(
+            translation: CGPoint(x: 0, y: 180),
+            viewportSize: viewport
+        )
+        let distant = VideoPreviewDismissGesturePolicy.backgroundOpacity(
+            translation: CGPoint(x: 0, y: 1_000),
+            viewportSize: viewport
+        )
+
+        XCTAssertEqual(resting, 1)
+        XCTAssertLessThan(dragged, resting)
+        XCTAssertEqual(distant, 0.28, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testDismissGestureAllowsButtonsButYieldsToContinuousControls() {
+        let root = UIView()
+        let plainSurface = UIView()
+        let button = UIButton(type: .system)
+        let buttonLabel = UILabel()
+        let slider = UISlider()
+        let adjustableControl = UIView()
+        adjustableControl.accessibilityTraits = .adjustable
+
+        root.addSubview(plainSurface)
+        root.addSubview(button)
+        button.addSubview(buttonLabel)
+        root.addSubview(slider)
+        root.addSubview(adjustableControl)
+
+        XCTAssertTrue(VideoPreviewGestureTouchPolicy.allowsDismissGesture(
+            startingAt: plainSurface
+        ))
+        XCTAssertTrue(VideoPreviewGestureTouchPolicy.allowsDismissGesture(
+            startingAt: button
+        ))
+        XCTAssertTrue(VideoPreviewGestureTouchPolicy.allowsDismissGesture(
+            startingAt: buttonLabel
+        ))
+        XCTAssertFalse(VideoPreviewGestureTouchPolicy.allowsDismissGesture(
+            startingAt: slider
+        ))
+        XCTAssertFalse(VideoPreviewGestureTouchPolicy.allowsDismissGesture(
+            startingAt: adjustableControl
+        ))
+    }
+
+    func testDismissalLifecycleIsIdempotentAndCancellationRestoresActiveState() {
+        var lifecycle = VideoPreviewDismissalLifecycleState()
+
+        XCTAssertEqual(lifecycle.phase, .active)
+        XCTAssertFalse(lifecycle.dismissalStarted)
+        XCTAssertTrue(lifecycle.begin())
+        XCTAssertFalse(lifecycle.begin())
+        XCTAssertTrue(lifecycle.dismissalStarted)
+        XCTAssertTrue(lifecycle.cancel())
+        XCTAssertEqual(lifecycle.phase, .active)
+        XCTAssertFalse(lifecycle.cancel())
+
+        XCTAssertTrue(lifecycle.begin())
+        XCTAssertTrue(lifecycle.finish())
+        XCTAssertEqual(lifecycle.phase, .finished)
+        XCTAssertFalse(lifecycle.finish())
+        XCTAssertFalse(lifecycle.cancel())
+    }
+
+    func testDetachedControllerFinishesOnlyAfterBothOwnershipSignalsDisappear() {
+        XCTAssertFalse(VideoPreviewDetachmentPolicy.shouldFinishDismissal(
+            hasPresentingController: true,
+            isInWindow: true
+        ))
+        XCTAssertFalse(VideoPreviewDetachmentPolicy.shouldFinishDismissal(
+            hasPresentingController: false,
+            isInWindow: true
+        ))
+        XCTAssertFalse(VideoPreviewDetachmentPolicy.shouldFinishDismissal(
+            hasPresentingController: true,
+            isInWindow: false
+        ))
+        XCTAssertTrue(VideoPreviewDetachmentPolicy.shouldFinishDismissal(
+            hasPresentingController: false,
+            isInWindow: false
+        ))
+    }
+
+    func testSameVideoCanQueueImmediateReopenAcrossTenDismissalCycles() {
+        let sourceKey = "fixture-video"
+        var arbiter = MediaPreviewPresentationArbiterState()
+        var active = MediaPreviewPresentationRequest(
+            id: UUID(),
+            kind: .video,
+            sourceKey: sourceKey
+        )
+        XCTAssertEqual(arbiter.submit(active), .startNow)
+        XCTAssertTrue(arbiter.presentationDidFinish(active))
+
+        for _ in 1...10 {
+            var lifecycle = VideoPreviewDismissalLifecycleState()
+            XCTAssertTrue(lifecycle.begin())
+            XCTAssertTrue(arbiter.dismissalWillBegin(active))
+
+            let next = MediaPreviewPresentationRequest(
+                id: UUID(),
+                kind: .video,
+                sourceKey: sourceKey
+            )
+            XCTAssertEqual(arbiter.submit(next), .queued(replacing: nil))
+
+            XCTAssertTrue(lifecycle.finish())
+            XCTAssertTrue(arbiter.dismissalDidFinish(active))
+            XCTAssertEqual(arbiter.finishSettlement(), next)
+            XCTAssertTrue(arbiter.presentationDidFinish(next))
+            active = next
+        }
+
+        XCTAssertEqual(arbiter.phase, .presented(active))
+    }
+
     func testVideoSourceIdentityIsStableAndContentSpecific() {
         let first = makeVideo(url: "https://video.example/first.mp4")
         let matching = makeVideo(url: "https://video.example/first.mp4")

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -616,6 +616,370 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
+    func testReplySettingDefaultsOffEnablesRepliesAndPersistsAcrossRelaunch() {
+        var app = launchApp(
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION_RISK"]
+        )
+        rootTab("我的", in: app).tap()
+
+        let settingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(settingsEntry, in: app, maxSwipes: 8))
+        settingsEntry.tap()
+        XCTAssertTrue(app.navigationBars["设置"].waitForExistence(timeout: 8))
+
+        let repliesToggle = app.switches["settings-replies-enabled-toggle"]
+        XCTAssertTrue(repliesToggle.waitForExistence(timeout: 5))
+        XCTAssertEqual(repliesToggle.value as? String, "0", "回帖设置必须默认关闭")
+        repliesToggle.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).tap()
+        XCTAssertTrue(waitForSwitch(repliesToggle, value: "1"))
+
+        app.terminate()
+        app = launchApp(
+            account: "loggedIn",
+            additionalArguments: ["UITEST_PRESERVE_CONTENT_SUBMISSION_SETTINGS"]
+        )
+        rootTab("我的", in: app).tap()
+        let persistedSettingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(persistedSettingsEntry, in: app, maxSwipes: 8))
+        persistedSettingsEntry.tap()
+        XCTAssertTrue(app.navigationBars["设置"].waitForExistence(timeout: 8))
+
+        let persistedToggle = app.switches["settings-replies-enabled-toggle"]
+        XCTAssertTrue(persistedToggle.waitForExistence(timeout: 5))
+        XCTAssertEqual(persistedToggle.value as? String, "1", "重启后应保留已开启的回帖设置")
+    }
+
+    func testEnabledReplySettingShowsHittableThreadEntry() {
+        let app = launchApp(
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"]
+        )
+        openFirstThread(in: app)
+
+        let replyEntry = app.buttons["thread-compose-reply-button"]
+        XCTAssertTrue(replyEntry.waitForExistence(timeout: 8))
+        XCTAssertTrue(waitForHittable(replyEntry, expected: true, timeout: 5))
+        replyEntry.tap()
+
+        let riskAlert = app.alerts["实验性发布功能"]
+        XCTAssertTrue(riskAlert.waitForExistence(timeout: 8))
+        riskAlert.buttons["了解并继续"].tap()
+        XCTAssertTrue(app.navigationBars["回复帖子"].waitForExistence(timeout: 8))
+    }
+
+    func testPlainTextTapOpensCorrectMainFloorAndSubpostComposer() {
+        let app = launchApp(
+            scenario: "subpostReference",
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"]
+        )
+        openFirstThread(in: app)
+
+        let mainText = app.textViews["thread-main-text"]
+        XCTAssertTrue(mainText.waitForExistence(timeout: 8))
+        mainText.coordinate(withNormalizedOffset: CGVector(dx: 0.12, dy: 0.18)).tap()
+
+        let riskAlert = app.alerts["实验性发布功能"]
+        XCTAssertTrue(riskAlert.waitForExistence(timeout: 8))
+        riskAlert.buttons["了解并继续"].tap()
+        assertReplyComposer(
+            navigationTitle: "回复用户",
+            prompt: "回复 合成内容作者",
+            in: app
+        )
+        app.navigationBars["回复用户"].buttons["取消"].tap()
+
+        let floorText = app.textViews.matching(identifier: "thread-reply-text")
+            .matching(NSPredicate(format: "value CONTAINS %@", "确定性回复内容"))
+            .firstMatch
+        XCTAssertTrue(revealBySwipingUp(floorText, in: app, maxSwipes: 12))
+        floorText.coordinate(withNormalizedOffset: CGVector(dx: 0.18, dy: 0.35)).tap()
+        assertReplyComposer(
+            navigationTitle: "回复用户",
+            prompt: "回复 很长很长的合成回复用户名用于布局测试",
+            in: app
+        )
+        app.navigationBars["回复用户"].buttons["取消"].tap()
+
+        XCTAssertTrue(waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 12))
+        app.buttons["查看全部4条回复"].tap()
+        XCTAssertTrue(app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8))
+
+        let subpostText = app.textViews.matching(identifier: "thread-subpost-text")
+            .matching(NSPredicate(format: "value CONTAINS %@", "楼中楼参考布局回复2"))
+            .firstMatch
+        XCTAssertTrue(revealBySwipingUp(subpostText, in: app, maxSwipes: 8))
+        subpostText.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.5)).tap()
+        assertReplyComposer(
+            navigationTitle: "回复用户",
+            prompt: "回复 合成内容作者",
+            in: app
+        )
+        app.navigationBars["回复用户"].buttons["取消"].tap()
+        XCTAssertTrue(app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 5))
+    }
+
+    func testLiveAccountContentLifecycle() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["TIEBAPURE_RUN_LIVE_ACCOUNT_UI"] == "1" else {
+            throw XCTSkip("真实账号冒烟仅在显式启用时运行。")
+        }
+
+        let mode = environment["TIEBAPURE_LIVE_ACCOUNT_MODE"] ?? "read"
+        let forumName = environment["TIEBAPURE_LIVE_FORUM"]
+            ?? "洗个头脱了四五百根怎么了"
+        let token = environment["TIEBAPURE_LIVE_TEST_TOKEN"]
+            ?? String(UUID().uuidString.prefix(8))
+        let title = environment["TIEBAPURE_LIVE_THREAD_TITLE"]
+            ?? "TiebaPure 测试 \(token)"
+        let threadBody = environment["TIEBAPURE_LIVE_THREAD_BODY"]
+            ?? "TiebaPure 真实账号低频测试，请忽略。标记：\(token)"
+
+        let app = XCUIApplication()
+        app.launch()
+
+        let meTab = rootTab("我的", in: app)
+        XCTAssertTrue(meTab.waitForExistence(timeout: 20))
+        meTab.tap()
+        XCTAssertTrue(app.buttons["me-user-profile-button"].waitForExistence(timeout: 10))
+
+        if mode == "cleanup" {
+            openLiveTestThreadFromHistory(title: title, in: app)
+            deleteCurrentLiveTestThread(in: app)
+            return
+        }
+
+        if mode == "write" || mode == "resume" || mode == "resumeSubpost" {
+            let settingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+            XCTAssertTrue(settingsEntry.waitForExistence(timeout: 10))
+            settingsEntry.tap()
+
+            let repliesToggle = app.switches["settings-replies-enabled-toggle"]
+            XCTAssertTrue(repliesToggle.waitForExistence(timeout: 10))
+            if (repliesToggle.value as? String) != "1" {
+                repliesToggle.coordinate(
+                    withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)
+                ).tap()
+            }
+            let repliesEnabled = XCTNSPredicateExpectation(
+                predicate: NSPredicate(format: "value == %@", "1"),
+                object: repliesToggle
+            )
+            XCTAssertEqual(XCTWaiter.wait(for: [repliesEnabled], timeout: 5), .completed)
+
+            let settingsBackButton = app.navigationBars["设置"].buttons.firstMatch
+            XCTAssertTrue(settingsBackButton.waitForExistence(timeout: 5))
+            settingsBackButton.tap()
+        }
+
+        let bodyEditor = app.textViews["正文内容"]
+        let submissionError = app.descendants(matching: .any)[
+            "content-composer-submission-error"
+        ]
+        var forumNavigationBar: XCUIElement?
+
+        if mode == "resume" || mode == "resumeSubpost" {
+            openLiveTestThreadFromHistory(title: title, in: app)
+        } else {
+            let followedForums = app.buttons["关注的吧"]
+            XCTAssertTrue(followedForums.waitForExistence(timeout: 10))
+            followedForums.tap()
+
+            let targetForum = app.buttons.matching(
+                NSPredicate(format: "label CONTAINS %@", forumName)
+            ).firstMatch
+            XCTAssertTrue(targetForum.waitForExistence(timeout: 20), "未找到真实账号测试吧：\(forumName)")
+            targetForum.tap()
+
+            let resolvedForumNavigationBar = app.navigationBars.matching(
+                NSPredicate(format: "identifier CONTAINS %@", forumName)
+            ).firstMatch
+            XCTAssertTrue(resolvedForumNavigationBar.waitForExistence(timeout: 15))
+            forumNavigationBar = resolvedForumNavigationBar
+            let newThreadButton = app.buttons["forum-new-thread-button"]
+            XCTAssertTrue(newThreadButton.waitForExistence(timeout: 10))
+
+            guard mode == "write" else { return }
+
+            newThreadButton.tap()
+            let riskAlert = app.alerts["实验性发布功能"]
+            if riskAlert.waitForExistence(timeout: 2) {
+                riskAlert.buttons["了解并继续"].tap()
+            }
+
+            let titleField = app.textFields["帖子标题"]
+            XCTAssertTrue(titleField.waitForExistence(timeout: 10))
+            XCTAssertTrue(bodyEditor.waitForExistence(timeout: 10))
+            titleField.tap()
+            titleField.typeText(title)
+            bodyEditor.tap()
+            bodyEditor.typeText(threadBody)
+
+            let sendThread = app.navigationBars["发布新帖"].buttons["发送"]
+            XCTAssertTrue(waitForHittable(sendThread, expected: true, timeout: 5))
+            sendThread.tap()
+            let threadComposer = app.navigationBars["发布新帖"]
+            let submissionDeadline = Date().addingTimeInterval(30)
+            while threadComposer.exists, submissionError.exists == false, Date() < submissionDeadline {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            }
+            XCTAssertFalse(
+                submissionError.exists,
+                "真实发帖被服务端明确拒绝：\(submissionError.label)"
+            )
+            XCTAssertFalse(threadComposer.exists, "真实发帖请求未完成")
+            XCTAssertTrue(app.descendants(matching: .any)["thread-main-text"].waitForExistence(timeout: 30))
+        }
+
+        if mode != "resumeSubpost" {
+            let threadReply = environment["TIEBAPURE_LIVE_THREAD_REPLY"]
+                ?? "普通回帖测试 \(token)"
+            let threadReplyButton = app.buttons["thread-compose-reply-button"]
+            XCTAssertTrue(threadReplyButton.waitForExistence(timeout: 10))
+            threadReplyButton.tap()
+            XCTAssertTrue(bodyEditor.waitForExistence(timeout: 10))
+            bodyEditor.tap()
+            bodyEditor.typeText(threadReply)
+            let sendReply = app.navigationBars["回复帖子"].buttons["发送"]
+            XCTAssertTrue(waitForHittable(sendReply, expected: true, timeout: 5))
+            sendReply.tap()
+            waitForLiveSubmissionToFinish(
+                editor: bodyEditor,
+                error: submissionError,
+                timeout: 30
+            )
+            XCTAssertFalse(
+                submissionError.exists,
+                "真实普通回帖被服务端明确拒绝：\(submissionError.label)"
+            )
+            XCTAssertFalse(bodyEditor.exists, "普通回帖请求未完成")
+        }
+
+        let floorReplyButton = app.buttons.matching(
+            NSPredicate(format: "label == %@", "回复第2楼")
+        ).firstMatch
+        let threadScrollView = app.scrollViews["thread-detail-scroll-view"]
+        for _ in 0..<12 where floorReplyButton.exists == false || floorReplyButton.isHittable == false {
+            threadScrollView.swipeUp()
+        }
+        XCTAssertTrue(floorReplyButton.exists && floorReplyButton.isHittable)
+        floorReplyButton.tap()
+        XCTAssertTrue(bodyEditor.waitForExistence(timeout: 10))
+        bodyEditor.tap()
+        let floorReply = environment["TIEBAPURE_LIVE_FLOOR_REPLY"]
+            ?? "楼层回复测试 \(token)"
+        bodyEditor.typeText(floorReply)
+        let sendFloorReply = app.buttons["发送"]
+        XCTAssertTrue(waitForHittable(sendFloorReply, expected: true, timeout: 5))
+        sendFloorReply.tap()
+        waitForLiveSubmissionToFinish(
+            editor: bodyEditor,
+            error: submissionError,
+            timeout: 30
+        )
+        XCTAssertFalse(
+            submissionError.exists,
+            "真实楼层回复被服务端明确拒绝：\(submissionError.label)"
+        )
+        XCTAssertFalse(bodyEditor.exists, "楼层回复请求未完成")
+
+        let subpostNavigationBar = app.navigationBars.matching(
+            NSPredicate(format: "identifier CONTAINS %@", "楼的回复")
+        ).firstMatch
+        XCTAssertTrue(subpostNavigationBar.waitForExistence(timeout: 30))
+        let subpostReplyButton = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "subpost-reply-button-")
+        ).firstMatch
+        XCTAssertTrue(subpostReplyButton.waitForExistence(timeout: 20))
+        subpostReplyButton.tap()
+        XCTAssertTrue(bodyEditor.waitForExistence(timeout: 10))
+        bodyEditor.tap()
+        let subpostReply = environment["TIEBAPURE_LIVE_SUBPOST_REPLY"]
+            ?? "楼中楼回复测试 \(token)"
+        bodyEditor.typeText(subpostReply)
+        let sendSubpostReply = app.buttons["发送"]
+        XCTAssertTrue(waitForHittable(sendSubpostReply, expected: true, timeout: 5))
+        sendSubpostReply.tap()
+        waitForLiveSubmissionToFinish(
+            editor: bodyEditor,
+            error: submissionError,
+            timeout: 30
+        )
+        XCTAssertFalse(
+            submissionError.exists,
+            "真实楼中楼回复被服务端明确拒绝：\(submissionError.label)"
+        )
+        XCTAssertFalse(bodyEditor.exists, "楼中楼回复请求未完成")
+
+        let closeSubposts = subpostNavigationBar.buttons["完成"]
+        XCTAssertTrue(closeSubposts.waitForExistence(timeout: 10))
+        closeSubposts.tap()
+        XCTAssertTrue(app.descendants(matching: .any)["thread-main-text"].waitForExistence(timeout: 10))
+
+        deleteCurrentLiveTestThread(in: app, forumNavigationBar: forumNavigationBar)
+    }
+
+    private func waitForLiveSubmissionToFinish(
+        editor: XCUIElement,
+        error: XCUIElement,
+        timeout: TimeInterval
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while editor.exists, error.exists == false, Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+    }
+
+    private func openLiveTestThreadFromHistory(title: String, in app: XCUIApplication) {
+        let historyEntry = app.buttons["browsing-history-entry"]
+        XCTAssertTrue(
+            waitForElement(named: "browsing-history-entry", in: app, maxSwipes: 4),
+            "未找到浏览历史入口"
+        )
+        historyEntry.tap()
+        XCTAssertTrue(app.navigationBars["浏览历史"].waitForExistence(timeout: 10))
+
+        let targetThread = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", title)
+        ).firstMatch
+        XCTAssertTrue(
+            targetThread.waitForExistence(timeout: 10),
+            "浏览历史中没有待处理的测试帖：\(title)"
+        )
+        targetThread.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["thread-main-text"]
+                .waitForExistence(timeout: 20)
+        )
+    }
+
+    private func deleteCurrentLiveTestThread(
+        in app: XCUIApplication,
+        forumNavigationBar: XCUIElement? = nil
+    ) {
+        let more = app.buttons["更多"]
+        XCTAssertTrue(more.waitForExistence(timeout: 10))
+        more.tap()
+        let delete = app.buttons["thread-delete-own-thread"]
+        XCTAssertTrue(delete.waitForExistence(timeout: 5))
+        delete.tap()
+        let confirmDelete = app.buttons["删除帖子"]
+        XCTAssertTrue(confirmDelete.waitForExistence(timeout: 5))
+        confirmDelete.tap()
+        if let forumNavigationBar {
+            XCTAssertTrue(
+                forumNavigationBar.waitForExistence(timeout: 30),
+                "删除测试帖后应返回测试吧"
+            )
+        } else {
+            XCTAssertTrue(
+                app.navigationBars["浏览历史"].waitForExistence(timeout: 30),
+                "从浏览历史删除测试帖后应返回浏览历史"
+            )
+        }
+    }
+
     func testComposerBlocksEditingWhenDraftReadFailsUntilRetrySucceeds() {
         let app = launchApp(
             account: "loggedIn",
@@ -2004,7 +2368,11 @@ final class TiebaPureUITests: XCTestCase {
     }
 
     func testTappingThreadImageStillOpensPreview() {
-        let app = launchApp(scenario: "imageGesture")
+        let app = launchApp(
+            scenario: "imageGesture",
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"]
+        )
         openFirstThread(in: app)
 
         for iteration in 0..<3 {
@@ -2017,6 +2385,7 @@ final class TiebaPureUITests: XCTestCase {
                 app.descendants(matching: .any)["full-screen-image-pager"].waitForExistence(timeout: 5),
                 "第\(iteration + 1)次真正点按图片仍应打开全屏预览"
             )
+            XCTAssertFalse(app.navigationBars["回复用户"].exists, "点击媒体不得触发回帖编辑器")
             app.buttons["关闭图片"].tap()
 
             let sourceIsHittable = XCTNSPredicateExpectation(
@@ -2790,7 +3159,11 @@ final class TiebaPureUITests: XCTestCase {
     }
 
     func testThreadDetailTextSupportsNativeCopySelection() {
-        let app = launchApp(scenario: "longContent")
+        let app = launchApp(
+            scenario: "longContent",
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"]
+        )
         openFirstThread(in: app)
 
         let mainText = app.textViews["thread-main-text"]
@@ -2805,6 +3178,7 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(copyControl.waitForExistence(timeout: 5))
         XCTAssertTrue(waitForHittable(copyControl, expected: true, timeout: 5))
         copyControl.tap()
+        XCTAssertFalse(app.navigationBars["回复用户"].exists, "长按复制不得触发回帖编辑器")
         XCTAssertTrue(app.buttons["更多"].exists)
     }
 
@@ -3364,7 +3738,10 @@ final class TiebaPureUITests: XCTestCase {
         let failedCover = app.buttons["播放视频，封面加载失败"]
         XCTAssertTrue(failedCover.waitForExistence(timeout: 5))
         failedCover.tap()
-        XCTAssertTrue(app.buttons["关闭视频"].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["full-screen-video-player"]
+                .waitForExistence(timeout: 5)
+        )
     }
 
     func testAutomaticVideoCoverFailureDoesNotBlockMediaDestinations() {
@@ -3372,10 +3749,19 @@ final class TiebaPureUITests: XCTestCase {
 
         let video = app.buttons["播放视频，封面加载失败"]
         XCTAssertTrue(video.waitForExistence(timeout: 5))
-        video.tap()
-        let closeVideo = app.buttons["关闭视频"]
-        XCTAssertTrue(closeVideo.waitForExistence(timeout: 5))
-        closeVideo.tap()
+        for cycle in 1...2 {
+            video.tap()
+            let player = app.descendants(matching: .any)["full-screen-video-player"]
+            XCTAssertTrue(
+                player.waitForExistence(timeout: 5),
+                "无封面视频第\(cycle)次没有打开"
+            )
+            player.swipeDown(velocity: .slow)
+            XCTAssertTrue(
+                waitForHittable(video, expected: true, timeout: 5),
+                "无封面视频第\(cycle)次退出后没有立即恢复交互"
+            )
+        }
 
         let gridVideo = app.buttons.matching(
             NSPredicate(format: "label BEGINSWITH %@", "测试视频，封面加载失败")
@@ -3407,13 +3793,11 @@ final class TiebaPureUITests: XCTestCase {
         for cycle in 1...2 {
             video.tap()
             let player = app.descendants(matching: .any)["full-screen-video-player"]
-            let close = app.buttons["关闭视频"]
             XCTAssertTrue(
                 player.waitForExistence(timeout: 5),
                 "第\(cycle)次没有打开全屏视频"
             )
-            XCTAssertTrue(close.waitForExistence(timeout: 5))
-            close.tap()
+            player.swipeDown(velocity: .slow)
             XCTAssertTrue(
                 waitForHittable(video, expected: true, timeout: 5),
                 "第\(cycle)次关闭后视频封面没有恢复交互"
@@ -4357,6 +4741,7 @@ final class TiebaPureUITests: XCTestCase {
             "UITEST_DISABLE_ANIMATIONS",
             "UITEST_RESET_SEARCH_HISTORY",
             "UITEST_RESET_BROWSING_HISTORY",
+            "UITEST_RESET_RECENT_FORUMS",
             "UITEST_RESET_LOCAL_THREAD_LIBRARY",
             "UITEST_RESET_BLOCKLIST",
             "UITEST_RESET_FORUM_THREAD_SORT"
@@ -4374,6 +4759,45 @@ final class TiebaPureUITests: XCTestCase {
         }
         app.launch()
         return app
+    }
+
+    private func waitForSwitch(
+        _ toggle: XCUIElement,
+        value: String,
+        timeout: TimeInterval = 5
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", value),
+            object: toggle
+        )
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    private func assertReplyComposer(
+        navigationTitle: String,
+        prompt: String,
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            app.navigationBars[navigationTitle].waitForExistence(timeout: 8),
+            "点击纯文本后应打开 \(navigationTitle) 编辑器",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            app.staticTexts[prompt].waitForExistence(timeout: 5),
+            "编辑器回复目标不正确：\(prompt)",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            app.textViews["正文内容"].waitForExistence(timeout: 5),
+            "回复编辑器必须显示正文输入区",
+            file: file,
+            line: line
+        )
     }
 
     private func diagnosticMetric(_ name: String, from value: String) -> Int? {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -169,7 +169,7 @@ final class TiebaPureUITests: XCTestCase {
 
         XCTAssertTrue(app.descendants(matching: .any)["user-profile-screen"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.staticTexts["合成内容作者"].waitForExistence(timeout: 8))
-        XCTAssertTrue(app.staticTexts["user-profile-metadata"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["user-profile-metadata"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.buttons["user-profile-follow-button"].exists)
         XCTAssertTrue(app.buttons["user-profile-posts-tab"].exists)
         XCTAssertTrue(app.buttons["user-profile-thread-row-1001"].waitForExistence(timeout: 8))
@@ -648,6 +648,63 @@ final class TiebaPureUITests: XCTestCase {
         let persistedToggle = app.switches["settings-replies-enabled-toggle"]
         XCTAssertTrue(persistedToggle.waitForExistence(timeout: 5))
         XCTAssertEqual(persistedToggle.value as? String, "1", "重启后应保留已开启的回帖设置")
+    }
+
+    func testDisabledPostingAndLikesHideWriteActionsButKeepEveryLikeCount() {
+        var app = launchApp(scenario: "subpostReference", account: "loggedIn")
+        rootTab("我的", in: app).tap()
+
+        let settingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(settingsEntry, in: app, maxSwipes: 8))
+        settingsEntry.tap()
+        XCTAssertTrue(app.navigationBars["设置"].waitForExistence(timeout: 8))
+
+        let newThreadsToggle = app.switches["settings-new-threads-enabled-toggle"]
+        let likesToggle = app.switches["settings-likes-enabled-toggle"]
+        XCTAssertTrue(newThreadsToggle.waitForExistence(timeout: 5))
+        XCTAssertTrue(likesToggle.waitForExistence(timeout: 5))
+        XCTAssertEqual(newThreadsToggle.value as? String, "1")
+        XCTAssertEqual(likesToggle.value as? String, "1")
+        newThreadsToggle.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).tap()
+        likesToggle.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).tap()
+        XCTAssertTrue(waitForSwitch(newThreadsToggle, value: "0"))
+        XCTAssertTrue(waitForSwitch(likesToggle, value: "0"))
+
+        app.terminate()
+        app = launchApp(
+            scenario: "subpostReference",
+            account: "loggedIn",
+            additionalArguments: ["UITEST_PRESERVE_CONTENT_SUBMISSION_SETTINGS"]
+        )
+        openFirstFollowedForum(in: app)
+        XCTAssertFalse(
+            app.buttons["forum-new-thread-button"].waitForExistence(timeout: 2),
+            "关闭发帖后不应保留发布入口"
+        )
+        openFirstThread(in: app)
+
+        assertLikeCountIsReadOnly(identifier: "thread-main-like-button", in: app)
+        XCTAssertTrue(
+            revealBySwipingUp(
+                app.descendants(matching: .any)["thread-like-button-2002"],
+                in: app,
+                maxSwipes: 12
+            )
+        )
+        assertLikeCountIsReadOnly(identifier: "thread-like-button-2002", in: app)
+
+        XCTAssertTrue(waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 8))
+        app.buttons["查看全部4条回复"].tap()
+        XCTAssertTrue(app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8))
+        assertLikeCountIsReadOnly(identifier: "thread-subpost-parent-like-button", in: app)
+        XCTAssertTrue(
+            revealBySwipingUp(
+                app.descendants(matching: .any)["thread-subpost-like-button-3051"],
+                in: app,
+                maxSwipes: 8
+            )
+        )
+        assertLikeCountIsReadOnly(identifier: "thread-subpost-like-button-3051", in: app)
     }
 
     func testEnabledReplySettingShowsHittableThreadEntry() {
@@ -5132,6 +5189,13 @@ final class TiebaPureUITests: XCTestCase {
         return app.descendants(matching: .any)
             .matching(NSPredicate(format: "label == %@ OR identifier == %@", label, label))
             .firstMatch
+    }
+
+    private func assertLikeCountIsReadOnly(identifier: String, in app: XCUIApplication) {
+        let count = app.descendants(matching: .any)[identifier]
+        XCTAssertTrue(count.waitForExistence(timeout: 5), "关闭点赞后仍应显示 \(identifier) 的赞数")
+        XCTAssertFalse(app.buttons[identifier].exists, "关闭点赞后 \(identifier) 不应仍是按钮")
+        XCTAssertTrue(count.label.contains("点赞"), "只读计数仍应提供完整的点赞无障碍标签")
     }
 
     private func openFirstThread(in app: XCUIApplication) {

--- a/TiebaPureUITests/UserProfileManagementUITests.swift
+++ b/TiebaPureUITests/UserProfileManagementUITests.swift
@@ -1,0 +1,112 @@
+import XCTest
+
+final class UserProfileManagementUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testOwnProfileEditorShowsFieldsAndPersistsFixtureSuccess() {
+        let app = launchLoggedInFixture()
+        openOwnProfile(in: app)
+
+        XCTAssertFalse(app.buttons["user-profile-follow-button"].exists)
+        let editButton = app.buttons["user-profile-edit-button"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 8))
+        XCTAssertGreaterThanOrEqual(editButton.frame.height, 44)
+        editButton.tap()
+
+        let nickname = app.textFields["user-profile-edit-nickname"]
+        let introduction = app.textViews["user-profile-edit-introduction"]
+        let sex = app.segmentedControls["user-profile-edit-sex"]
+        XCTAssertTrue(nickname.waitForExistence(timeout: 5))
+        XCTAssertTrue(introduction.exists)
+        XCTAssertTrue(sex.exists)
+        XCTAssertTrue(app.buttons["user-profile-edit-save"].exists)
+
+        nickname.tap()
+        nickname.typeText("新")
+        app.buttons["男"].tap()
+        app.buttons["user-profile-edit-save"].tap()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-edit-success"]
+                .waitForExistence(timeout: 8)
+        )
+        app.buttons["user-profile-edit-done"].tap()
+        XCTAssertTrue(app.staticTexts["模拟登录用户新"].waitForExistence(timeout: 5))
+    }
+
+    func testOwnThreadDeleteConfirmsOnceThenReturnsAndRemovesFixtureRow() {
+        let app = launchLoggedInFixture()
+        openOwnProfile(in: app)
+
+        let thread = app.buttons["user-profile-thread-row-1001"]
+        XCTAssertTrue(thread.waitForExistence(timeout: 8))
+        thread.tap()
+
+        XCTAssertTrue(
+            app.textViews["thread-main-text"].waitForExistence(timeout: 8),
+            "必须等本人主题详情和作者身份校验完成后再打开更多菜单"
+        )
+
+        let more = app.buttons["更多"]
+        XCTAssertTrue(more.waitForExistence(timeout: 8))
+        more.tap()
+
+        let delete = app.buttons["thread-delete-own-thread"]
+        XCTAssertTrue(delete.waitForExistence(timeout: 5))
+        delete.tap()
+        let confirm = app.buttons["删除帖子"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5))
+        confirm.tap()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+        XCTAssertTrue(thread.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["user-profile-thread-row-1002"].exists)
+    }
+
+    private func launchLoggedInFixture() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "UITEST_USE_FIXTURES",
+            "UITEST_DISABLE_ANIMATIONS",
+            "UITEST_RESET_APPEARANCE",
+            "UITEST_RESET_READING_PREFERENCES",
+            "UITEST_RESET_BLOCKLIST"
+        ]
+        app.launchEnvironment["TIEBAPURE_FIXTURE_SCENARIO"] = "profileManagement"
+        app.launchEnvironment["TIEBAPURE_FIXTURE_ACCOUNT"] = "loggedIn"
+        app.launch()
+        return app
+    }
+
+    private func openOwnProfile(in app: XCUIApplication) {
+        let meTab = rootTab("我的", symbolIdentifier: "person.circle", in: app)
+        XCTAssertTrue(meTab.waitForExistence(timeout: 20))
+        meTab.tap()
+
+        let profileButton = app.buttons["me-user-profile-button"]
+        XCTAssertTrue(profileButton.waitForExistence(timeout: 8))
+        profileButton.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+    }
+
+    private func rootTab(
+        _ label: String,
+        symbolIdentifier: String,
+        in app: XCUIApplication
+    ) -> XCUIElement {
+        let symbolButton = app.buttons.matching(identifier: symbolIdentifier).firstMatch
+        if symbolButton.exists { return symbolButton }
+        return app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label == %@ OR identifier == %@", label, label))
+            .firstMatch
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.3.8
-        CURRENT_PROJECT_VERSION: 27
+        MARKETING_VERSION: 1.3.9
+        CURRENT_PROJECT_VERSION: 28
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.3.8
-        CURRENT_PROJECT_VERSION: 27
+        MARKETING_VERSION: 1.3.9
+        CURRENT_PROJECT_VERSION: 28
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.3.7
-        CURRENT_PROJECT_VERSION: 26
+        MARKETING_VERSION: 1.3.8
+        CURRENT_PROJECT_VERSION: 27
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.3.7
-        CURRENT_PROJECT_VERSION: 26
+        MARKETING_VERSION: 1.3.8
+        CURRENT_PROJECT_VERSION: 27
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 变更

- 在设置中增加回帖总开关，并补齐楼层、楼中楼快捷回复
- 支持本人资料的昵称、简介和性别修改
- 本人主题仅提供删除和二次确认，不支持编辑正文或修改帖子状态
- 完善视频预览的退出、拖动和重复打开行为
- 加固账号切换、注销和写请求响应判定，避免跨会话提交与不确定结果重试
- 隔离 UI fixture 的最近贴吧数据，保证自动化测试确定性

## 验证

- 单元测试完整运行两轮：合计 1151 次测试运行、7 项真实账号测试跳过、0 失败
- iPhone 17 fixture UI：8/8 通过
- iPad Pro 11-inch fixture UI：2/2 通过
- xcodebuild analyze 通过
- Release unsigned IPA 打包及包结构、隐私清单、版本与 ProMotion 检查通过
- GitHub Actions ci-ok 通过

这是基于 fix/refresh-and-video-viewer 的堆叠 PR；待前置 PR 合并后再调整基线并合并。