### PR TITLE
Redesign the user profile

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1243,13 +1243,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.9;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1260,14 +1260,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.9;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1313,14 +1313,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.9;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1333,13 +1333,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.9;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -955,9 +955,9 @@ struct ForumThreadRow: View {
 
         var cardRadius: CGFloat {
             switch self {
-            case .list:
+            case .list, .userProfile:
                 return 0
-            case .homeFeed, .userProfile:
+            case .homeFeed:
                 return TiebaPureTheme.Radius.card
             }
         }

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -328,7 +328,7 @@ struct UserProfileView: View {
                 .frame(minHeight: 220)
                 .background(Color(uiColor: .systemBackground))
         } else {
-            LazyVStack(spacing: TiebaPureTheme.Spacing.sm) {
+            LazyVStack(spacing: TiebaPureTheme.Spacing.xs) {
                 ForEach(Array(threads.enumerated()), id: \.element.id) { index, thread in
                     ForumThreadRow(
                         thread: thread,
@@ -1180,71 +1180,107 @@ private struct UserProfileHeader: View {
     let onEditProfile: (() -> Void)?
 
     private enum Layout {
-        static let avatarSize: CGFloat = 72
+        static let avatarSize: CGFloat = 56
         static let actionMinWidth: CGFloat = 80
     }
 
+    private var identityMetadataItems: [String] {
+        UserProfileMetadataText.items(for: profile, group: .identity)
+    }
+
+    private var detailMetadataItems: [String] {
+        UserProfileMetadataText.items(for: profile, group: .details)
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
-            if showsProfileAction {
-                if dynamicTypeSize.isAccessibilitySize {
-                    VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.sm) {
-                        identityBlock
-                        profileAction
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                    }
-                } else {
-                    HStack(alignment: .top, spacing: TiebaPureTheme.Spacing.sm) {
-                        identityBlock
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .layoutPriority(1)
-                        profileAction
-                    }
-                }
-            } else {
-                identityBlock
-            }
+        VStack(alignment: .leading, spacing: 0) {
+            identityAndAction
 
             if profile.intro.isEmpty == false {
                 Text(profile.intro)
                     .font(.body)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.primary)
                     .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)
                     .accessibilityLabel("个人简介：\(profile.intro)")
+                    .padding(.top, TiebaPureTheme.Spacing.sm)
             }
 
+            if detailMetadataItems.isEmpty == false {
+                ProfileMetadataView(
+                    items: detailMetadataItems,
+                    accessibilityIdentifier: "user-profile-secondary-metadata"
+                )
+                .padding(.top, profile.intro.isEmpty ? TiebaPureTheme.Spacing.sm : TiebaPureTheme.Spacing.xxs)
+            }
+
+            Divider()
+                .padding(.top, TiebaPureTheme.Spacing.sm)
+
             profileStats
-            .padding(.top, TiebaPureTheme.Spacing.xs)
         }
         .padding(.horizontal, TiebaPureTheme.Spacing.md)
-        .padding(.vertical, TiebaPureTheme.Spacing.sm)
+        .padding(.top, TiebaPureTheme.Spacing.sm)
+        .padding(.bottom, TiebaPureTheme.Spacing.xxs)
         .background(Color(uiColor: .systemBackground))
     }
 
-    private var identityBlock: some View {
-        HStack(alignment: .top, spacing: TiebaPureTheme.Spacing.sm) {
-            AvatarView(
-                url: profile.user.portraitURL,
-                title: profile.user.displayNameResolved,
-                size: Layout.avatarSize
-            )
-
+    @ViewBuilder
+    private var identityAndAction: some View {
+        if dynamicTypeSize.isAccessibilitySize {
             VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xs) {
-                ViewThatFits(in: .horizontal) {
-                    HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.xs) {
-                        profileName
-                        levelBadge
-                    }
-                    VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xs) {
-                        profileName
-                        levelBadge
-                    }
+                HStack(alignment: .top, spacing: TiebaPureTheme.Spacing.sm) {
+                    profileAvatar
+                    identitySummary
                 }
 
-                ProfileMetadataView(profile: profile)
+                if showsProfileAction {
+                    profileAction
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.sm) {
+                profileAvatar
+                identitySummary
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
+
+                if showsProfileAction {
+                    profileAction
+                }
+            }
+        }
+    }
+
+    private var profileAvatar: some View {
+        AvatarView(
+            url: profile.user.portraitURL,
+            title: profile.user.displayNameResolved,
+            size: Layout.avatarSize
+        )
+        .accessibilityIdentifier("user-profile-avatar")
+    }
+
+    private var identitySummary: some View {
+        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.xs) {
+                    profileName
+                    levelBadge
+                }
+                VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
+                    profileName
+                    levelBadge
+                }
+            }
+
+            if identityMetadataItems.isEmpty == false {
+                ProfileMetadataView(
+                    items: identityMetadataItems,
+                    accessibilityIdentifier: "user-profile-metadata"
+                )
+            }
         }
     }
 
@@ -1254,15 +1290,15 @@ private struct UserProfileHeader: View {
 
     @ViewBuilder
     private var profileStats: some View {
-        if dynamicTypeSize.isAccessibilitySize {
-            VStack(spacing: 0) {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: TiebaPureTheme.Spacing.md) {
                 profileStatViews
             }
-        } else {
-            HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
                 profileStatViews
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
@@ -1305,31 +1341,33 @@ private struct UserProfileHeader: View {
                     ProgressView()
                         .controlSize(.small)
                 } else {
-                    Label(
-                        profile.isFollowed ? "已关注" : "关注",
-                        systemImage: profile.isFollowed ? "checkmark" : "plus"
-                    )
-                    .font(.subheadline.weight(.semibold))
+                    if profile.isFollowed {
+                        Label("已关注", systemImage: "checkmark")
+                            .font(.subheadline.weight(.semibold))
+                    } else {
+                        HStack(spacing: TiebaPureTheme.Spacing.xxs) {
+                            Image(systemName: "plus")
+                                .foregroundStyle(TiebaPureTheme.ColorToken.primaryAccent)
+                            Text("关注")
+                                .foregroundStyle(.primary)
+                        }
+                        .font(.subheadline.weight(.semibold))
+                    }
                 }
             }
             .frame(minWidth: Layout.actionMinWidth, minHeight: 44)
             .padding(.horizontal, TiebaPureTheme.Spacing.xxs)
         }
         .buttonStyle(.plain)
-        .foregroundStyle(
-            profile.isFollowed
-                ? Color.secondary
-                : TiebaPureTheme.ColorToken.primaryAccent
-        )
+        .foregroundStyle(Color.primary)
         .background(
-            TiebaPureTheme.ColorToken.readerSecondarySurface,
+            profile.isFollowed
+                ? TiebaPureTheme.ColorToken.readerSecondarySurface
+                : TiebaPureTheme.ColorToken.primaryAccent.opacity(0.12),
             in: RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
         )
-        .overlay {
-            RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
-                .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
-        }
         .disabled(followAction.isUpdating)
+        .opacity(followAction.isUpdating ? 0.65 : 1)
         .accessibilityLabel(profile.isFollowed ? "取消关注" : "关注用户")
         .accessibilityHint(profile.isFollowed ? "停止关注该用户" : "关注该用户")
         .accessibilityIdentifier("user-profile-follow-button")
@@ -1337,21 +1375,21 @@ private struct UserProfileHeader: View {
 
     private func editProfileButton(action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            Label("编辑资料", systemImage: "pencil")
+            HStack(spacing: TiebaPureTheme.Spacing.xxs) {
+                Image(systemName: "pencil")
+                    .foregroundStyle(TiebaPureTheme.ColorToken.primaryAccent)
+                Text("编辑资料")
+                    .foregroundStyle(.primary)
+            }
                 .font(.subheadline.weight(.semibold))
                 .frame(minWidth: 96, minHeight: 44)
                 .padding(.horizontal, TiebaPureTheme.Spacing.xxs)
         }
         .buttonStyle(.plain)
-        .foregroundStyle(TiebaPureTheme.ColorToken.primaryAccent)
         .background(
-            TiebaPureTheme.ColorToken.readerSecondarySurface,
+            TiebaPureTheme.ColorToken.primaryAccent.opacity(0.12),
             in: RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
         )
-        .overlay {
-            RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.card, style: .continuous)
-                .stroke(TiebaPureTheme.ColorToken.readerSeparator, lineWidth: 0.5)
-        }
         .accessibilityLabel("编辑个人资料")
         .accessibilityHint("修改昵称、简介和性别")
         .accessibilityIdentifier("user-profile-edit-button")
@@ -1363,6 +1401,8 @@ private struct UserProfileHeader: View {
             Text("Lv.\(level)")
                 .font(.caption.weight(.bold))
                 .foregroundStyle(.primary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 3)
                 .background(
@@ -1374,34 +1414,46 @@ private struct UserProfileHeader: View {
     }
 }
 
-private struct ProfileMetadataView: View {
-    let profile: UserProfile
+enum UserProfileMetadataGroup {
+    case identity
+    case details
+}
 
-    private var items: [String] {
+enum UserProfileMetadataText {
+    static func items(for profile: UserProfile, group: UserProfileMetadataGroup) -> [String] {
         var result: [String] = []
-        if profile.sex != .unspecified {
-            result.append(profile.sex.accessibilityText)
-        }
-        if profile.tiebaID.isEmpty == false {
-            result.append("ID \(profile.tiebaID)")
-        }
-        if profile.tiebaAge.isEmpty == false {
-            result.append("吧龄 \(profile.tiebaAge)")
-        }
-        if let location = ThreadPostMetadataText.normalizedLocation(profile.location) {
-            result.append("IP属地 \(location)")
+        switch group {
+        case .identity:
+            if profile.sex != .unspecified {
+                result.append(profile.sex.accessibilityText)
+            }
+            if profile.tiebaID.isEmpty == false {
+                result.append("ID \(profile.tiebaID)")
+            }
+        case .details:
+            if profile.tiebaAge.isEmpty == false {
+                result.append("吧龄 \(profile.tiebaAge)")
+            }
+            if let location = ThreadPostMetadataText.normalizedLocation(profile.location) {
+                result.append("IP属地 \(location)")
+            }
         }
         return result
     }
+}
+
+private struct ProfileMetadataView: View {
+    let items: [String]
+    let accessibilityIdentifier: String
 
     var body: some View {
         Text(items.joined(separator: "  ·  "))
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(items.joined(separator: "，"))
-        .accessibilityIdentifier("user-profile-metadata")
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(items.joined(separator: "，"))
+            .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 
@@ -1421,13 +1473,13 @@ private struct ProfileStat: View {
             Button(action: action) { content }
                 .buttonStyle(.plain)
                 .contentShape(Rectangle())
-                .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+                .frame(minWidth: 44, minHeight: 44, alignment: .leading)
                 .accessibilityLabel("\(label)\(value)")
                 .accessibilityHint("查看用户列表")
                 .accessibilityIdentifier("user-profile-\(identifierComponent)-stat")
         } else {
             content
-                .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+                .frame(minWidth: 44, minHeight: 44, alignment: .leading)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel("\(label)\(value)")
                 .accessibilityIdentifier("user-profile-\(identifierComponent)-stat")
@@ -1435,15 +1487,16 @@ private struct ProfileStat: View {
     }
 
     private var content: some View {
-        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
+        HStack(alignment: .firstTextBaseline, spacing: TiebaPureTheme.Spacing.xxs) {
             Text(UserProfileCountText.string(value))
-                .font(.title3.weight(.bold))
+                .font(.body.weight(.bold))
                 .monospacedDigit()
             Text(label)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
         }
-        .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+        .fixedSize(horizontal: true, vertical: false)
+        .frame(minWidth: 44, minHeight: 44, alignment: .leading)
         .contentShape(Rectangle())
     }
 
@@ -1466,7 +1519,7 @@ private struct UserProfileTabBar: View {
             tabButton(.threads, title: "帖子 \(threadCount)")
             tabButton(.followedForums, title: "关注的吧 \(followedForumCount)")
         }
-        .background(Color(uiColor: .systemBackground))
+        .background(TiebaPureTheme.ColorToken.readerSectionBand)
         .overlay(alignment: .bottom) { Divider() }
     }
 

--- a/TiebaPureTests/UserProfileTests.swift
+++ b/TiebaPureTests/UserProfileTests.swift
@@ -177,6 +177,71 @@ final class UserProfileTests: XCTestCase {
         XCTAssertEqual(UserProfileCountText.string(-1), "0")
     }
 
+    func testProfileThreadsUseFlatContentSections() {
+        XCTAssertEqual(ForumThreadRow.Presentation.userProfile.cardRadius, 0)
+        XCTAssertFalse(ForumThreadRow.Presentation.userProfile.showsDivider)
+    }
+
+    func testProfileMetadataOmitsEmptyGroupsWithoutReservedLayoutSpace() {
+        let profile = UserProfile(
+            user: UserSummary(id: 99, name: "other", displayName: "其他用户", portrait: "portrait"),
+            isCurrentUser: false,
+            isFollowed: false,
+            tiebaID: "",
+            tiebaAge: "",
+            sex: .unspecified,
+            location: "  ",
+            intro: "",
+            backgroundURL: nil,
+            agreeCount: 0,
+            followingCount: 0,
+            followerCount: 0,
+            threadCount: 0,
+            followedForumCount: 0,
+            followedForums: [],
+            followedForumsVisibility: .visible
+        )
+
+        XCTAssertTrue(UserProfileMetadataText.items(for: profile, group: .identity).isEmpty)
+        XCTAssertTrue(UserProfileMetadataText.items(for: profile, group: .details).isEmpty)
+    }
+
+    func testProfileMetadataKeepsIdentityAndDetailsInSeparateRows() {
+        var profile = UserProfile(
+            user: UserSummary(id: 99, name: "other", displayName: "其他用户", portrait: "portrait"),
+            isCurrentUser: false,
+            isFollowed: false,
+            tiebaID: "tieba-99",
+            tiebaAge: "10.5年",
+            sex: .female,
+            location: "广东",
+            intro: "",
+            backgroundURL: nil,
+            agreeCount: 0,
+            followingCount: 0,
+            followerCount: 0,
+            threadCount: 0,
+            followedForumCount: 0,
+            followedForums: [],
+            followedForumsVisibility: .visible
+        )
+
+        XCTAssertEqual(
+            UserProfileMetadataText.items(for: profile, group: .identity),
+            ["女", "ID tieba-99"]
+        )
+        XCTAssertEqual(
+            UserProfileMetadataText.items(for: profile, group: .details),
+            ["吧龄 10.5年", "IP属地 广东"]
+        )
+
+        profile.location = "IP属地：北京"
+        XCTAssertEqual(
+            UserProfileMetadataText.items(for: profile, group: .details),
+            ["吧龄 10.5年", "IP属地 北京"]
+        )
+    }
+
     func testFollowRequestUsesMinimalAuthenticatedFormShape() throws {
         let account = makeAccount()
         let user = UserSummary(

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -170,7 +170,24 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["user-profile-screen"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.staticTexts["合成内容作者"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.descendants(matching: .any)["user-profile-metadata"].waitForExistence(timeout: 8))
-        XCTAssertTrue(app.buttons["user-profile-follow-button"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["user-profile-secondary-metadata"].exists)
+        let avatar = app.descendants(matching: .any)["user-profile-avatar"]
+        XCTAssertTrue(avatar.exists)
+        XCTAssertEqual(avatar.frame.width, 56, accuracy: 1)
+        XCTAssertEqual(avatar.frame.height, 56, accuracy: 1)
+        let followButton = app.buttons["user-profile-follow-button"]
+        XCTAssertTrue(followButton.exists)
+        XCTAssertGreaterThanOrEqual(followButton.frame.width, 44)
+        XCTAssertGreaterThanOrEqual(followButton.frame.height, 44)
+
+        let agreeStat = app.descendants(matching: .any)["user-profile-agree-stat"]
+        let followingStat = app.buttons["user-profile-following-stat"]
+        let followersStat = app.buttons["user-profile-followers-stat"]
+        XCTAssertTrue(agreeStat.exists)
+        XCTAssertTrue(followingStat.exists)
+        XCTAssertTrue(followersStat.exists)
+        XCTAssertEqual(agreeStat.frame.midY, followingStat.frame.midY, accuracy: 1)
+        XCTAssertEqual(followingStat.frame.midY, followersStat.frame.midY, accuracy: 1)
         XCTAssertTrue(app.buttons["user-profile-posts-tab"].exists)
         XCTAssertTrue(app.buttons["user-profile-thread-row-1001"].waitForExistence(timeout: 8))
         attachScreenshot(named: "fixture-public-user-profile-posts")
@@ -180,6 +197,90 @@ final class TiebaPureUITests: XCTestCase {
         forumsTab.tap()
         XCTAssertTrue(app.buttons["user-profile-forum-row-0"].waitForExistence(timeout: 5))
         attachScreenshot(named: "fixture-public-user-profile")
+    }
+
+    func testPublicUserProfileHeaderFitsAtAccessibilityXXXL() {
+        let app = launchApp(additionalArguments: [
+            "-UIPreferredContentSizeCategoryName",
+            "UICTContentSizeCategoryAccessibilityXXXL"
+        ])
+        openFirstThread(in: app)
+
+        let userButton = app.buttons["thread-main-user-button"]
+        XCTAssertTrue(userButton.waitForExistence(timeout: 8))
+        userButton.tap()
+
+        XCTAssertTrue(app.descendants(matching: .any)["user-profile-screen"].waitForExistence(timeout: 8))
+        let avatar = app.descendants(matching: .any)["user-profile-avatar"]
+        let primaryMetadata = app.descendants(matching: .any)["user-profile-metadata"]
+        let secondaryMetadata = app.descendants(matching: .any)["user-profile-secondary-metadata"]
+        let followButton = app.buttons["user-profile-follow-button"]
+        let agreeStat = app.descendants(matching: .any)["user-profile-agree-stat"]
+        let followingStat = app.buttons["user-profile-following-stat"]
+        let followersStat = app.buttons["user-profile-followers-stat"]
+
+        for element in [
+            avatar,
+            primaryMetadata,
+            secondaryMetadata,
+            followButton,
+            agreeStat,
+            followingStat,
+            followersStat
+        ] {
+            XCTAssertTrue(element.waitForExistence(timeout: 8))
+            let horizontalBounds = app.frame.insetBy(dx: 8, dy: 0)
+            XCTAssertGreaterThanOrEqual(
+                element.frame.minX,
+                horizontalBounds.minX,
+                "\(element.identifier) 左侧不能超出屏幕：\(element.frame)"
+            )
+            XCTAssertLessThanOrEqual(
+                element.frame.maxX,
+                horizontalBounds.maxX,
+                "\(element.identifier) 右侧不能超出屏幕：\(element.frame)"
+            )
+        }
+
+        for element in [followButton, agreeStat, followingStat, followersStat] {
+            XCTAssertGreaterThanOrEqual(element.frame.width, 44)
+            XCTAssertGreaterThanOrEqual(element.frame.height, 44)
+        }
+        XCTAssertFalse(
+            avatar.frame.intersects(followButton.frame),
+            "头像和关注按钮不能重叠：\(avatar.frame)，\(followButton.frame)"
+        )
+        XCTAssertFalse(
+            agreeStat.frame.intersects(followingStat.frame),
+            "获赞和关注统计不能重叠：\(agreeStat.frame)，\(followingStat.frame)"
+        )
+        XCTAssertFalse(
+            followingStat.frame.intersects(followersStat.frame),
+            "关注和粉丝统计不能重叠：\(followingStat.frame)，\(followersStat.frame)"
+        )
+        attachScreenshot(named: "fixture-public-user-profile-axxxl")
+    }
+
+    func testLongNamePublicUserProfileFitsInDarkMode() {
+        let app = launchApp(
+            additionalArguments: ["-dev.infinityf4p.tiebapure.appearance", "dark"],
+            resetAppearance: false
+        )
+        let userButton = app.buttons["feed-user-button-2"]
+        XCTAssertTrue(userButton.waitForExistence(timeout: 8))
+        userButton.tap()
+
+        XCTAssertTrue(app.descendants(matching: .any)["user-profile-screen"].waitForExistence(timeout: 8))
+        let name = app.descendants(matching: .any)["user-profile-name"]
+        let followButton = app.buttons["user-profile-follow-button"]
+        XCTAssertTrue(name.waitForExistence(timeout: 8))
+        XCTAssertTrue(followButton.waitForExistence(timeout: 8))
+        XCTAssertTrue(name.label.contains("特别长的合成用户名"))
+        XCTAssertLessThanOrEqual(name.frame.maxX, followButton.frame.minX + 1)
+        XCTAssertGreaterThanOrEqual(followButton.frame.width, 44)
+        XCTAssertGreaterThanOrEqual(followButton.frame.height, 44)
+        XCTAssertLessThanOrEqual(followButton.frame.maxX, app.frame.maxX - 8)
+        attachScreenshot(named: "fixture-public-user-profile-dark-long-name")
     }
 
     func testPrivateUserProfileShowsExplicitPrivacyStates() {

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.3.9
-        CURRENT_PROJECT_VERSION: 28
+        MARKETING_VERSION: 1.4.0
+        CURRENT_PROJECT_VERSION: 29
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.3.9
-        CURRENT_PROJECT_VERSION: 28
+        MARKETING_VERSION: 1.4.0
+        CURRENT_PROJECT_VERSION: 29
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## Summary
- adopt the selected compact D profile layout with a 56 pt avatar and clearer information hierarchy
- use a light blue semantic surface for the follow action and flatten profile thread sections
- handle empty metadata, Dynamic Type, dark mode, and long names without overflow
- bump the app version to 1.4.0 (29)

## Validation
- full TiebaPureTests suite
- standard, Accessibility XXXL, dark mode, and long-name fixture UI checks
- profile follow, privacy, own-profile edit, and one-level back navigation UI regressions
- xcodebuild analyze
- XcodeGen consistency check
- unsigned Release IPA package audit