### PR TITLE
Improve iOS 18 scroll performance

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1243,13 +1243,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1260,14 +1260,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1313,14 +1313,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1333,13 +1333,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 @MainActor
 final class AppEnvironment: ObservableObject {
@@ -238,6 +239,17 @@ final class AppEnvironment: ObservableObject {
         let environment = ProcessInfo.processInfo.environment
         let scenario = FixtureScenario(rawValue: environment["TIEBAPURE_FIXTURE_SCENARIO"] ?? "success") ?? .success
         let delay = Int(environment["TIEBAPURE_FIXTURE_DELAY_MS"] ?? "0") ?? 0
+        if scenario == .scrollPerformance {
+            let artwork = UIGraphicsImageRenderer(size: CGSize(width: 48, height: 48)).image { context in
+                UIColor.systemGray5.setFill()
+                context.cgContext.fill(CGRect(x: 0, y: 0, width: 48, height: 48))
+                UIColor.systemGray.setFill()
+                context.cgContext.fillEllipse(in: CGRect(x: 8, y: 8, width: 32, height: 32))
+            }
+            if let data = artwork.pngData() {
+                _ = try? TiebaEmoticonCache.shared.store(data, for: "image_emoticon25")
+            }
+        }
         let accountData: Data?
         if environment["TIEBAPURE_FIXTURE_ACCOUNT"] == "loggedIn" {
             accountData = try? JSONEncoder().encode(FixtureTiebaAPI.account)

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -23,6 +23,7 @@ enum FixtureScenario: String {
     case forumCategories
     case forumCategoryRace
     case voicePlayback
+    case readingPosition
     case submissionFailure
     case submissionVerification
     case submissionUnknown
@@ -245,7 +246,9 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 .text(text),
                 .link(title: "百度贴吧 HTTPS 链接", url: URL(string: "https://tieba.baidu.com"))
             ]
-        if scenario != .textClipping, usesVoicePlayback == false {
+        if scenario != .textClipping,
+           scenario != .readingPosition,
+           usesVoicePlayback == false {
             mainBlocks.append(.image(longImage))
         }
         let fixtureMain = Post(
@@ -302,9 +305,15 @@ struct FixtureTiebaAPI: TiebaAPIService {
             likeCount: usesLargeLikeCount ? 123_456 : 3,
             previewSubposts: replySubposts
         )
-        let replies = scenario == .textClipping
-            ? Self.textClippingReplyFixtures(threadID: threadID, author: replyAuthor)
-            : [reply]
+        let replies: [Post]
+        switch scenario {
+        case .textClipping:
+            replies = Self.textClippingReplyFixtures(threadID: threadID, author: replyAuthor)
+        case .readingPosition:
+            replies = Self.readingPositionReplyFixtures(threadID: threadID, author: replyAuthor)
+        default:
+            replies = [reply]
+        }
         let submittedPosts = await state.submittedPosts(threadID: threadID)
         let posts = page == 1 ? [main] + replies + submittedPosts : []
         return ThreadPage(
@@ -946,6 +955,30 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 ipAddress: index.isMultiple(of: 2) ? "上海" : "广东",
                 createdAt: Date(timeIntervalSince1970: TimeInterval(1_700_000_200 + index * 60)),
                 blocks: blocks,
+                subpostCount: 0,
+                likeCount: index,
+                previewSubposts: []
+            )
+        }
+    }
+
+    static func readingPositionReplyFixtures(
+        threadID: Int64,
+        author: UserSummary
+    ) -> [Post] {
+        (0..<32).map { index in
+            Post(
+                id: UInt64(4_000 + index),
+                threadID: threadID,
+                floor: index + 2,
+                author: author,
+                ipAddress: index.isMultiple(of: 2) ? "上海" : "广东",
+                createdAt: Date(timeIntervalSince1970: TimeInterval(1_700_001_000 + index * 60)),
+                blocks: [
+                    .text(index.isMultiple(of: 3)
+                        ? String(repeating: "用于验证阅读位置保存与恢复的合成长回复。", count: 4)
+                        : "阅读位置回归回复第 \(index + 1) 条。")
+                ],
                 subpostCount: 0,
                 likeCount: index,
                 previewSubposts: []

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -24,6 +24,7 @@ enum FixtureScenario: String {
     case forumCategoryRace
     case voicePlayback
     case readingPosition
+    case scrollPerformance
     case submissionFailure
     case submissionVerification
     case submissionUnknown
@@ -230,7 +231,9 @@ struct FixtureTiebaAPI: TiebaAPIService {
         } else {
             text = "这是完全离线的合成帖子正文，内容不来自真实用户。"
         }
-        let imageFixtureHost = scenario == .imageGesture
+        let scrollVariant = ProcessInfo.processInfo.environment["TIEBAPURE_SCROLL_FIXTURE_VARIANT"]
+            ?? "mixed"
+        let imageFixtureHost = scenario == .imageGesture || scenario == .scrollPerformance
             ? "fixture-success.invalid"
             : "fixture.invalid"
         let longImage = ImageContent(
@@ -246,9 +249,22 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 .text(text),
                 .link(title: "百度贴吧 HTTPS 链接", url: URL(string: "https://tieba.baidu.com"))
             ]
+        if scenario == .scrollPerformance {
+            switch scrollVariant {
+            case "text":
+                mainBlocks = [.text(text)]
+            case "emoticons":
+                mainBlocks = [.text(text), .emoticon(code: "滑稽")]
+            case "images":
+                mainBlocks = [.text(text), .image(longImage)]
+            default:
+                mainBlocks.append(.emoticon(code: "滑稽"))
+            }
+        }
         if scenario != .textClipping,
            scenario != .readingPosition,
-           usesVoicePlayback == false {
+           usesVoicePlayback == false,
+           scenario != .scrollPerformance || ["mixed", "production"].contains(scrollVariant) {
             mainBlocks.append(.image(longImage))
         }
         let fixtureMain = Post(
@@ -311,6 +327,8 @@ struct FixtureTiebaAPI: TiebaAPIService {
             replies = Self.textClippingReplyFixtures(threadID: threadID, author: replyAuthor)
         case .readingPosition:
             replies = Self.readingPositionReplyFixtures(threadID: threadID, author: replyAuthor)
+        case .scrollPerformance:
+            replies = Self.scrollPerformanceReplyFixtures(threadID: threadID, author: replyAuthor)
         default:
             replies = [reply]
         }
@@ -982,6 +1000,71 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 subpostCount: 0,
                 likeCount: index,
                 previewSubposts: []
+            )
+        }
+    }
+
+    static func scrollPerformanceReplyFixtures(
+        threadID: Int64,
+        author: UserSummary
+    ) -> [Post] {
+        let variant = ProcessInfo.processInfo.environment["TIEBAPURE_SCROLL_FIXTURE_VARIANT"]
+            ?? "mixed"
+        let includesEmoticons = variant == "mixed" || variant == "emoticons" || variant == "production"
+        let includesImages = variant == "mixed" || variant == "images" || variant == "production"
+        let includesSubposts = variant == "production"
+        return (0..<40).map { index in
+            var blocks: [ContentBlock] = includesEmoticons && index.isMultiple(of: 3)
+                ? [
+                    .emoticon(code: "滑稽"),
+                    .text(" 混合内容滚动回复第 \(index + 1) 条，表情只应刷新当前使用它的行。")
+                ]
+                : [
+                    .text(index.isMultiple(of: 2)
+                        ? String(repeating: "混合内容滚动性能回归长回复。", count: 4)
+                        : "混合内容滚动回复第 \(index + 1) 条。")
+                ]
+            if includesImages, index.isMultiple(of: 4) {
+                let imageCount = index.isMultiple(of: 8) ? 3 : 1
+                for imageIndex in 0..<imageCount {
+                    let identity = "scroll-\(index)-\(imageIndex)"
+                    blocks.append(.image(ImageContent(
+                        thumbnailURL: URL(string: "https://fixture-success.invalid/\(identity)-thumbnail.png"),
+                        originalURL: URL(string: "https://fixture-success.invalid/\(identity)-original.png"),
+                        width: 640,
+                        height: imageIndex == 0 ? 480 : 640,
+                        showOriginalButton: false
+                    )))
+                }
+            }
+            let previewSubposts: [Subpost] = includesSubposts && index.isMultiple(of: 2)
+                ? (0..<3).map { subpostIndex in
+                    Subpost(
+                        id: UInt64(50_000 + index * 10 + subpostIndex),
+                        floor: subpostIndex + 1,
+                        author: author,
+                        ipAddress: subpostIndex.isMultiple(of: 2) ? "广东" : "浙江",
+                        blocks: [
+                            .text("楼中楼摘要第 \(subpostIndex + 1) 条 "),
+                            .emoticon(code: "滑稽"),
+                            .text("，用于验证真实复杂回复的滚动性能。")
+                        ],
+                        createdAt: Date(timeIntervalSince1970: TimeInterval(1_700_003_000 + index * 60)),
+                        likeCount: subpostIndex
+                    )
+                }
+                : []
+            return Post(
+                id: UInt64(5_000 + index),
+                threadID: threadID,
+                floor: index + 2,
+                author: author,
+                ipAddress: index.isMultiple(of: 2) ? "上海" : "广东",
+                createdAt: Date(timeIntervalSince1970: TimeInterval(1_700_002_000 + index * 60)),
+                blocks: blocks,
+                subpostCount: previewSubposts.count,
+                likeCount: index * 173,
+                previewSubposts: previewSubposts
             )
         }
     }

--- a/TiebaPure/Core/UI/AvatarView.swift
+++ b/TiebaPure/Core/UI/AvatarView.swift
@@ -77,6 +77,12 @@ enum TiebaImageDecodePolicy {
     static let maximumSourceDimension = 32_768
     static let maximumSourcePixels = 100_000_000
     static let maximumDecodedPixelSize = 4_096
+    static let maximumPreviewDecodedPixelSize = 2_560
+    static let maximumPreviewDisplayScale: CGFloat = 3
+    private static let previewDecodeBuckets = [
+        128, 256, 384, 512, 640, 768, 1_024, 1_280,
+        1_536, 1_792, 2_048, 2_304, 2_560
+    ]
 
     static func allows(width: Int, height: Int) -> Bool {
         guard width > 0, height > 0,
@@ -93,6 +99,23 @@ enum TiebaImageDecodePolicy {
     static func decodeTargetPixelSize(_ requested: Int) -> Int {
         guard requested > 0 else { return maximumDecodedPixelSize }
         return min(requested, maximumDecodedPixelSize)
+    }
+
+    static func previewTargetPixelSize(
+        for pointSize: CGSize,
+        displayScale: CGFloat
+    ) -> Int {
+        let longestPointEdge = max(pointSize.width, pointSize.height)
+        guard longestPointEdge.isFinite,
+              longestPointEdge > 0,
+              displayScale.isFinite,
+              displayScale > 0 else {
+            return 512
+        }
+        let previewScale = min(displayScale, maximumPreviewDisplayScale)
+        let requiredPixels = Int(ceil(longestPointEdge * previewScale))
+        return previewDecodeBuckets.first(where: { $0 >= requiredPixels })
+            ?? maximumPreviewDecodedPixelSize
     }
 }
 
@@ -117,14 +140,35 @@ actor TiebaImagePipeline {
         }
     }
 
+    private struct InFlightRequest {
+        let operationID: UUID
+        let task: Task<Void, Never>
+        var waiters: [UUID: CheckedContinuation<UIImage, Error>]
+    }
+
+    private final class WaiterLease: @unchecked Sendable {
+        let id = UUID()
+
+        private let lock = NSLock()
+        private var cancelled = false
+
+        func markCancelled() {
+            lock.withLock { cancelled = true }
+        }
+
+        var isCancelled: Bool {
+            lock.withLock { cancelled }
+        }
+    }
+
     private let memoryCache = NSCache<NSString, UIImage>()
     private let urlCache: URLCache
     private let session: URLSession
-    private var inFlight: [DecodeRequest: Task<UIImage, Error>] = [:]
+    private var inFlight: [DecodeRequest: InFlightRequest] = [:]
 
-    init() {
-        let configuration = URLSessionConfiguration.default
-        let urlCache = URLCache(
+    init(configuration suppliedConfiguration: URLSessionConfiguration? = nil) {
+        let configuration = suppliedConfiguration ?? .default
+        let urlCache = suppliedConfiguration?.urlCache ?? URLCache(
             memoryCapacity: 64 * 1_024 * 1_024,
             diskCapacity: 256 * 1_024 * 1_024,
             diskPath: "TiebaPureImages"
@@ -143,8 +187,14 @@ actor TiebaImagePipeline {
     }
 
     func clearCaches() {
-        inFlight.values.forEach { $0.cancel() }
+        let pendingRequests = Array(inFlight.values)
         inFlight.removeAll()
+        for request in pendingRequests {
+            request.task.cancel()
+            request.waiters.values.forEach {
+                $0.resume(throwing: CancellationError())
+            }
+        }
         memoryCache.removeAllObjects()
         urlCache.removeAllCachedResponses()
     }
@@ -240,34 +290,110 @@ actor TiebaImagePipeline {
             memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
             return image
         }
-        if let task = inFlight[request] {
-            let image = try await task.value
+        return try await waitForSharedImage(request)
+    }
+
+    private func waitForSharedImage(_ request: DecodeRequest) async throws -> UIImage {
+        let lease = WaiterLease()
+        return try await withTaskCancellationHandler {
+            let image = try await withCheckedThrowingContinuation { continuation in
+                registerWaiter(
+                    continuation,
+                    lease: lease,
+                    for: request
+                )
+            }
             try Task.checkCancellation()
-            await onProgress?(BoundedURLSessionProgress(receivedBytes: 1, expectedBytes: 1))
             return image
-        }
-
-        let session = session
-        let task = Task<UIImage, Error> {
-            try await Self.download(
-                request: request,
-                session: session,
-                onProgress: nil
-            )
-        }
-        inFlight[request] = task
-
-        do {
-            let image = try await task.value
-            let cost = Int(image.size.width * image.size.height * image.scale * image.scale * 4)
-            memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
-            inFlight[request] = nil
-            return image
-        } catch {
-            inFlight[request] = nil
-            throw error
+        } onCancel: {
+            lease.markCancelled()
+            Task {
+                await self.cancelWaiter(lease, for: request)
+            }
         }
     }
+
+    private func registerWaiter(
+        _ continuation: CheckedContinuation<UIImage, Error>,
+        lease: WaiterLease,
+        for request: DecodeRequest
+    ) {
+        guard lease.isCancelled == false else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        if var requestState = inFlight[request] {
+            requestState.waiters[lease.id] = continuation
+            inFlight[request] = requestState
+            return
+        }
+
+        let operationID = UUID()
+        let session = session
+        let task = Task {
+            let result: Result<UIImage, Error>
+            do {
+                result = .success(try await Self.download(
+                    request: request,
+                    session: session,
+                    onProgress: nil
+                ))
+            } catch {
+                result = .failure(error)
+            }
+            await self.completeSharedRequest(
+                request,
+                operationID: operationID,
+                result: result
+            )
+        }
+        inFlight[request] = InFlightRequest(
+            operationID: operationID,
+            task: task,
+            waiters: [lease.id: continuation]
+        )
+    }
+
+    private func cancelWaiter(_ lease: WaiterLease, for request: DecodeRequest) {
+        guard var requestState = inFlight[request],
+              let continuation = requestState.waiters.removeValue(forKey: lease.id) else {
+            return
+        }
+        continuation.resume(throwing: CancellationError())
+        guard requestState.waiters.isEmpty else {
+            inFlight[request] = requestState
+            return
+        }
+        inFlight[request] = nil
+        requestState.task.cancel()
+    }
+
+    private func completeSharedRequest(
+        _ request: DecodeRequest,
+        operationID: UUID,
+        result: Result<UIImage, Error>
+    ) {
+        guard let requestState = inFlight[request],
+              requestState.operationID == operationID else {
+            return
+        }
+        inFlight[request] = nil
+
+        switch result {
+        case let .success(image):
+            let cost = Int(image.size.width * image.size.height * image.scale * image.scale * 4)
+            memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
+            requestState.waiters.values.forEach { $0.resume(returning: image) }
+        case let .failure(error):
+            requestState.waiters.values.forEach { $0.resume(throwing: error) }
+        }
+    }
+
+#if DEBUG
+    func inFlightWaiterCountForTesting() -> Int {
+        inFlight.values.reduce(0) { $0 + $1.waiters.count }
+    }
+#endif
 
     private static func download(
         request: DecodeRequest,
@@ -393,16 +519,27 @@ private final class TiebaRemoteImageModel: ObservableObject {
 
     @Published private(set) var phase: Phase = .empty
     private var sourceKey = ""
-    private var task: Task<Void, Never>?
+    private var loadID: UUID?
+    private var task: Task<UIImage, Error>?
 
     deinit {
         task?.cancel()
     }
 
-    func load(urls: [URL], force: Bool = false) {
-        let key = urls.map(\.absoluteString).joined(separator: "|")
+    func load(
+        urls: [URL],
+        targetPixelSize: Int,
+        force: Bool = false
+    ) async {
+        let key = Self.sourceKey(urls: urls, targetPixelSize: targetPixelSize)
         let sourceChanged = key != sourceKey
-        guard force || sourceChanged || isEmpty || isFailed else { return }
+        let resumesInterruptedLoad: Bool
+        if case .loading = phase {
+            resumesInterruptedLoad = task == nil
+        } else {
+            resumesInterruptedLoad = false
+        }
+        guard force || sourceChanged || isEmpty || isFailed || resumesInterruptedLoad else { return }
         sourceKey = key
         task?.cancel()
 
@@ -413,35 +550,76 @@ private final class TiebaRemoteImageModel: ObservableObject {
 
         phase = .loading
         let requestKey = key
-        task = Task {
-            do {
-                let image = try await TiebaImagePipeline.shared.image(from: urls)
-                guard Task.isCancelled == false, sourceKey == requestKey else { return }
-                phase = .success(image)
-            } catch is CancellationError {
-                return
-            } catch {
-                guard Task.isCancelled == false, sourceKey == requestKey else { return }
-                phase = .failure
+        let requestID = UUID()
+        loadID = requestID
+        let loadTask = Task {
+            try await TiebaImagePipeline.shared.image(
+                from: urls,
+                targetPixelSize: targetPixelSize
+            )
+        }
+        task = loadTask
+
+        do {
+            let image = try await withTaskCancellationHandler {
+                try await loadTask.value
+            } onCancel: {
+                loadTask.cancel()
             }
+            guard Task.isCancelled == false,
+                  sourceKey == requestKey,
+                  loadID == requestID else { return }
+            task = nil
+            loadID = nil
+            phase = .success(image)
+        } catch is CancellationError {
+            guard sourceKey == requestKey, loadID == requestID else { return }
+            task = nil
+            loadID = nil
+            phase = .empty
+        } catch {
+            guard Task.isCancelled == false,
+                  sourceKey == requestKey,
+                  loadID == requestID else { return }
+            task = nil
+            loadID = nil
+            phase = .failure
         }
     }
 
-    func suspendAutomaticLoad(urls: [URL]) {
-        let key = urls.map(\.absoluteString).joined(separator: "|")
+    func suspendAutomaticLoad(urls: [URL], targetPixelSize: Int) {
+        let key = Self.sourceKey(urls: urls, targetPixelSize: targetPixelSize)
         if sourceKey != key {
             task?.cancel()
+            task = nil
+            loadID = nil
             sourceKey = key
             phase = .empty
             return
         }
         guard case .loading = phase else { return }
         task?.cancel()
+        task = nil
+        loadID = nil
         phase = .empty
     }
 
-    func represents(urls: [URL]) -> Bool {
-        sourceKey == urls.map(\.absoluteString).joined(separator: "|")
+    func cancelActiveLoad(publishesPhaseChange: Bool = true) {
+        task?.cancel()
+        task = nil
+        loadID = nil
+        if publishesPhaseChange, case .loading = phase {
+            phase = .empty
+        }
+    }
+
+    func represents(urls: [URL], targetPixelSize: Int) -> Bool {
+        sourceKey == Self.sourceKey(urls: urls, targetPixelSize: targetPixelSize)
+    }
+
+    private static func sourceKey(urls: [URL], targetPixelSize: Int) -> String {
+        "\(TiebaImageDecodePolicy.decodeTargetPixelSize(targetPixelSize))|"
+            + urls.map(\.absoluteString).joined(separator: "|")
     }
 
     private var isFailed: Bool {
@@ -477,6 +655,7 @@ enum TiebaRemoteImageLoadState: Equatable, Sendable {
 
 struct TiebaRemoteImage: View {
     let urls: [URL]
+    var targetPixelSize: Int
     var contentMode: ContentMode = .fill
     var showsProgress = false
     var retryTrigger = 0
@@ -493,6 +672,7 @@ struct TiebaRemoteImage: View {
     init(
         primaryURL: URL?,
         fallbackURL: URL? = nil,
+        targetPixelSize: Int = TiebaImageDecodePolicy.maximumPreviewDecodedPixelSize,
         contentMode: ContentMode = .fill,
         showsProgress: Bool = false,
         retryTrigger: Int = 0,
@@ -505,6 +685,7 @@ struct TiebaRemoteImage: View {
         onDebugImageObserverResolved: ((UIView, UIImage) -> Void)? = nil
     ) {
         urls = TiebaImageSourcePolicy.urls(primary: primaryURL, fallback: fallbackURL)
+        self.targetPixelSize = TiebaImageDecodePolicy.decodeTargetPixelSize(targetPixelSize)
         self.contentMode = contentMode
         self.showsProgress = showsProgress
         self.retryTrigger = retryTrigger
@@ -521,7 +702,7 @@ struct TiebaRemoteImage: View {
         Group {
             switch model.phase {
             case let .success(image):
-                if model.represents(urls: urls) {
+                if model.represents(urls: urls, targetPixelSize: targetPixelSize) {
                     if showsResolvedImage {
                         Image(uiImage: image)
                             .resizable()
@@ -565,7 +746,13 @@ struct TiebaRemoteImage: View {
             case .failure:
                 if showsRetryButton {
                     Button {
-                        model.load(urls: urls, force: true)
+                        Task {
+                            await model.load(
+                                urls: urls,
+                                targetPixelSize: targetPixelSize,
+                                force: true
+                            )
+                        }
                     } label: {
                         retryLabel
                     }
@@ -578,16 +765,26 @@ struct TiebaRemoteImage: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task(id: "\(urls.map(\.absoluteString).joined(separator: "|"))#\(retryTrigger)#\(loadsAutomatically)") {
+        .task(id: "\(targetPixelSize)#\(urls.map(\.absoluteString).joined(separator: "|"))#\(retryTrigger)#\(loadsAutomatically)") {
             guard loadsAutomatically else {
-                model.suspendAutomaticLoad(urls: urls)
+                model.suspendAutomaticLoad(urls: urls, targetPixelSize: targetPixelSize)
                 return
             }
-            model.load(urls: urls, force: retryTrigger > 0)
+            await model.load(
+                urls: urls,
+                targetPixelSize: targetPixelSize,
+                force: retryTrigger > 0
+            )
+        }
+        .onDisappear {
+            // A recycled row only needs to release its network lease. Keeping
+            // the loading phase avoids a redundant ObservableObject publish
+            // and transition-anchor invalidation while the scroll is moving.
+            model.cancelActiveLoad(publishesPhaseChange: false)
         }
         .onReceive(model.$phase) { phase in
             guard case let .success(image) = phase,
-                  model.represents(urls: urls) else {
+                  model.represents(urls: urls, targetPixelSize: targetPixelSize) else {
                 return
             }
             onImageResolved?(image)
@@ -775,6 +972,8 @@ private struct TiebaResolvedImageFrameReader: UIViewRepresentable {
 }
 
 struct AvatarView: View {
+    @Environment(\.displayScale) private var displayScale
+
     let url: URL?
     let title: String?
     let size: CGFloat
@@ -793,8 +992,12 @@ struct AvatarView: View {
             if let url {
                 TiebaRemoteImage(
                     primaryURL: url,
+                    targetPixelSize: TiebaImageDecodePolicy.previewTargetPixelSize(
+                        for: CGSize(width: size, height: size),
+                        displayScale: displayScale
+                    ),
                     contentMode: .fill,
-                    showsProgress: true,
+                    showsProgress: false,
                     showsRetryButton: false
                 )
             } else {

--- a/TiebaPure/Core/UI/AvatarView.swift
+++ b/TiebaPure/Core/UI/AvatarView.swift
@@ -192,6 +192,14 @@ actor TiebaImagePipeline {
         guard TiebaImageSourcePolicy.isSyntheticFailureURL(url) == false else {
             throw TiebaImagePipelineError.invalidImageData
         }
+        let request = DecodeRequest(
+            url: safeURL,
+            targetPixelSize: TiebaImageDecodePolicy.decodeTargetPixelSize(targetPixelSize)
+        )
+        if let cached = memoryCache.object(forKey: request.cacheKey) {
+            await onProgress?(BoundedURLSessionProgress(receivedBytes: 1, expectedBytes: 1))
+            return cached
+        }
 #if DEBUG
         if TiebaImageSourcePolicy.isSyntheticSuccessURL(url) {
             await onProgress?(BoundedURLSessionProgress(
@@ -215,17 +223,12 @@ actor TiebaImagePipeline {
                     expectedBytes: TiebaImageSourcePolicy.syntheticOriginalByteCount
                 ))
             }
-            return Self.syntheticFixtureImage(for: url)
+            let image = Self.syntheticFixtureImage(for: url)
+            let cost = Int(image.size.width * image.size.height * image.scale * image.scale * 4)
+            memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
+            return image
         }
 #endif
-        let request = DecodeRequest(
-            url: safeURL,
-            targetPixelSize: TiebaImageDecodePolicy.decodeTargetPixelSize(targetPixelSize)
-        )
-        if let cached = memoryCache.object(forKey: request.cacheKey) {
-            await onProgress?(BoundedURLSessionProgress(receivedBytes: 1, expectedBytes: 1))
-            return cached
-        }
         if let onProgress {
             let image = try await Self.download(
                 request: request,

--- a/TiebaPure/Core/UI/MediaGridView.swift
+++ b/TiebaPure/Core/UI/MediaGridView.swift
@@ -232,7 +232,10 @@ private struct MediaItemButton: View {
                 showsManualLoadIndicator: true,
                 previewSource: previewSource,
                 onTransitionTap: activate,
-                onLoadStateChange: { loadState = $0 },
+                onLoadStateChange: { state in
+                    guard loadState != state else { return }
+                    loadState = state
+                },
                 onImageResolved: {
                     previewSource.store(
                         image: $0,
@@ -419,10 +422,12 @@ private struct MediaThumbnailView: View {
                     showsRetryButton: false,
                     showsResolvedImage: previewSource == nil,
                     loadsAutomatically: isManualLoadAuthorized,
-                    onLoadStateChange: {
-                        internalLoadState = $0
-                        onLoadStateChange($0)
-                        if $0 != .success {
+                    onLoadStateChange: { state in
+                        if internalLoadState != state {
+                            internalLoadState = state
+                        }
+                        onLoadStateChange(state)
+                        if state == .failure {
                             previewSource?.clearImage(
                                 sourceIdentity: item.previewSourceIdentity
                             )

--- a/TiebaPure/Core/UI/MediaGridView.swift
+++ b/TiebaPure/Core/UI/MediaGridView.swift
@@ -373,6 +373,7 @@ private struct MediaItemButton: View {
 
 private struct MediaThumbnailView: View {
     @Environment(\.readingPreferences) private var readingPreferences
+    @Environment(\.displayScale) private var displayScale
 
     let item: ReaderMediaItem
     let maxHeight: CGFloat?
@@ -414,28 +415,34 @@ private struct MediaThumbnailView: View {
                 .fill(TiebaPureTheme.ColorToken.readerTertiarySurface)
 
             if item.thumbnailURL != nil {
-                TiebaRemoteImage(
-                    primaryURL: requestSources.primaryURL,
-                    fallbackURL: requestSources.fallbackURL,
-                    contentMode: .fill,
-                    retryTrigger: retryTrigger,
-                    showsRetryButton: false,
-                    showsResolvedImage: previewSource == nil,
-                    loadsAutomatically: isManualLoadAuthorized,
-                    onLoadStateChange: { state in
-                        if internalLoadState != state {
-                            internalLoadState = state
-                        }
-                        onLoadStateChange(state)
-                        if state == .failure {
-                            previewSource?.clearImage(
-                                sourceIdentity: item.previewSourceIdentity
-                            )
-                        }
-                    },
-                    onImageResolved: onImageResolved,
-                    onDebugImageObserverResolved: onDebugImageObserverResolved
-                )
+                GeometryReader { proxy in
+                    TiebaRemoteImage(
+                        primaryURL: requestSources.primaryURL,
+                        fallbackURL: requestSources.fallbackURL,
+                        targetPixelSize: TiebaImageDecodePolicy.previewTargetPixelSize(
+                            for: proxy.size,
+                            displayScale: displayScale
+                        ),
+                        contentMode: .fill,
+                        retryTrigger: retryTrigger,
+                        showsRetryButton: false,
+                        showsResolvedImage: previewSource == nil,
+                        loadsAutomatically: isManualLoadAuthorized,
+                        onLoadStateChange: { state in
+                            if internalLoadState != state {
+                                internalLoadState = state
+                            }
+                            onLoadStateChange(state)
+                            if state == .failure {
+                                previewSource?.clearImage(
+                                    sourceIdentity: item.previewSourceIdentity
+                                )
+                            }
+                        },
+                        onImageResolved: onImageResolved,
+                        onDebugImageObserverResolved: onDebugImageObserverResolved
+                    )
+                }
 
                 if let previewSource {
                     ImagePreviewSourceAnchorReader(

--- a/TiebaPure/Core/UI/ShortPullRefresh.swift
+++ b/TiebaPure/Core/UI/ShortPullRefresh.swift
@@ -267,7 +267,180 @@ extension View {
         )
     }
 
+    @ViewBuilder
+    func scrollFrameProbeForUITests() -> some View {
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("UITEST_SCROLL_FRAME_PROBE") {
+            modifier(ScrollFrameProbeModifier())
+        } else {
+            self
+        }
+        #else
+        self
+        #endif
+    }
+
 }
+
+#if DEBUG
+private struct ScrollFrameProbeSample: Codable, Sendable {
+    var frameIntervals: [TimeInterval]
+    var expectedFrameIntervals: [TimeInterval]
+    var intervalRatios: [Double]
+    var activeFrameCount: Int
+    var maximumFramesPerSecond: Int
+}
+
+private actor ScrollFrameProbeWriter {
+    private var latestRevision = 0
+
+    func write(
+        samples: [ScrollFrameProbeSample],
+        revision: Int,
+        to outputURL: URL
+    ) {
+        guard revision > latestRevision else { return }
+        latestRevision = revision
+        guard let data = try? JSONEncoder().encode(samples) else { return }
+        try? data.write(to: outputURL, options: .atomic)
+    }
+}
+
+@MainActor
+private final class ScrollFrameProbe: NSObject {
+    static let shared = ScrollFrameProbe()
+
+    private var displayLink: CADisplayLink?
+    private var previousTimestamp: CFTimeInterval?
+    private var previousExpectedInterval: CFTimeInterval?
+    private var intervals: [TimeInterval] = []
+    private var expectedIntervals: [TimeInterval] = []
+    private var intervalRatios: [Double] = []
+    private var activeFrameCount: Int?
+    private var samples: [ScrollFrameProbeSample] = []
+    private let writer = ScrollFrameProbeWriter()
+    private var writeRevision = 0
+    private var delayedFinishTask: Task<Void, Never>?
+
+    private var outputURL: URL {
+        let variant = ProcessInfo.processInfo.environment["TIEBAPURE_SCROLL_FIXTURE_VARIANT"]
+            ?? "mixed"
+        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("TiebaPureScrollFrameProbe-\(variant).json")
+    }
+
+    override private init() {
+        super.init()
+        try? FileManager.default.removeItem(at: outputURL)
+    }
+
+    func begin() {
+        delayedFinishTask?.cancel()
+        delayedFinishTask = nil
+        finish(writeEmptySample: displayLink != nil)
+        intervals = []
+        expectedIntervals = []
+        intervalRatios = []
+        intervals.reserveCapacity(240)
+        expectedIntervals.reserveCapacity(240)
+        intervalRatios.reserveCapacity(240)
+        activeFrameCount = nil
+        previousTimestamp = nil
+        previousExpectedInterval = nil
+        let link = CADisplayLink(target: self, selector: #selector(handleFrame(_:)))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    func finish() {
+        delayedFinishTask?.cancel()
+        delayedFinishTask = nil
+        finish(writeEmptySample: true)
+    }
+
+    func finishAfterIdle() {
+        delayedFinishTask?.cancel()
+        activeFrameCount = intervals.count
+        delayedFinishTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .milliseconds(650))
+            } catch {
+                return
+            }
+            finish()
+        }
+    }
+
+    private func finish(writeEmptySample: Bool) {
+        displayLink?.invalidate()
+        displayLink = nil
+        previousTimestamp = nil
+        previousExpectedInterval = nil
+        guard writeEmptySample, intervals.isEmpty == false else { return }
+
+        samples.append(
+            ScrollFrameProbeSample(
+                frameIntervals: intervals,
+                expectedFrameIntervals: expectedIntervals,
+                intervalRatios: intervalRatios,
+                activeFrameCount: min(activeFrameCount ?? intervals.count, intervals.count),
+                maximumFramesPerSecond: UIScreen.main.maximumFramesPerSecond
+            )
+        )
+        intervals = []
+        expectedIntervals = []
+        intervalRatios = []
+        activeFrameCount = nil
+        writeRevision += 1
+        let revision = writeRevision
+        let snapshot = samples
+        let outputURL = outputURL
+        Task {
+            await writer.write(
+                samples: snapshot,
+                revision: revision,
+                to: outputURL
+            )
+        }
+    }
+
+    @objc private func handleFrame(_ displayLink: CADisplayLink) {
+        let fallbackInterval = 1.0 / Double(max(UIScreen.main.maximumFramesPerSecond, 1))
+        let targetInterval = displayLink.targetTimestamp - displayLink.timestamp
+        let currentExpectedInterval = targetInterval.isFinite && targetInterval > 0
+            ? targetInterval
+            : fallbackInterval
+        if let previousTimestamp, let previousExpectedInterval {
+            let interval = displayLink.timestamp - previousTimestamp
+            // ProMotion may legitimately move between 120/80/60 Hz. The
+            // slower of the adjacent target periods is the budget for this
+            // transition; a fixed 1/120s denominator reports those changes as
+            // false dropped frames on iOS 26 simulators.
+            let expectedInterval = max(previousExpectedInterval, currentExpectedInterval)
+            intervals.append(interval)
+            expectedIntervals.append(expectedInterval)
+            intervalRatios.append(interval / expectedInterval)
+        }
+        previousTimestamp = displayLink.timestamp
+        previousExpectedInterval = currentExpectedInterval
+    }
+}
+
+private struct ScrollFrameProbeModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.onScrollPhaseChange { oldPhase, newPhase in
+            let wasDirect = oldPhase == .tracking || oldPhase == .interacting
+            let isDirect = newPhase == .tracking || newPhase == .interacting
+            if isDirect, wasDirect == false {
+                ScrollFrameProbe.shared.begin()
+            }
+            if newPhase == .idle, oldPhase != .idle {
+                ScrollFrameProbe.shared.finishAfterIdle()
+            }
+        }
+    }
+}
+#endif
 
 private struct ShortPullRefreshModifier: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion

--- a/TiebaPure/Core/UI/ShortPullRefresh.swift
+++ b/TiebaPure/Core/UI/ShortPullRefresh.swift
@@ -164,6 +164,8 @@ enum ShortPullRefreshSurface: Equatable, Sendable {
 /// Small equatable projection keeps `onScrollGeometryChange` updates limited to
 /// the values that actually affect pull-to-refresh.
 struct ShortPullRefreshGeometry: Equatable {
+    static let awayFromTopDistance = ShortPullRefreshPolicy.topTolerance + 1
+
     var distanceFromTop: CGFloat
     var pullDistance: CGFloat
     var fingerEquivalentPullDistance: CGFloat
@@ -189,14 +191,19 @@ struct ShortPullRefreshGeometry: Equatable {
         topInset: CGFloat,
         viewportLength: CGFloat? = nil
     ) {
-        distanceFromTop = ShortPullRefreshPolicy.distanceFromTop(
+        let signedDistance = ShortPullRefreshPolicy.signedDistanceFromTop(
             contentOffsetY: contentOffsetY,
             topInset: topInset
         )
-        pullDistance = ShortPullRefreshPolicy.pullDistance(
-            contentOffsetY: contentOffsetY,
-            topInset: topInset
-        )
+        if signedDistance > ShortPullRefreshPolicy.topTolerance {
+            distanceFromTop = Self.awayFromTopDistance
+            pullDistance = 0
+            fingerEquivalentPullDistance = 0
+            return
+        }
+
+        distanceFromTop = max(signedDistance, 0)
+        pullDistance = max(-signedDistance, 0)
         if let viewportLength {
             fingerEquivalentPullDistance = ShortPullRefreshPolicy.fingerEquivalentPullDistance(
                 overscrollDistance: pullDistance,
@@ -260,17 +267,6 @@ extension View {
         )
     }
 
-    @ViewBuilder
-    func trackVerticalScrollDistanceFromTop(_ distance: Binding<CGFloat>) -> some View {
-        onScrollGeometryChange(for: CGFloat.self) { geometry in
-            ShortPullRefreshPolicy.distanceFromTop(
-                contentOffsetY: geometry.contentOffset.y,
-                topInset: geometry.contentInsets.top
-            )
-        } action: { _, newDistance in
-            distance.wrappedValue = newDistance
-        }
-    }
 }
 
 private struct ShortPullRefreshModifier: ViewModifier {
@@ -291,7 +287,6 @@ private struct ShortPullRefreshModifier: ViewModifier {
     @State private var activeRefreshSource: ShortPullRefreshSource?
     @State private var refreshTask: Task<Void, Never>?
     @State private var verticalPanIntent: Bool?
-    @State private var panTranslation: CGSize = .zero
 
     func body(content: Content) -> some View {
         content
@@ -402,14 +397,13 @@ private struct ShortPullRefreshModifier: ViewModifier {
             return
         }
 
-        // Once UIKit has resolved the pan as vertical, its translation is the
-        // authoritative finger distance. Unlike rubber-band geometry, it
-        // remains stable through the release frame and also decreases when
-        // the user deliberately pushes back above the 80-point threshold.
-        let pullDistance = verticalPanIntent == true
-            ? max(panTranslation.height, 0)
-            : newGeometry.fingerEquivalentPullDistance
-        updateArmedState(pullDistance: pullDistance)
+        // Once UIKit resolves this as a vertical pull, the recognizer callback
+        // owns progress updates. Geometry still tracks rubber-band displacement
+        // for the held refresh offset, but must not cause a second state write.
+        guard verticalPanIntent != true else { return }
+        updateArmedState(
+            pullDistance: newGeometry.fingerEquivalentPullDistance
+        )
     }
 
     private func handlePhaseChange(
@@ -471,7 +465,6 @@ private struct ShortPullRefreshModifier: ViewModifier {
         gestureStartedAtTop = false
         pullProgress = 0
         didReachThreshold = false
-        panTranslation = .zero
     }
 
     private func handlePanChange(
@@ -481,20 +474,18 @@ private struct ShortPullRefreshModifier: ViewModifier {
         switch state {
         case .began:
             verticalPanIntent = nil
-            panTranslation = .zero
         case .changed, .ended:
-            panTranslation = translation
             if verticalPanIntent == nil {
                 verticalPanIntent = ShortPullRefreshPolicy.verticalPullIntent(
                     translation: translation
                 )
-            }
-            guard verticalPanIntent == true else {
                 if verticalPanIntent == false {
                     gestureStartedAtTop = false
                     pullProgress = 0
                     didReachThreshold = false
                 }
+            }
+            guard verticalPanIntent == true else {
                 return
             }
             guard isDirectlyInteracting,
@@ -582,9 +573,11 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: AttachmentView, context: Context) {
-        context.coordinator.surfaceColor = surfaceColor
-        context.coordinator.onStateChange = onStateChange
-        context.coordinator.scheduleAttachment(from: uiView)
+        context.coordinator.update(
+            surfaceColor: surfaceColor,
+            onStateChange: onStateChange,
+            from: uiView
+        )
     }
 
     static func dismantleUIView(_ uiView: AttachmentView, coordinator: Coordinator) {
@@ -593,23 +586,38 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
     }
 
     final class AttachmentView: UIView {
-        var onHierarchyChange: ((UIView) -> Void)?
+        var onHierarchyChange: ((AttachmentView) -> Void)?
+        private(set) var hierarchyGeneration: UInt = 0
 
         override func didMoveToSuperview() {
             super.didMoveToSuperview()
+            hierarchyGeneration &+= 1
             onHierarchyChange?(self)
         }
 
         override func didMoveToWindow() {
             super.didMoveToWindow()
+            hierarchyGeneration &+= 1
             onHierarchyChange?(self)
+        }
+    }
+
+    final class ScrollLifecycleSentinel: UIView {
+        var onWindowChange: ((ScrollLifecycleSentinel) -> Void)?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            onWindowChange?(self)
         }
     }
 
     final class Coordinator: NSObject {
         var surfaceColor: UIColor {
             didSet {
-                attachedScrollView?.backgroundColor = surfaceColor
+                guard oldValue.isEqual(surfaceColor) == false else { return }
+                if attachedScrollView?.backgroundColor?.isEqual(surfaceColor) != true {
+                    attachedScrollView?.backgroundColor = surfaceColor
+                }
             }
         }
         var onStateChange: (UIGestureRecognizer.State, CGSize) -> Void
@@ -617,6 +625,9 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
         private var originalBackgroundColor: UIColor?
         private weak var panGestureRecognizer: UIPanGestureRecognizer?
         private var pendingAttachment: DispatchWorkItem?
+        private var attachmentRequestID: UInt = 0
+        private var attachedHierarchyGeneration: UInt?
+        private var lifecycleSentinel: ScrollLifecycleSentinel?
 
         init(
             surfaceColor: UIColor,
@@ -626,35 +637,82 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
             self.onStateChange = onStateChange
         }
 
-        func scheduleAttachment(from view: UIView) {
+        func update(
+            surfaceColor: UIColor,
+            onStateChange: @escaping (UIGestureRecognizer.State, CGSize) -> Void,
+            from view: AttachmentView
+        ) {
+            self.surfaceColor = surfaceColor
+            self.onStateChange = onStateChange
+            guard hasUsableAttachment(for: view) == false else { return }
+            scheduleAttachment(from: view)
+        }
+
+        func scheduleAttachment(from view: AttachmentView) {
+            currentAttachmentView = view
+            attachmentRequestID &+= 1
+            let requestID = attachmentRequestID
+            let hierarchyGeneration = view.hierarchyGeneration
             pendingAttachment?.cancel()
             let workItem = DispatchWorkItem { [weak self, weak view] in
                 guard let self, let view else { return }
-                self.attach(to: Self.enclosingScrollView(startingAt: view))
+                guard self.attachmentRequestID == requestID,
+                      view.hierarchyGeneration == hierarchyGeneration else { return }
+                self.pendingAttachment = nil
+                self.attach(
+                    to: Self.enclosingScrollView(startingAt: view),
+                    hierarchyGeneration: hierarchyGeneration
+                )
             }
             pendingAttachment = workItem
             DispatchQueue.main.async(execute: workItem)
         }
 
         func detach() {
+            attachmentRequestID &+= 1
             pendingAttachment?.cancel()
             pendingAttachment = nil
             panGestureRecognizer?.removeTarget(self, action: #selector(handlePan(_:)))
             panGestureRecognizer = nil
             restoreScrollBackground()
+            currentAttachmentView = nil
         }
 
-        private func attach(to scrollView: UIScrollView?) {
-            guard let scrollView else { return }
+        private func hasUsableAttachment(for view: AttachmentView) -> Bool {
+            guard let scrollView = attachedScrollView,
+                  let recognizer = panGestureRecognizer,
+                  recognizer === scrollView.panGestureRecognizer,
+                  lifecycleSentinel?.superview === scrollView,
+                  attachedHierarchyGeneration == view.hierarchyGeneration,
+                  let window = view.window,
+                  scrollView.window === window else {
+                return false
+            }
+            return true
+        }
+
+        private func attach(
+            to scrollView: UIScrollView?,
+            hierarchyGeneration: UInt
+        ) {
+            guard let scrollView else {
+                detach()
+                return
+            }
             let recognizer = scrollView.panGestureRecognizer
             if attachedScrollView === scrollView,
                panGestureRecognizer === recognizer {
-                scrollView.backgroundColor = surfaceColor
+                attachedHierarchyGeneration = hierarchyGeneration
+                installLifecycleSentinelIfNeeded(on: scrollView)
+                if scrollView.backgroundColor?.isEqual(surfaceColor) != true {
+                    scrollView.backgroundColor = surfaceColor
+                }
                 return
             }
             panGestureRecognizer?.removeTarget(self, action: #selector(handlePan(_:)))
             restoreScrollBackground()
             attachedScrollView = scrollView
+            attachedHierarchyGeneration = hierarchyGeneration
             originalBackgroundColor = scrollView.backgroundColor
             // UIKit renders rubber-band overscroll using the scroll view's
             // own background, not the SwiftUI background behind it. Keeping
@@ -663,13 +721,40 @@ private struct ShortPullScrollViewPanObserver: UIViewRepresentable {
             scrollView.backgroundColor = surfaceColor
             panGestureRecognizer = recognizer
             recognizer.addTarget(self, action: #selector(handlePan(_:)))
+            installLifecycleSentinelIfNeeded(on: scrollView)
         }
 
         private func restoreScrollBackground() {
+            lifecycleSentinel?.onWindowChange = nil
+            lifecycleSentinel?.removeFromSuperview()
+            lifecycleSentinel = nil
             attachedScrollView?.backgroundColor = originalBackgroundColor
             attachedScrollView = nil
+            attachedHierarchyGeneration = nil
             originalBackgroundColor = nil
         }
+
+        private func installLifecycleSentinelIfNeeded(on scrollView: UIScrollView) {
+            if lifecycleSentinel?.superview === scrollView { return }
+
+            lifecycleSentinel?.onWindowChange = nil
+            lifecycleSentinel?.removeFromSuperview()
+            let sentinel = ScrollLifecycleSentinel(frame: .zero)
+            sentinel.isUserInteractionEnabled = false
+            sentinel.isAccessibilityElement = false
+            sentinel.backgroundColor = .clear
+            sentinel.onWindowChange = { [weak self, weak sentinel] changedSentinel in
+                guard changedSentinel === sentinel,
+                      changedSentinel.window == nil,
+                      let self,
+                      let attachmentView = self.currentAttachmentView else { return }
+                self.scheduleAttachment(from: attachmentView)
+            }
+            lifecycleSentinel = sentinel
+            scrollView.addSubview(sentinel)
+        }
+
+        private weak var currentAttachmentView: AttachmentView?
 
         @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {
             let point = recognizer.translation(in: recognizer.view)

--- a/TiebaPure/Domain/Models/AppPersistence.swift
+++ b/TiebaPure/Domain/Models/AppPersistence.swift
@@ -266,8 +266,13 @@ enum PersistedRecordStore {
         threadID: Int64,
         in context: ModelContext
     ) throws {
-        let records = try context.fetch(FetchDescriptor<ThreadReadingPositionRecord>())
-        for record in records where record.threadID == threadID {
+        let requestedThreadID = threadID
+        let records = try context.fetch(FetchDescriptor<ThreadReadingPositionRecord>(
+            predicate: #Predicate { record in
+                record.threadID == requestedThreadID
+            }
+        ))
+        for record in records {
             context.delete(record)
         }
         try save(context)

--- a/TiebaPure/Domain/Models/LocalThreadLibrary.swift
+++ b/TiebaPure/Domain/Models/LocalThreadLibrary.swift
@@ -64,6 +64,139 @@ enum LocalThreadListSelectionPolicy {
     }
 }
 
+private enum ThreadReadingPositionDatabaseMutation: Sendable {
+    case upsert(ThreadReadingPosition, limit: Int)
+    case delete(threadID: Int64)
+    case deleteAll
+}
+
+@ModelActor
+private actor ThreadReadingPositionDatabaseActor {
+    func apply(
+        _ mutation: ThreadReadingPositionDatabaseMutation
+    ) throws -> [ThreadReadingPosition] {
+        switch mutation {
+        case let .upsert(position, limit):
+            return try upsert(position, limit: limit)
+        case let .delete(threadID):
+            return try delete(threadID: threadID)
+        case .deleteAll:
+            return try deleteAll()
+        }
+    }
+
+    private func upsert(
+        _ position: ThreadReadingPosition,
+        limit: Int
+    ) throws -> [ThreadReadingPosition] {
+        try Task.checkCancellation()
+        let effectiveLimit = min(
+            max(limit, 0),
+            LocalThreadLibraryPolicy.maximumReadingPositions
+        )
+
+        do {
+            var records = try modelContext.fetch(
+                FetchDescriptor<ThreadReadingPositionRecord>()
+            )
+            guard effectiveLimit > 0 else {
+                for record in records {
+                    modelContext.delete(record)
+                }
+                try Task.checkCancellation()
+                try save()
+                return []
+            }
+
+            if let existing = records.first(where: { $0.threadID == position.threadID }) {
+                existing.postIDBitPattern = Int64(bitPattern: position.postID)
+                existing.floor = position.floor
+                existing.updatedAt = position.updatedAt
+            } else {
+                let inserted = ThreadReadingPositionRecord(entry: position, sortIndex: 0)
+                modelContext.insert(inserted)
+                records.append(inserted)
+            }
+
+            records.sort {
+                if $0.updatedAt != $1.updatedAt {
+                    return $0.updatedAt > $1.updatedAt
+                }
+                return $0.threadID < $1.threadID
+            }
+
+            var seenThreadIDs = Set<Int64>()
+            var retained: [ThreadReadingPositionRecord] = []
+            retained.reserveCapacity(min(records.count, effectiveLimit))
+            for record in records {
+                guard seenThreadIDs.insert(record.threadID).inserted,
+                      retained.count < effectiveLimit else {
+                    modelContext.delete(record)
+                    continue
+                }
+                record.sortIndex = retained.count
+                retained.append(record)
+            }
+            try Task.checkCancellation()
+            try save()
+            return retained.map(\.entry)
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    private func delete(threadID: Int64) throws -> [ThreadReadingPosition] {
+        try Task.checkCancellation()
+        let requestedThreadID = threadID
+        do {
+            let records = try modelContext.fetch(FetchDescriptor<ThreadReadingPositionRecord>(
+                predicate: #Predicate { record in
+                    record.threadID == requestedThreadID
+                }
+            ))
+            for record in records {
+                modelContext.delete(record)
+            }
+            try Task.checkCancellation()
+            try save()
+            return try orderedPositions()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    private func deleteAll() throws -> [ThreadReadingPosition] {
+        try Task.checkCancellation()
+        do {
+            let records = try modelContext.fetch(
+                FetchDescriptor<ThreadReadingPositionRecord>()
+            )
+            for record in records {
+                modelContext.delete(record)
+            }
+            try Task.checkCancellation()
+            try save()
+            return []
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    private func orderedPositions() throws -> [ThreadReadingPosition] {
+        try modelContext.fetch(FetchDescriptor<ThreadReadingPositionRecord>())
+            .sorted { $0.sortIndex < $1.sortIndex }
+            .map(\.entry)
+    }
+
+    private func save() throws {
+        guard modelContext.hasChanges else { return }
+        try modelContext.save()
+    }
+}
+
 struct ThreadFavoriteEntry: Codable, Equatable, Identifiable, Sendable {
     var threadID: Int64
     var forumID: Int64?
@@ -260,8 +393,12 @@ final class LocalThreadLibraryStore: ObservableObject {
     private let readingPositionLimit: Int
     private let now: () -> Date
     private let modelContext: ModelContext
+    private let readingPositionDatabaseActorTask: Task<ThreadReadingPositionDatabaseActor, Never>
     private let persistentBackendIsAvailable: Bool
     private let faultInjector: PersistenceFaultInjector
+    private var readingPositionMutationTail: Task<Bool, Never>?
+    private var readingPositionMutationTailID: UUID?
+    private var pendingReadingPositionMutationCount = 0
 
     @Published private(set) var favorites: [ThreadFavoriteEntry]
     @Published private(set) var readingPositions: [ThreadReadingPosition]
@@ -293,6 +430,9 @@ final class LocalThreadLibraryStore: ObservableObject {
         self.faultInjector = faultInjector
         let context = modelContainer.mainContext
         modelContext = context
+        readingPositionDatabaseActorTask = Task.detached(priority: .utility) {
+            ThreadReadingPositionDatabaseActor(modelContainer: modelContainer)
+        }
         let initialAvailability = persistenceAvailability
             ?? AppModelContainer.persistenceAvailability(for: modelContainer)
         persistentBackendIsAvailable = initialAvailability.canPersist
@@ -383,6 +523,7 @@ final class LocalThreadLibraryStore: ObservableObject {
 
     @discardableResult
     func reload() -> Bool {
+        guard pendingReadingPositionMutationCount == 0 else { return false }
         var succeeded = true
         do {
             let result = try Self.loadAndRepairFavorites(
@@ -517,7 +658,79 @@ final class LocalThreadLibraryStore: ObservableObject {
     }
 
     @discardableResult
+    func recordReadingPositionInBackground(
+        threadID: Int64,
+        postID: UInt64,
+        floor: Int
+    ) async -> Bool {
+        await enqueueReadingPosition(
+            threadID: threadID,
+            postID: postID,
+            floor: floor
+        ).value
+    }
+
+    func enqueueReadingPosition(
+        threadID: Int64,
+        postID: UInt64,
+        floor: Int
+    ) -> Task<Bool, Never> {
+        guard let position = LocalThreadLibraryPolicy.readingPosition(
+            threadID: threadID,
+            postID: postID,
+            floor: floor,
+            updatedAt: now()
+        ) else { return completedReadingPositionMutation(false) }
+        if pendingReadingPositionMutationCount == 0,
+           let current = self.position(for: threadID),
+           current.postID == postID,
+           current.floor == floor {
+            return completedReadingPositionMutation(true)
+        }
+        return enqueueReadingPositionMutation(
+            .upsert(position, limit: readingPositionLimit),
+            operation: "save reading position"
+        )
+    }
+
+    @discardableResult
+    func clearReadingPositionInBackground(threadID: Int64) async -> Bool {
+        await enqueueClearReadingPosition(threadID: threadID).value
+    }
+
+    func enqueueClearReadingPosition(threadID: Int64) -> Task<Bool, Never> {
+        guard pendingReadingPositionMutationCount > 0
+                || readingPositions.contains(where: { $0.threadID == threadID }) else {
+            return completedReadingPositionMutation(true)
+        }
+        return enqueueReadingPositionMutation(
+            .delete(threadID: threadID),
+            operation: "clear reading position"
+        )
+    }
+
+    @discardableResult
+    func clearReadingPositionsInBackground() async -> Bool {
+        await enqueueClearReadingPositions().value
+    }
+
+    func enqueueClearReadingPositions() -> Task<Bool, Never> {
+        enqueueReadingPositionMutation(
+            .deleteAll,
+            operation: "clear reading positions",
+            removesLegacyValueOnSuccess: true
+        )
+    }
+
+    func waitForPendingReadingPositionMutations() async {
+        while let tail = readingPositionMutationTail {
+            _ = await tail.value
+        }
+    }
+
+    @discardableResult
     func recordReadingPosition(threadID: Int64, postID: UInt64, floor: Int) -> Bool {
+        guard pendingReadingPositionMutationCount == 0 else { return false }
         guard let position = LocalThreadLibraryPolicy.readingPosition(
             threadID: threadID,
             postID: postID,
@@ -556,6 +769,7 @@ final class LocalThreadLibraryStore: ObservableObject {
 
     @discardableResult
     func clearReadingPosition(threadID: Int64) -> Bool {
+        guard pendingReadingPositionMutationCount == 0 else { return false }
         guard readingPositions.contains(where: { $0.threadID == threadID }) else { return true }
         guard persistentBackendIsAvailable else {
             persistenceAvailability = .unavailable
@@ -578,6 +792,7 @@ final class LocalThreadLibraryStore: ObservableObject {
 
     @discardableResult
     func clearReadingPositions() -> Bool {
+        guard pendingReadingPositionMutationCount == 0 else { return false }
         guard persistentBackendIsAvailable else {
             persistenceAvailability = .unavailable
             return false
@@ -601,6 +816,7 @@ final class LocalThreadLibraryStore: ObservableObject {
 
     @discardableResult
     func clearAll() -> Bool {
+        guard pendingReadingPositionMutationCount == 0 else { return false }
         guard persistentBackendIsAvailable else {
             persistenceAvailability = .unavailable
             return false
@@ -620,6 +836,61 @@ final class LocalThreadLibraryStore: ObservableObject {
             persistenceAvailability = .unavailable
             return false
         }
+    }
+
+    private func enqueueReadingPositionMutation(
+        _ mutation: ThreadReadingPositionDatabaseMutation,
+        operation: String,
+        removesLegacyValueOnSuccess: Bool = false
+    ) -> Task<Bool, Never> {
+        guard persistentBackendIsAvailable else {
+            persistenceAvailability = .unavailable
+            return completedReadingPositionMutation(false)
+        }
+
+        let previousMutation = readingPositionMutationTail
+        let databaseActorTask = readingPositionDatabaseActorTask
+        let mutationID = UUID()
+        pendingReadingPositionMutationCount += 1
+        readingPositionMutationTailID = mutationID
+
+        let mutationTask = Task { @MainActor [weak self] in
+            if let previousMutation {
+                _ = await previousMutation.value
+            }
+            guard let self else { return false }
+            defer {
+                self.pendingReadingPositionMutationCount = max(
+                    self.pendingReadingPositionMutationCount - 1,
+                    0
+                )
+                if self.readingPositionMutationTailID == mutationID {
+                    self.readingPositionMutationTail = nil
+                    self.readingPositionMutationTailID = nil
+                }
+            }
+
+            do {
+                let databaseActor = await databaseActorTask.value
+                let persisted = try await databaseActor.apply(mutation)
+                self.readingPositions = persisted
+                if removesLegacyValueOnSuccess {
+                    self.defaults.removeObject(forKey: self.readingPositionsKey)
+                }
+                self.markPersistenceSucceeded()
+                return true
+            } catch {
+                PersistenceDiagnostics.report(error, operation: operation)
+                self.persistenceAvailability = .unavailable
+                return false
+            }
+        }
+        readingPositionMutationTail = mutationTask
+        return mutationTask
+    }
+
+    private func completedReadingPositionMutation(_ result: Bool) -> Task<Bool, Never> {
+        Task { result }
     }
 
     @discardableResult

--- a/TiebaPure/Domain/Models/TiebaEmoticon.swift
+++ b/TiebaPure/Domain/Models/TiebaEmoticon.swift
@@ -239,19 +239,76 @@ enum TiebaEmoticon {
     }
 }
 
-/// Bumps when artwork arrives from the network, so views that rendered the
-/// text fallback rebuild with the image. Emoticons are drawn both as SwiftUI
-/// views and as NSTextAttachments inside synchronously-built attributed
-/// strings, and neither can await a download mid-layout.
+/// Publishes the exact artwork names that became available. Updates arriving
+/// in the same run-loop turn are coalesced so a reply containing several newly
+/// downloaded emoticons rebuilds once instead of once per image.
 @MainActor
-final class TiebaEmoticonArtwork: ObservableObject {
+final class TiebaEmoticonArtwork {
     static let shared = TiebaEmoticonArtwork()
+    nonisolated static let didChangeNotification = Notification.Name("TiebaEmoticonArtworkDidChange")
 
-    @Published private(set) var revision = 0
+    private var pendingImageNames: Set<String> = []
+    private var flushTask: Task<Void, Never>?
 
     private init() {}
 
-    func didFetch() {
-        revision &+= 1
+    func didFetch(_ imageName: String) {
+        guard imageName.isEmpty == false else { return }
+        pendingImageNames.insert(imageName)
+        guard flushTask == nil else { return }
+        flushTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            self?.flushPendingChanges()
+        }
+    }
+
+    nonisolated static func imageNames(from notification: Notification) -> Set<String> {
+        Set(notification.userInfo?["imageNames"] as? [String] ?? [])
+    }
+
+    private func flushPendingChanges() {
+        let imageNames = pendingImageNames.sorted()
+        pendingImageNames.removeAll(keepingCapacity: true)
+        flushTask = nil
+        guard imageNames.isEmpty == false else { return }
+        NotificationCenter.default.post(
+            name: Self.didChangeNotification,
+            object: self,
+            userInfo: ["imageNames": imageNames]
+        )
+    }
+}
+
+final class TiebaEmoticonArtworkObserver: ObservableObject, @unchecked Sendable {
+    @Published private(set) var revision = 0
+
+    private let imageNames: Set<String>
+    private var notificationToken: NSObjectProtocol?
+
+    init(imageNames: Set<String>) {
+        self.imageNames = imageNames
+        notificationToken = NotificationCenter.default.addObserver(
+            forName: TiebaEmoticonArtwork.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  self.imageNames.isDisjoint(
+                    with: TiebaEmoticonArtwork.imageNames(from: notification)
+                  ) == false else {
+                return
+            }
+            self.revision &+= 1
+        }
+    }
+
+    convenience init(code: String) {
+        self.init(imageNames: Set([TiebaEmoticon.imageName(for: code) ?? code]))
+    }
+
+    deinit {
+        if let notificationToken {
+            NotificationCenter.default.removeObserver(notificationToken)
+        }
     }
 }

--- a/TiebaPure/Domain/Models/TiebaEmoticonRepository.swift
+++ b/TiebaPure/Domain/Models/TiebaEmoticonRepository.swift
@@ -450,9 +450,9 @@ actor TiebaEmoticonRepository {
     static let shared = TiebaEmoticonRepository(
         cache: .shared,
         downloader: TiebaEmoticonCDNClient.shared,
-        onArtworkAvailable: {
+        onArtworkAvailable: { imageName in
             await MainActor.run {
-                TiebaEmoticonArtwork.shared.didFetch()
+                TiebaEmoticonArtwork.shared.didFetch(imageName)
             }
         }
     )
@@ -463,7 +463,7 @@ actor TiebaEmoticonRepository {
     private let maximumInFlightRequests: Int
     private let maximumNegativeEntries: Int
     private let now: @Sendable () -> Date
-    private let onArtworkAvailable: @Sendable () async -> Void
+    private let onArtworkAvailable: @Sendable (String) async -> Void
     private let downloadLimiter: TiebaEmoticonDownloadLimiter
     private var inFlight: [String: Task<Bool, Never>] = [:]
     private var retryAfter: [String: Date] = [:]
@@ -477,7 +477,7 @@ actor TiebaEmoticonRepository {
         maximumInFlightRequests: Int = 64,
         maximumNegativeEntries: Int = 256,
         now: @escaping @Sendable () -> Date = { Date() },
-        onArtworkAvailable: @escaping @Sendable () async -> Void = {}
+        onArtworkAvailable: @escaping @Sendable (String) async -> Void = { _ in }
     ) {
         self.cache = cache
         self.downloader = downloader
@@ -502,7 +502,7 @@ actor TiebaEmoticonRepository {
         }
         if cache.image(for: imageName) != nil {
             retryAfter[imageName] = nil
-            await onArtworkAvailable()
+            await onArtworkAvailable(imageName)
             return true
         }
         if let retryDate = retryAfter[imageName], retryDate > currentDate { return false }
@@ -532,7 +532,7 @@ actor TiebaEmoticonRepository {
                 try Task.checkCancellation()
                 try cache.store(data, for: imageName)
                 await limiter.release()
-                await callback()
+                await callback(imageName)
                 return true
             } catch {
                 await limiter.release()

--- a/TiebaPure/Features/Compose/ContentComposerView.swift
+++ b/TiebaPure/Features/Compose/ContentComposerView.swift
@@ -857,7 +857,15 @@ private struct ContentComposerEmoticonButton: View {
     let entry: ContentComposerEmoticon
     let action: () -> Void
 
-    @ObservedObject private var artwork = TiebaEmoticonArtwork.shared
+    @StateObject private var artwork: TiebaEmoticonArtworkObserver
+
+    init(entry: ContentComposerEmoticon, action: @escaping () -> Void) {
+        self.entry = entry
+        self.action = action
+        _artwork = StateObject(wrappedValue: TiebaEmoticonArtworkObserver(
+            imageNames: [entry.imageName]
+        ))
+    }
 
     var body: some View {
         Button(action: action) {

--- a/TiebaPure/Features/Media/ImageDownloadService.swift
+++ b/TiebaPure/Features/Media/ImageDownloadService.swift
@@ -104,42 +104,17 @@ struct TiebaImageMetadataClient: Sendable {
         var headRequest = TiebaImageRequestPolicy.request(for: safeURL)
         headRequest.httpMethod = "HEAD"
         headRequest.cachePolicy = .reloadIgnoringLocalCacheData
-        do {
-            let (_, rawHeadResponse) = try await BoundedURLSession(session: session).data(
-                for: headRequest,
-                maximumBytes: 1_024,
-                requiredMIMEPrefix: "image/",
-                enforcesDeclaredContentLength: false
-            )
-            if let response = rawHeadResponse as? HTTPURLResponse,
-               (200...299).contains(response.statusCode),
-               let length = TiebaImageMetadataPolicy.contentLength(from: response) {
-                return length
-            }
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch let error as URLError where error.code == .cancelled {
-            throw CancellationError()
-        } catch {
-            // Servers that do not implement HEAD still get the bounded Range
-            // probe below. Other failures remain an unknown size, not a load
-            // failure for the visible preview.
-        }
-
-        try Task.checkCancellation()
-        var rangeRequest = TiebaImageRequestPolicy.request(for: safeURL)
-        rangeRequest.cachePolicy = .reloadIgnoringLocalCacheData
-        rangeRequest.setValue("bytes=0-0", forHTTPHeaderField: "Range")
-        let (_, response) = try await BoundedURLSession(session: session).data(
-            for: rangeRequest,
+        let (_, rawHeadResponse) = try await BoundedURLSession(session: session).data(
+            for: headRequest,
             maximumBytes: 1_024,
-            requiredMIMEPrefix: "image/"
+            requiredMIMEPrefix: "image/",
+            enforcesDeclaredContentLength: false
         )
-        guard let http = response as? HTTPURLResponse,
-              (200...299).contains(http.statusCode) else {
+        guard let response = rawHeadResponse as? HTTPURLResponse,
+              (200...299).contains(response.statusCode) else {
             return nil
         }
-        return TiebaImageMetadataPolicy.contentLength(from: http)
+        return TiebaImageMetadataPolicy.contentLength(from: response)
     }
 
     private static func makeSession() -> URLSession {

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -563,8 +563,12 @@ final class ImagePreviewSourceAnchor: ObservableObject {
 
     func store(image: UIImage, sourceIdentity: String) {
         bind(to: sourceIdentity)
-        self.image = image
-        view?.image = image
+        if self.image !== image {
+            self.image = image
+        }
+        if view?.image !== image {
+            view?.image = image
+        }
     }
 
     func clearImage(sourceIdentity: String) {
@@ -597,9 +601,11 @@ final class ImagePreviewSourceAnchor: ObservableObject {
         bind(to: sourceIdentity)
         if self.view !== view {
             self.view?.image = nil
+            self.view = view
         }
-        self.view = view
-        view.image = image
+        if view.image !== image {
+            view.image = image
+        }
     }
 
     func detach(_ view: ImagePreviewSourceView, sourceIdentity: String) {
@@ -695,17 +701,12 @@ struct ImagePreviewSourceAnchorReader: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: ImagePreviewSourceView, context: Context) {
-        // A recycled cell keeps its UIView but can be handed a different post's
-        // image, so the registry entry has to follow the new identity.
-        if context.coordinator.registeredIdentity != sourceIdentity {
-            if let previous = context.coordinator.registeredIdentity {
-                ImagePreviewSourceRegistry.shared.unregister(uiView, identity: previous)
-            }
-            context.coordinator.registeredIdentity = sourceIdentity
-        }
-        uiView.onTransitionTap = onTransitionTap
-        anchor.attach(uiView, sourceIdentity: sourceIdentity)
-        ImagePreviewSourceRegistry.shared.register(uiView, identity: sourceIdentity)
+        context.coordinator.update(
+            uiView,
+            anchor: anchor,
+            sourceIdentity: sourceIdentity,
+            onTransitionTap: onTransitionTap
+        )
     }
 
     static func dismantleUIView(_ uiView: ImagePreviewSourceView, coordinator: Coordinator) {
@@ -727,6 +728,46 @@ struct ImagePreviewSourceAnchorReader: UIViewRepresentable {
 
         init(anchor: ImagePreviewSourceAnchor) {
             self.anchor = anchor
+        }
+
+        func update(
+            _ uiView: ImagePreviewSourceView,
+            anchor: ImagePreviewSourceAnchor,
+            sourceIdentity: String,
+            onTransitionTap: (() -> Void)?
+        ) {
+            // A recycled cell keeps its UIView but can be handed a different post's
+            // image, so the registry entry has to follow the new identity.
+            let previousIdentity = registeredIdentity
+            let anchorChanged = self.anchor !== anchor
+            let identityChanged = previousIdentity != sourceIdentity
+
+            if anchorChanged {
+                if let previousIdentity {
+                    self.anchor?.detach(
+                        uiView,
+                        sourceIdentity: previousIdentity
+                    )
+                }
+                self.anchor = anchor
+            }
+
+            if identityChanged {
+                if let previousIdentity {
+                    ImagePreviewSourceRegistry.shared.unregister(
+                        uiView,
+                        identity: previousIdentity
+                    )
+                }
+                registeredIdentity = sourceIdentity
+            }
+            uiView.onTransitionTap = onTransitionTap
+            if anchorChanged || identityChanged || anchor.view !== uiView {
+                anchor.attach(uiView, sourceIdentity: sourceIdentity)
+            }
+            if identityChanged {
+                ImagePreviewSourceRegistry.shared.register(uiView, identity: sourceIdentity)
+            }
         }
     }
 

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -4,6 +4,7 @@ import Combine
 
 struct ImageViewer: View {
     @Environment(\.readingPreferences) private var readingPreferences
+    @Environment(\.displayScale) private var displayScale
 
     let image: ImageContent
     let galleryImages: [ImageContent]
@@ -107,13 +108,18 @@ struct ImageViewer: View {
         .aspectRatio(inlineAspectRatio, contentMode: .fit)
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay {
-            ZStack {
+            GeometryReader { proxy in
+                ZStack {
                 RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.media, style: .continuous)
                     .fill(TiebaPureTheme.ColorToken.readerTertiarySurface)
 
                 TiebaRemoteImage(
                     primaryURL: imageRequestSources.primaryURL,
                     fallbackURL: imageRequestSources.fallbackURL,
+                    targetPixelSize: TiebaImageDecodePolicy.previewTargetPixelSize(
+                        for: proxy.size,
+                        displayScale: displayScale
+                    ),
                     contentMode: .fill,
                     showsProgress: true,
                     retryTrigger: inlineRetryTrigger,
@@ -172,6 +178,7 @@ struct ImageViewer: View {
                         .allowsHitTesting(false)
                         .accessibilityHidden(true)
                 }
+            }
             }
         }
         .frame(maxHeight: InlineImageLayoutPolicy.maximumInlineHeight)
@@ -2386,6 +2393,28 @@ enum FullScreenImageSourcePolicy {
             downloadURL: safeOriginal ?? safeThumbnail
         )
     }
+
+    /// Automatic full-screen image-body loading stays on the preview tier. A
+    /// distinct original image body is reserved for the explicit original and
+    /// download actions; the visible page may still issue a body-free HEAD
+    /// request so the control can display its file size.
+    static func automaticPreviewURLs(
+        primary: URL?,
+        fallback: URL?,
+        original: URL?
+    ) -> [URL] {
+        let candidates = TiebaImageSourcePolicy.urls(
+            primary: primary,
+            fallback: fallback
+        )
+        guard let safeOriginal = TiebaURL.image(original?.absoluteString) else {
+            return candidates
+        }
+        let previewCandidates = candidates.filter { $0 != safeOriginal }
+        // Some legacy payloads expose only one URL. It can still be decoded at
+        // preview size; there is no distinct lower-resolution network source.
+        return previewCandidates.isEmpty ? Array(candidates.prefix(1)) : previewCandidates
+    }
 }
 
 private struct FullScreenImageItem: Identifiable {
@@ -2442,7 +2471,7 @@ enum ImagePreviewResolvedImageVisibilityPolicy {
 }
 
 enum FullScreenImageLoadSchedulingPolicy {
-    /// A page may start its original-image load only after the hero
+    /// A page may start its preview-image load only after the hero
     /// presentation has finished, and only while it is the visible page or an
     /// immediate neighbor. Loading every page at presentation time flooded
     /// the 0.32s transition window with downloads and full-size decodes.
@@ -2460,15 +2489,49 @@ enum FullScreenImageLoadSchedulingPolicy {
     }
 }
 
+enum FullScreenImageMetadataSchedulingPolicy {
+    /// Original-file metadata is needed for the visible "查看原图" control,
+    /// but adjacent pages must not touch their original URLs speculatively.
+    static func allowsLoading(
+        pageIndex: Int,
+        currentIndex: Int,
+        didFinishPresentation: Bool
+    ) -> Bool {
+        didFinishPresentation && pageIndex == currentIndex
+    }
+}
+
 enum FullScreenImageDecodePolicy {
-    /// First-paint decodes target the screen's longest edge in pixels instead
-    /// of `TiebaImageDecodePolicy.maximumDecodedPixelSize`; the
-    /// full-resolution tier is requested only from the explicit original-image
-    /// control.
-    static let initialTargetPixelSize: Int = {
-        let screen = UIScreen.main
-        return Int((max(screen.bounds.width, screen.bounds.height) * screen.scale).rounded(.up))
-    }()
+    static let maximumPreviewDecodedPixelSize = 3_072
+    static let maximumPreviewDisplayScale: CGFloat = 3
+
+    /// Match the screen's native pixel density without decoding beyond the
+    /// size a phone or tablet can use for its initial full-screen presentation.
+    /// The explicit original-image action remains on the separate 4096 tier.
+    static var initialTargetPixelSize: Int {
+        previewTargetPixelSize(
+            for: UIScreen.main.bounds.size,
+            displayScale: UIScreen.main.scale
+        )
+    }
+
+    static func previewTargetPixelSize(
+        for pointSize: CGSize,
+        displayScale: CGFloat
+    ) -> Int {
+        let longestPointEdge = max(pointSize.width, pointSize.height)
+        guard longestPointEdge.isFinite,
+              longestPointEdge > 0,
+              displayScale.isFinite,
+              displayScale > 0 else {
+            return 1_024
+        }
+        let previewScale = min(displayScale, maximumPreviewDisplayScale)
+        return min(
+            Int(ceil(longestPointEdge * previewScale)),
+            maximumPreviewDecodedPixelSize
+        )
+    }
 }
 
 enum FullScreenImagePlaceholderPolicy {
@@ -3050,7 +3113,12 @@ private final class FullScreenZoomImageController: UIViewController,
     }
 
     private func startOriginalMetadataLoadingIfEligible() {
-        guard didFinishMetadataRequest == false,
+        guard FullScreenImageMetadataSchedulingPolicy.allowsLoading(
+            pageIndex: imageIndex,
+            currentIndex: transitionState.currentIndex,
+            didFinishPresentation: transitionState.didFinishPresentation
+        ),
+              didFinishMetadataRequest == false,
               metadataTask == nil,
               let originalURL else {
             return
@@ -3076,7 +3144,7 @@ private final class FullScreenZoomImageController: UIViewController,
             } catch {
                 guard let self else { return }
                 self.metadataTask = nil
-                // A transient HEAD/Range failure must not suppress the size
+                // A transient HEAD failure must not suppress the size
                 // forever. The next time this page becomes eligible, retry.
                 self.didFinishMetadataRequest = false
             }
@@ -3090,9 +3158,10 @@ private final class FullScreenZoomImageController: UIViewController,
         if placeholderImage == nil {
             activityIndicator.startAnimating()
         }
-        let urls = TiebaImageSourcePolicy.urls(
+        let urls = FullScreenImageSourcePolicy.automaticPreviewURLs(
             primary: primaryURL,
-            fallback: fallbackURL
+            fallback: fallbackURL,
+            original: originalURL
         )
         loadTask = Task { [weak self] in
             guard let self else { return }
@@ -3661,7 +3730,7 @@ struct FullScreenImageView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack {
             Color.black
                 .ignoresSafeArea()
 
@@ -3684,24 +3753,15 @@ struct FullScreenImageView: View {
                 .accessibilityElement()
                 .accessibilityIdentifier("full-screen-image-pager")
 
-            Button {
-                close()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: TiebaPureTheme.IconSize.toolbar, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
-                    .background(.black.opacity(0.45), in: Circle())
-            }
-            .accessibilityLabel("关闭图片")
-            .padding(TiebaPureTheme.Spacing.md)
-
             VStack(spacing: 0) {
                 Spacer(minLength: 0)
                 bottomBar
             }
         }
         .accessibilityHint("双指捏合或双击缩放，单指可斜向拖动图片，轻点图片返回来源页面")
+        .accessibilityAction(.escape) {
+            close()
+        }
         .alert(item: $downloadNotice) { notice in
             Alert(
                 title: Text(notice.title),

--- a/TiebaPure/Features/Media/VideoPlayerView.swift
+++ b/TiebaPure/Features/Media/VideoPlayerView.swift
@@ -50,6 +50,7 @@ enum VideoPreviewReusePolicy {
 
 struct VideoPlayerView: View {
     @Environment(\.readingPreferences) private var readingPreferences
+    @Environment(\.displayScale) private var displayScale
 
     let video: VideoContent
 
@@ -140,27 +141,33 @@ struct VideoPlayerView: View {
                 .fill(TiebaPureTheme.ColorToken.readerTertiarySurface)
 
             if let coverURL = video.coverURL {
-                TiebaRemoteImage(
-                    primaryURL: coverURL,
-                    contentMode: .fill,
-                    showsProgress: true,
-                    showsRetryButton: false,
-                    showsResolvedImage: false,
-                    loadsAutomatically: mediaRequestPolicy.loadsAutomatically || isManualCoverLoadAuthorized,
-                    onLoadStateChange: {
-                        coverLoadState = $0
-                        coverLoadStateIdentity = previewSourceIdentity
-                        if $0 != .success {
-                            previewSource.clearImage(sourceIdentity: previewSourceIdentity)
+                GeometryReader { proxy in
+                    TiebaRemoteImage(
+                        primaryURL: coverURL,
+                        targetPixelSize: TiebaImageDecodePolicy.previewTargetPixelSize(
+                            for: proxy.size,
+                            displayScale: displayScale
+                        ),
+                        contentMode: .fill,
+                        showsProgress: true,
+                        showsRetryButton: false,
+                        showsResolvedImage: false,
+                        loadsAutomatically: mediaRequestPolicy.loadsAutomatically || isManualCoverLoadAuthorized,
+                        onLoadStateChange: {
+                            coverLoadState = $0
+                            coverLoadStateIdentity = previewSourceIdentity
+                            if $0 != .success {
+                                previewSource.clearImage(sourceIdentity: previewSourceIdentity)
+                            }
+                        },
+                        onImageResolved: {
+                            previewSource.store(
+                                image: $0,
+                                sourceIdentity: previewSourceIdentity
+                            )
                         }
-                    },
-                    onImageResolved: {
-                        previewSource.store(
-                            image: $0,
-                            sourceIdentity: previewSourceIdentity
-                        )
-                    }
-                )
+                    )
+                }
 
                 ImagePreviewSourceAnchorReader(
                     anchor: previewSource,

--- a/TiebaPure/Features/Profile/ThreadFavoritesView.swift
+++ b/TiebaPure/Features/Profile/ThreadFavoritesView.swift
@@ -122,8 +122,10 @@ struct ThreadFavoritesView: View {
             titleVisibility: .visible
         ) {
             Button("清除", role: .destructive) {
-                if libraryStore.clearReadingPositions() == false {
-                    showsPersistenceError = true
+                Task {
+                    if await libraryStore.clearReadingPositionsInBackground() == false {
+                        showsPersistenceError = true
+                    }
                 }
             }
             Button("取消", role: .cancel) {}
@@ -150,8 +152,9 @@ struct ThreadFavoritesView: View {
         } message: {
             Text("未能保存本机帖子记录，请稍后重试。")
         }
-        .onAppear {
-            libraryStore.reload()
+        .task {
+            await libraryStore.waitForPendingReadingPositionMutations()
+            _ = libraryStore.reload()
         }
         .onChange(of: visibleThreadIDs) { _, _ in
             synchronizeSelection()

--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -41,20 +41,43 @@ struct ContentBlocksView: View {
             ForEach(InlineContentGroup.groups(from: blocks)) { group in
                 switch group.kind {
                 case let .inline(inlineBlocks):
-                    InlineContentText(
-                        blocks: inlineBlocks,
-                        style: textStyle,
-                        lineLimit: lineLimit,
-                        readerFontSize: readerFontSize,
-                        readerLineSpacing: readerLineSpacing,
-                        allowsTextSelection: ThreadContentInteractionPolicy.allowsTextSelection(
-                            for: lineLimit
-                        ),
-                        accessibilityIdentifier: inlineAccessibilityIdentifier,
-                        onOpenUser: onOpenUser,
-                        onPlainTextTap: onPlainTextTap
-                    )
-                    .fixedSize(horizontal: false, vertical: true)
+                    if let plainText = InlinePlainTextPolicy.text(from: inlineBlocks) {
+                        PlainInlineContentText(
+                            text: plainText,
+                            style: textStyle,
+                            lineLimit: lineLimit,
+                            readerFontSize: readerFontSize,
+                            readerLineSpacing: readerLineSpacing,
+                            accessibilityIdentifier: inlineAccessibilityIdentifier,
+                            onPlainTextTap: onPlainTextTap
+                        )
+                    } else if InlineNativeTextPolicy.supports(inlineBlocks) {
+                        NativeInlineContentText(
+                            blocks: inlineBlocks,
+                            style: textStyle,
+                            lineLimit: lineLimit,
+                            readerFontSize: readerFontSize,
+                            readerLineSpacing: readerLineSpacing,
+                            accessibilityIdentifier: inlineAccessibilityIdentifier,
+                            onPlainTextTap: onPlainTextTap
+                        )
+                        .id(InlineNativeTextPolicy.artworkIdentity(in: inlineBlocks))
+                    } else {
+                        InlineContentText(
+                            blocks: inlineBlocks,
+                            style: textStyle,
+                            lineLimit: lineLimit,
+                            readerFontSize: readerFontSize,
+                            readerLineSpacing: readerLineSpacing,
+                            allowsTextSelection: ThreadContentInteractionPolicy.allowsTextSelection(
+                                for: lineLimit
+                            ),
+                            accessibilityIdentifier: inlineAccessibilityIdentifier,
+                            onOpenUser: onOpenUser,
+                            onPlainTextTap: onPlainTextTap
+                        )
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
                 case let .media(mediaBlocks):
                     MediaBlocksView(blocks: mediaBlocks)
                 case let .voice(voice):
@@ -74,6 +97,245 @@ struct ContentBlocksView: View {
                     }
                 }
             }
+        }
+    }
+}
+
+enum InlinePlainTextPolicy {
+    static func text(from blocks: [ContentBlock]) -> String? {
+        var result = ""
+        for block in blocks {
+            guard case let .text(text) = block else { return nil }
+            result.append(text)
+        }
+        return result
+    }
+}
+
+enum InlineNativeTextPolicy {
+    static func supports(_ blocks: [ContentBlock]) -> Bool {
+        blocks.isEmpty == false && blocks.allSatisfy { block in
+            switch block {
+            case .text, .emoticon:
+                return true
+            case .link, .mention, .image, .video, .voice:
+                return false
+            }
+        }
+    }
+
+    static func artworkImageNames(in blocks: [ContentBlock]) -> Set<String> {
+        Set(blocks.compactMap { block in
+            guard case let .emoticon(code) = block else { return nil }
+            return TiebaEmoticon.imageName(for: code)
+        })
+    }
+
+    static func artworkIdentity(in blocks: [ContentBlock]) -> String {
+        artworkImageNames(in: blocks).sorted().joined(separator: "|")
+    }
+}
+
+private struct NativeInlineContentText: View {
+    let blocks: [ContentBlock]
+    let style: InlineContentText.Style
+    let lineLimit: Int
+    let readerFontSize: ReaderFontSize
+    let readerLineSpacing: ReaderLineSpacing
+    let accessibilityIdentifier: String?
+    let onPlainTextTap: (() -> Void)?
+
+    @Environment(\.displayScale) private var displayScale
+    @StateObject private var artwork: TiebaEmoticonArtworkObserver
+
+    init(
+        blocks: [ContentBlock],
+        style: InlineContentText.Style,
+        lineLimit: Int,
+        readerFontSize: ReaderFontSize,
+        readerLineSpacing: ReaderLineSpacing,
+        accessibilityIdentifier: String?,
+        onPlainTextTap: (() -> Void)?
+    ) {
+        self.blocks = blocks
+        self.style = style
+        self.lineLimit = lineLimit
+        self.readerFontSize = readerFontSize
+        self.readerLineSpacing = readerLineSpacing
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.onPlainTextTap = onPlainTextTap
+        _artwork = StateObject(wrappedValue: TiebaEmoticonArtworkObserver(
+            imageNames: InlineNativeTextPolicy.artworkImageNames(in: blocks)
+        ))
+    }
+
+    var body: some View {
+        let _ = artwork.revision
+        let font = style.font(readerFontSize: readerFontSize)
+        let maximumNumberOfLines = ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit)
+        let content = composedText(font: font)
+            .font(Font(font))
+            .foregroundStyle(Color(uiColor: style.foregroundColor))
+            .lineSpacing(ReaderTypographyPolicy.lineSpacing(
+                readerLineSpacing,
+                context: style == .subpost ? .subpost : .body
+            ))
+            .lineLimit(maximumNumberOfLines == 0 ? nil : maximumNumberOfLines)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityLabel(accessibilityText)
+
+        selectableContent(content)
+    }
+
+    private func composedText(font: UIFont) -> Text {
+        blocks.reduce(Text("")) { partial, block in
+            switch block {
+            case let .text(text):
+                return partial + Text(verbatim: text)
+            case let .emoticon(code):
+                let size = min(style.emoticonSize, font.lineHeight)
+                if let image = InlineEmoticonImage.image(
+                    for: code,
+                    pointSize: size,
+                    displayScale: displayScale
+                ) {
+                    let baseline = font.descender + max((font.lineHeight - size) / 2, 0)
+                    return partial + Text(Image(uiImage: image)).baselineOffset(baseline)
+                }
+                return partial + Text(verbatim: TiebaEmoticon.displayText(for: code))
+            case .link, .mention, .image, .video, .voice:
+                return partial
+            }
+        }
+    }
+
+    private var accessibilityText: String {
+        blocks.compactMap(\.plainText).joined()
+    }
+
+    @ViewBuilder
+    private func selectableContent<Content: View>(_ content: Content) -> some View {
+        if ThreadContentInteractionPolicy.allowsTextSelection(for: lineLimit) {
+            identifiedContent(content.textSelection(.enabled))
+        } else {
+            identifiedContent(content.textSelection(.disabled))
+        }
+    }
+
+    @ViewBuilder
+    private func identifiedContent<Content: View>(_ content: Content) -> some View {
+        if let accessibilityIdentifier {
+            interactiveContent(content.accessibilityIdentifier(accessibilityIdentifier))
+        } else {
+            interactiveContent(content)
+        }
+    }
+
+    @ViewBuilder
+    private func interactiveContent<Content: View>(_ content: Content) -> some View {
+        if let onPlainTextTap {
+            content
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onPlainTextTap)
+        } else {
+            content
+        }
+    }
+}
+
+@MainActor
+private enum InlineEmoticonImage {
+    private static let cache = NSCache<NSString, UIImage>()
+
+    static func image(
+        for code: String,
+        pointSize: CGFloat,
+        displayScale: CGFloat
+    ) -> UIImage? {
+        guard pointSize > 0,
+              let imageName = TiebaEmoticon.imageName(for: code),
+              let source = TiebaEmoticon.cachedImage(for: code) else {
+            return nil
+        }
+        let resolvedScale = max(displayScale, 1)
+        let key = "\(imageName)#\(Int((pointSize * resolvedScale).rounded()))" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let image: UIImage
+        if let cgImage = source.cgImage {
+            let pixelSize = CGFloat(max(cgImage.width, cgImage.height))
+            image = UIImage(
+                cgImage: cgImage,
+                scale: max(pixelSize / pointSize, 1),
+                orientation: source.imageOrientation
+            )
+        } else {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = resolvedScale
+            image = UIGraphicsImageRenderer(
+                size: CGSize(width: pointSize, height: pointSize),
+                format: format
+            ).image { _ in
+                source.draw(in: CGRect(x: 0, y: 0, width: pointSize, height: pointSize))
+            }
+        }
+        cache.setObject(image, forKey: key)
+        return image
+    }
+}
+
+private struct PlainInlineContentText: View {
+    let text: String
+    let style: InlineContentText.Style
+    let lineLimit: Int
+    let readerFontSize: ReaderFontSize
+    let readerLineSpacing: ReaderLineSpacing
+    let accessibilityIdentifier: String?
+    let onPlainTextTap: (() -> Void)?
+
+    var body: some View {
+        let maximumNumberOfLines = ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit)
+        let content = Text(verbatim: text)
+            .font(Font(style.font(readerFontSize: readerFontSize)))
+            .foregroundStyle(Color(uiColor: style.foregroundColor))
+            .lineSpacing(ReaderTypographyPolicy.lineSpacing(
+                readerLineSpacing,
+                context: style == .subpost ? .subpost : .body
+            ))
+            .lineLimit(maximumNumberOfLines == 0 ? nil : maximumNumberOfLines)
+            .fixedSize(horizontal: false, vertical: true)
+
+        selectableContent(content)
+    }
+
+    @ViewBuilder
+    private func selectableContent<Content: View>(_ content: Content) -> some View {
+        if ThreadContentInteractionPolicy.allowsTextSelection(for: lineLimit) {
+            identifiedContent(content.textSelection(.enabled))
+        } else {
+            identifiedContent(content.textSelection(.disabled))
+        }
+    }
+
+    @ViewBuilder
+    private func identifiedContent<Content: View>(_ content: Content) -> some View {
+        if let accessibilityIdentifier {
+            interactiveContent(content.accessibilityIdentifier(accessibilityIdentifier))
+        } else {
+            interactiveContent(content)
+        }
+    }
+
+    @ViewBuilder
+    private func interactiveContent<Content: View>(_ content: Content) -> some View {
+        if let onPlainTextTap {
+            content
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onPlainTextTap)
+        } else {
+            content
         }
     }
 }
@@ -120,12 +382,18 @@ struct ContentBlockView: View {
 
 struct TiebaEmoticonView: View {
     let code: String
-    var size: CGFloat = 28
+    var size: CGFloat
 
-    // Redraw when artwork that was missing arrives from the network.
-    @ObservedObject private var artwork = TiebaEmoticonArtwork.shared
+    @StateObject private var artwork: TiebaEmoticonArtworkObserver
+
+    init(code: String, size: CGFloat = 28) {
+        self.code = code
+        self.size = size
+        _artwork = StateObject(wrappedValue: TiebaEmoticonArtworkObserver(code: code))
+    }
 
     var body: some View {
+        let _ = artwork.revision
         if let image = TiebaEmoticon.cachedImage(for: code) {
             Image(uiImage: image)
                 .resizable()
@@ -211,7 +479,9 @@ final class InlineContentTextView: UITextView {
     var allowsTextSelection = false
 
     private var appliedDisplayScale: CGFloat = 0
+    private var appliedRenderID: UInt?
     private var cachedFittingText: NSAttributedString?
+    private var cachedFittingRenderID: UInt?
     private var cachedFittingWidth: CGFloat = 0
     private var cachedFittingMaximumNumberOfLines = 0
     private var cachedFittingLineBreakMode: NSLineBreakMode = .byWordWrapping
@@ -242,7 +512,9 @@ final class InlineContentTextView: UITextView {
             [UITraitPreferredContentSizeCategory.self, UITraitLegibilityWeight.self]
         ) { (view: InlineContentTextView, _) in
             view.appliedDisplayScale = 0
+            view.appliedRenderID = nil
             view.cachedFittingText = nil
+            view.cachedFittingRenderID = nil
         }
     }
 
@@ -253,6 +525,7 @@ final class InlineContentTextView: UITextView {
 
     func apply(
         attributedText: NSAttributedString,
+        renderID: UInt? = nil,
         maximumNumberOfLines: Int,
         lineBreakMode: NSLineBreakMode
     ) {
@@ -262,9 +535,10 @@ final class InlineContentTextView: UITextView {
         // CTLine inset measurement entirely. Attachment-bearing strings
         // compare unequal per instance, which only costs a recompute.
         if displayScale == appliedDisplayScale,
+           renderID == nil || renderID == appliedRenderID,
            textContainer.maximumNumberOfLines == maximumNumberOfLines,
            textContainer.lineBreakMode == lineBreakMode,
-           textStorage.isEqual(to: attributedText) {
+           renderID != nil || textStorage.isEqual(to: attributedText) {
             return
         }
         appliedDisplayScale = displayScale
@@ -277,8 +551,14 @@ final class InlineContentTextView: UITextView {
             textContainerInset = resolvedInsets
             needsLayoutInvalidation = true
         }
-        if textStorage.isEqual(to: attributedText) == false {
+        let needsTextReplacement = if let renderID {
+            renderID != appliedRenderID
+        } else {
+            textStorage.isEqual(to: attributedText) == false
+        }
+        if needsTextReplacement {
             textStorage.setAttributedString(attributedText)
+            appliedRenderID = renderID
             needsLayoutInvalidation = true
         }
         if textContainer.maximumNumberOfLines != maximumNumberOfLines {
@@ -297,6 +577,7 @@ final class InlineContentTextView: UITextView {
     func fittingSize(
         width: CGFloat,
         attributedText: NSAttributedString,
+        renderID: UInt? = nil,
         maximumNumberOfLines: Int,
         lineBreakMode: NSLineBreakMode
     ) -> CGSize {
@@ -305,16 +586,24 @@ final class InlineContentTextView: UITextView {
         // input key; content changes always miss because the key includes
         // the attributed text itself.
         let displayScale = window?.screen.scale ?? UIScreen.main.scale
-        if let cachedFittingText,
+        let contentMatches: Bool
+        if let renderID {
+            contentMatches = renderID == cachedFittingRenderID
+        } else if let cachedFittingText {
+            contentMatches = cachedFittingText.isEqual(to: attributedText)
+        } else {
+            contentMatches = false
+        }
+        if contentMatches,
            cachedFittingWidth == width,
            cachedFittingMaximumNumberOfLines == maximumNumberOfLines,
            cachedFittingLineBreakMode == lineBreakMode,
-           cachedFittingDisplayScale == displayScale,
-           cachedFittingText.isEqual(to: attributedText) {
+           cachedFittingDisplayScale == displayScale {
             return cachedFittingSize
         }
         apply(
             attributedText: attributedText,
+            renderID: renderID,
             maximumNumberOfLines: maximumNumberOfLines,
             lineBreakMode: lineBreakMode
         )
@@ -336,7 +625,10 @@ final class InlineContentTextView: UITextView {
         ).height
         let liveLayoutHeight = ceil(max(geometryHeight, nativeHeight))
         let size = CGSize(width: width, height: liveLayoutHeight)
-        cachedFittingText = attributedText.copy() as? NSAttributedString
+        cachedFittingText = renderID == nil
+            ? attributedText.copy() as? NSAttributedString
+            : nil
+        cachedFittingRenderID = renderID
         cachedFittingWidth = width
         cachedFittingMaximumNumberOfLines = maximumNumberOfLines
         cachedFittingLineBreakMode = lineBreakMode
@@ -427,11 +719,6 @@ final class InlineContentTextView: UITextView {
 }
 
 struct InlineContentText: UIViewRepresentable {
-    // Attributed strings are built synchronously, so an emoticon that has no
-    // artwork yet renders as text; this rebuilds the run once it downloads.
-    @ObservedObject private var artwork = TiebaEmoticonArtwork.shared
-
-
     enum PrefixPart: Equatable {
         case text(String)
         case user(UserSummary)
@@ -449,7 +736,7 @@ struct InlineContentText: UIViewRepresentable {
         }
     }
 
-    enum Style {
+    enum Style: Equatable {
         case body
         case title
         case preview
@@ -528,6 +815,27 @@ struct InlineContentText: UIViewRepresentable {
         TiebaEmoticon.cachedImage(for: code)
     }
 
+    fileprivate struct RenderKey: Equatable {
+        var blocks: [ContentBlock]
+        var style: Style
+        var readerFontSize: String
+        var readerLineSpacing: String
+        var prefix: String?
+        var prefixParts: [PrefixPart]
+        var highlightKeyword: String?
+        var userLinksEnabled: Bool
+        var fontName: String
+        var fontPointSize: CGFloat
+        var fontLineHeight: CGFloat
+    }
+
+    fileprivate struct RenderedContent {
+        var id: UInt
+        var attributedString: NSAttributedString
+        var accessibilityText: String
+        var emoticonImageNames: Set<String>
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(onOpenUser: onOpenUser, onPlainTextTap: onPlainTextTap)
     }
@@ -571,10 +879,12 @@ struct InlineContentText: UIViewRepresentable {
     }
 
     func updateUIView(_ textView: InlineContentTextView, context: Context) {
+        let rendered = renderedContent(using: context.coordinator)
         textView.accessibilityIdentifier = accessibilityIdentifier
-        textView.accessibilityValue = accessibilityText()
+        textView.accessibilityValue = rendered.accessibilityText
         textView.apply(
-            attributedText: attributedString(),
+            attributedText: rendered.attributedString,
+            renderID: rendered.id,
             maximumNumberOfLines: ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit),
             lineBreakMode: ThreadContentDisplayPolicy.lineBreakMode(for: lineLimit)
         )
@@ -588,6 +898,20 @@ struct InlineContentText: UIViewRepresentable {
         }
         context.coordinator.onOpenUser = onOpenUser
         context.coordinator.onPlainTextTap = onPlainTextTap
+        context.coordinator.observeArtwork(
+            imageNames: rendered.emoticonImageNames,
+            rerender: { [weak textView, weak coordinator = context.coordinator] in
+                guard let textView, let coordinator else { return }
+                let refreshedContent = renderedContent(using: coordinator)
+                textView.accessibilityValue = refreshedContent.accessibilityText
+                textView.apply(
+                    attributedText: refreshedContent.attributedString,
+                    renderID: refreshedContent.id,
+                    maximumNumberOfLines: ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit),
+                    lineBreakMode: ThreadContentDisplayPolicy.lineBreakMode(for: lineLimit)
+                )
+            }
+        )
     }
 
     func sizeThatFits(
@@ -598,9 +922,11 @@ struct InlineContentText: UIViewRepresentable {
         guard let width = proposal.width else {
             return nil
         }
+        let rendered = renderedContent(using: context.coordinator)
         return uiView.fittingSize(
             width: width,
-            attributedText: attributedString(),
+            attributedText: rendered.attributedString,
+            renderID: rendered.id,
             maximumNumberOfLines: ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit),
             lineBreakMode: ThreadContentDisplayPolicy.lineBreakMode(for: lineLimit)
         )
@@ -610,6 +936,12 @@ struct InlineContentText: UIViewRepresentable {
         weak var textView: InlineContentTextView?
         var onOpenUser: ((UserSummary) -> Void)?
         var onPlainTextTap: (() -> Void)?
+        private var observedArtworkImageNames: Set<String> = []
+        private var artworkNotificationToken: NSObjectProtocol?
+        private var rerenderArtwork: (() -> Void)?
+        private var cachedRenderKey: RenderKey?
+        private var cachedRenderedContent: RenderedContent?
+        private var nextRenderID: UInt = 0
 
         init(
             onOpenUser: ((UserSummary) -> Void)?,
@@ -617,6 +949,70 @@ struct InlineContentText: UIViewRepresentable {
         ) {
             self.onOpenUser = onOpenUser
             self.onPlainTextTap = onPlainTextTap
+        }
+
+        deinit {
+            stopObservingArtwork()
+        }
+
+        func observeArtwork(
+            imageNames: Set<String>,
+            rerender: @escaping () -> Void
+        ) {
+            observedArtworkImageNames = imageNames
+            rerenderArtwork = rerender
+            guard imageNames.isEmpty == false else {
+                stopObservingArtwork()
+                return
+            }
+            guard artworkNotificationToken == nil else { return }
+            artworkNotificationToken = NotificationCenter.default.addObserver(
+                forName: TiebaEmoticonArtwork.didChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let self,
+                      self.observedArtworkImageNames.isDisjoint(
+                        with: TiebaEmoticonArtwork.imageNames(from: notification)
+                      ) == false else {
+                    return
+                }
+                self.invalidateRenderedContent()
+                self.rerenderArtwork?()
+            }
+        }
+
+        fileprivate func renderedContent(
+            for key: RenderKey,
+            emoticonImageNames: Set<String>,
+            makeAttributedString: () -> NSAttributedString,
+            makeAccessibilityText: () -> String
+        ) -> RenderedContent {
+            if cachedRenderKey == key, let cachedRenderedContent {
+                return cachedRenderedContent
+            }
+            nextRenderID &+= 1
+            let content = RenderedContent(
+                id: nextRenderID,
+                attributedString: makeAttributedString(),
+                accessibilityText: makeAccessibilityText(),
+                emoticonImageNames: emoticonImageNames
+            )
+            cachedRenderKey = key
+            cachedRenderedContent = content
+            return content
+        }
+
+        private func invalidateRenderedContent() {
+            cachedRenderKey = nil
+            cachedRenderedContent = nil
+        }
+
+        private func stopObservingArtwork() {
+            if let artworkNotificationToken {
+                NotificationCenter.default.removeObserver(artworkNotificationToken)
+                self.artworkNotificationToken = nil
+            }
         }
 
         @objc func handlePlainTextTap(_ recognizer: UITapGestureRecognizer) {
@@ -642,6 +1038,32 @@ struct InlineContentText: UIViewRepresentable {
             UIApplication.shared.open(safeURL)
             return false
         }
+    }
+
+    private func renderedContent(using coordinator: Coordinator) -> RenderedContent {
+        coordinator.renderedContent(
+            for: renderKey,
+            emoticonImageNames: emoticonImageNames,
+            makeAttributedString: attributedString,
+            makeAccessibilityText: accessibilityText
+        )
+    }
+
+    private var renderKey: RenderKey {
+        let font = style.font(readerFontSize: readerFontSize)
+        return RenderKey(
+            blocks: blocks,
+            style: style,
+            readerFontSize: readerFontSize.rawValue,
+            readerLineSpacing: readerLineSpacing.rawValue,
+            prefix: prefix,
+            prefixParts: prefixParts,
+            highlightKeyword: highlightKeyword,
+            userLinksEnabled: onOpenUser != nil,
+            fontName: font.fontName,
+            fontPointSize: font.pointSize,
+            fontLineHeight: font.lineHeight
+        )
     }
 
     func attributedString() -> NSAttributedString {
@@ -811,6 +1233,13 @@ struct InlineContentText: UIViewRepresentable {
         return [.text(prefix)]
     }
 
+    private var emoticonImageNames: Set<String> {
+        Set(blocks.compactMap { block in
+            guard case let .emoticon(code) = block else { return nil }
+            return TiebaEmoticon.imageName(for: code)
+        })
+    }
+
     private static let threadAuthorBadgeTitle = " 楼主 "
 
     private func threadAuthorBadgeText(baseFont: UIFont, paragraph: NSParagraphStyle) -> NSAttributedString {
@@ -841,6 +1270,20 @@ enum InlineContentTextLayout {
     ) -> UIEdgeInsets {
         guard attributedText.length > 0 else { return .zero }
 
+        let scale = max(displayScale, 1)
+        let fractionalBaselineGuard: CGFloat = 1
+        let physicalPixel = 1 / scale
+        let rasterizationGuard = fractionalBaselineGuard + physicalPixel * 2
+        let baselineInsets = UIEdgeInsets(
+            top: rasterizationGuard,
+            left: 0,
+            bottom: rasterizationGuard,
+            right: 0
+        )
+        guard requiresGlyphOutlineMeasurement(attributedText.string) else {
+            return baselineInsets
+        }
+
         let line = CTLineCreateWithAttributedString(attributedText)
         var ascent: CGFloat = 0
         var descent: CGFloat = 0
@@ -849,7 +1292,6 @@ enum InlineContentTextLayout {
         let inkBounds = CTLineGetBoundsWithOptions(line, [.useGlyphPathBounds])
         let topOverflow = max(inkBounds.maxY - ascent, 0)
         let bottomOverflow = max(-inkBounds.minY - descent, 0)
-        let scale = max(displayScale, 1)
         // Glyph-path bounds are vector bounds. TextKit can shift a fallback
         // font's live baseline by as much as the adjacent logical point. One
         // physical pixel absorbs fractional raster rounding and a second keeps
@@ -858,10 +1300,6 @@ enum InlineContentTextLayout {
         // clip: on a 2x iPad, a plain 1pt inset leaves the last two pixels of a
         // tall script on the clipping boundary even though it is sufficient on
         // a 3x phone.
-        let fractionalBaselineGuard: CGFloat = 1
-        let physicalPixel = 1 / scale
-        let rasterizationGuard = fractionalBaselineGuard + physicalPixel * 2
-
         return UIEdgeInsets(
             top: ceil(topOverflow * scale) / scale + rasterizationGuard,
             left: 0,
@@ -875,6 +1313,12 @@ enum InlineContentTextLayout {
             && abs(lhs.left - rhs.left) < 0.01
             && abs(lhs.bottom - rhs.bottom) < 0.01
             && abs(lhs.right - rhs.right) < 0.01
+    }
+
+    static func requiresGlyphOutlineMeasurement(_ text: String) -> Bool {
+        text.unicodeScalars.contains {
+            CharacterSet.nonBaseCharacters.contains($0)
+        }
     }
 
     static func measuredHeight(

--- a/TiebaPure/Features/Thread/PostRowView.swift
+++ b/TiebaPure/Features/Thread/PostRowView.swift
@@ -111,6 +111,20 @@ struct PostRowView: View {
     }
 }
 
+extension PostRowView: Equatable {
+    static func == (lhs: PostRowView, rhs: PostRowView) -> Bool {
+        lhs.post == rhs.post
+            && lhs.threadTitle == rhs.threadTitle
+            && lhs.threadAuthorID == rhs.threadAuthorID
+            && lhs.isMainPost == rhs.isMainPost
+            && lhs.isLikeUpdating == rhs.isLikeUpdating
+            && (lhs.onOpenSubposts != nil) == (rhs.onOpenSubposts != nil)
+            && (lhs.onOpenUser != nil) == (rhs.onOpenUser != nil)
+            && (lhs.onToggleLike != nil) == (rhs.onToggleLike != nil)
+            && (lhs.onReply != nil) == (rhs.onReply != nil)
+    }
+}
+
 private enum UserNameCenterAlignment: AlignmentID {
     static func defaultValue(in context: ViewDimensions) -> CGFloat {
         context[VerticalAlignment.center]

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -8,7 +8,7 @@ struct ThreadDetailView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.readingPreferences) private var readingPreferences
-    @ObservedObject private var localThreadLibraryStore = LocalThreadLibraryStore.shared
+    private let localThreadLibraryStore = LocalThreadLibraryStore.shared
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     let account: Account?
     let threadID: Int64
@@ -366,8 +366,16 @@ struct ThreadDetailView: View {
     }
 
     private func handleDisappear() {
+        let readingPositionRequest = readingPersistenceRequest(allowWhileLoading: true)
         readingTrackingState.cancelPendingCommit()
-        recordVisibleReadingPositionIfNeeded(allowWhileLoading: true)
+        readingTrackingState.pendingAutomaticPageLoad = false
+        if let readingPositionRequest {
+            _ = Self.enqueueReadingPositionRequest(
+                readingPositionRequest,
+                threadID: threadID,
+                store: localThreadLibraryStore
+            )
+        }
         cancelContentNavigation()
         loadTask?.cancel()
         requestGeneration += 1
@@ -414,7 +422,6 @@ struct ThreadDetailView: View {
                     .frame(height: 32)
                     .accessibilityHidden(true)
             }
-            .scrollTargetLayout()
             .readableWidth()
         }
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
@@ -438,6 +445,7 @@ struct ThreadDetailView: View {
                     ? { openReplyComposer(for: mainPost) }
                     : nil
             )
+            .equatable()
             .padding(.bottom, TiebaPureTheme.Spacing.xs)
             .threadPreciseScrollAnchor(
                 post: mainPost,
@@ -474,7 +482,10 @@ struct ThreadDetailView: View {
 
     @ViewBuilder
     private var replyRowsContent: some View {
-        if replyPosts.isEmpty, isLoading == false {
+        let visibleReplyPosts = replyPosts
+        let visibleReplyCount = visibleReplyPosts.count
+
+        if visibleReplyPosts.isEmpty, isLoading == false {
             ReaderStateView.empty(
                 title: "暂无回复",
                 message: seeLz ? "这个帖子暂时没有楼主回复。" : "这个帖子暂时没有更多回复。",
@@ -484,7 +495,7 @@ struct ThreadDetailView: View {
             .frame(maxWidth: .infinity)
             .background(Color(uiColor: .systemBackground))
         } else {
-            ForEach(Array(replyPosts.enumerated()), id: \.element.id) { index, post in
+            ForEach(Array(visibleReplyPosts.enumerated()), id: \.element.id) { index, post in
                 PostRowView(
                     post: post,
                     threadAuthorID: threadAuthorID,
@@ -498,12 +509,21 @@ struct ThreadDetailView: View {
                         ? { openReplyComposer(for: post) }
                         : nil
                 )
+                .equatable()
                 .threadPreciseScrollAnchor(
                     post: post,
                     isEnabled: preciseScrollSession?.postID == post.id
                 )
                 .id(post.id)
-                .onAppear { prefetchRepliesIfNeeded(index: index) }
+                .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+                    readingPostVisibilityChanged(post.id, isVisible: isVisible)
+                    if isVisible {
+                        prefetchRepliesIfNeeded(
+                            index: index,
+                            totalCount: visibleReplyCount
+                        )
+                    }
+                }
             }
         }
     }
@@ -522,12 +542,19 @@ struct ThreadDetailView: View {
         }
     }
 
-    private func prefetchRepliesIfNeeded(index: Int) {
-        guard PaginationPrefetchPolicy.shouldLoadMore(
+    private func prefetchRepliesIfNeeded(index: Int, totalCount: Int) {
+        guard didLoad,
+              isLoading == false,
+              hasMore,
+              PaginationPrefetchPolicy.shouldLoadMore(
             currentIndex: index,
-            totalCount: replyPosts.count
+            totalCount: totalCount
         ) else { return }
-        requestLoadMore()
+        if readingTrackingState.isScrollIdle {
+            requestLoadMore()
+        } else {
+            readingTrackingState.pendingAutomaticPageLoad = true
+        }
     }
 
     private func changeSeeLz(_ value: Bool) {
@@ -591,14 +618,12 @@ struct ThreadDetailView: View {
     }
 
     private var favoriteToolbarButton: some View {
-        Button(action: toggleFavorite) {
-            Image(systemName: isFavorite ? "star.fill" : "star")
-        }
-        .disabled(threadPage == nil)
-        .accessibilityLabel(isFavorite ? "取消收藏帖子" : "收藏帖子")
-        .accessibilityValue(isFavorite ? "已收藏" : "未收藏")
-        .accessibilityHint(isFavorite ? "从本机帖子收藏中移除" : "保存到本机帖子收藏")
-        .accessibilityIdentifier("thread-favorite-button")
+        ThreadFavoriteToolbarButton(
+            store: localThreadLibraryStore,
+            threadID: threadID,
+            isEnabled: threadPage != nil,
+            onToggle: toggleFavorite
+        )
     }
 
     private var searchToolbarButton: some View {
@@ -732,12 +757,14 @@ struct ThreadDetailView: View {
 
     private var loadMoreRepliesButton: some View {
         Button(action: requestMoreReplies) {
-            Label("加载更多回复", systemImage: "arrow.down.circle")
+            Text("加载更多回复")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(.plain)
         .minTouchTarget()
-        .padding(.horizontal, TiebaPureTheme.Spacing.md)
+        .padding(.vertical, TiebaPureTheme.Spacing.xs)
         .accessibilityIdentifier("thread-replies-load-more")
     }
 
@@ -948,6 +975,7 @@ struct ThreadDetailView: View {
                 .contentShape(Rectangle())
             }
             .accessibilityIdentifier("thread-detail-scroll-view")
+            .scrollFrameProbeForUITests()
             .shortPullRefresh(
                 isEnabled: didLoad && isLoading == false,
                 surface: .grouped,
@@ -967,13 +995,11 @@ struct ThreadDetailView: View {
                 }
                 readingTrackingState.isScrollIdle = newPhase == .idle
                 if newPhase == .idle {
+                    requestPendingAutomaticPageLoadIfPossible()
                     scheduleReadingPositionCommit()
                 } else {
                     readingTrackingState.cancelPendingCommit()
                 }
-            }
-            .onScrollTargetVisibilityChange(idType: UInt64.self, threshold: 0.01) { postIDs in
-                updateVisibleReadingPostIDs(postIDs)
             }
             .onScrollGeometryChange(for: ThreadReadingScrollRegion.self) { geometry in
                 ThreadReadingScrollRegion.resolve(
@@ -1111,10 +1137,6 @@ struct ThreadDetailView: View {
             components.queryItems = [URLQueryItem(name: "see_lz", value: "1")]
         }
         return components.url!
-    }
-
-    private var isFavorite: Bool {
-        localThreadLibraryStore.isFavorite(threadID: threadID)
     }
 
     private func toggleFavorite() {
@@ -1271,50 +1293,119 @@ struct ThreadDetailView: View {
         preciseScrollRetryCount = 0
     }
 
-    private func updateVisibleReadingPostIDs(_ postIDs: [UInt64]) {
-        let normalized = postIDs.filter { $0 > 0 }
-        guard readingTrackingState.visiblePostIDs != normalized else { return }
-        readingTrackingState.visiblePostIDs = normalized
-        if readingTrackingState.isScrollIdle {
+    private func readingPostVisibilityChanged(_ postID: UInt64, isVisible: Bool) {
+        let didChange = isVisible
+            ? readingTrackingState.postBecameVisible(postID)
+            : readingTrackingState.postBecameHidden(postID)
+        guard didChange else { return }
+        if readingTrackingState.isScrollIdle,
+           readingTrackingState.didMoveAwayFromTop {
             scheduleReadingPositionCommit()
         }
     }
 
+    private func requestPendingAutomaticPageLoadIfPossible() {
+        let canLoad = didLoad &&
+            readingTrackingState.isScrollIdle &&
+            isLoading == false &&
+            hasMore
+        guard readingTrackingState.consumePendingAutomaticPageLoad(canLoad: canLoad) else {
+            return
+        }
+        requestLoadMore()
+    }
+
     private func scheduleReadingPositionCommit() {
         readingTrackingState.pendingCommitTask?.cancel()
+        let commitID = UUID()
+        readingTrackingState.pendingCommitID = commitID
         readingTrackingState.pendingCommitTask = Task { @MainActor in
+            defer {
+                if readingTrackingState.pendingCommitID == commitID {
+                    readingTrackingState.pendingCommitTask = nil
+                    readingTrackingState.pendingCommitID = nil
+                }
+            }
             do {
-                try await Task.sleep(for: .milliseconds(80))
+                try await Task.sleep(for: ThreadReadingPersistencePolicy.idleDelay)
             } catch {
                 return
             }
             guard readingTrackingState.isScrollIdle else { return }
-            recordVisibleReadingPositionIfNeeded()
-            readingTrackingState.pendingCommitTask = nil
+            await commitReadingStateIfNeeded()
         }
     }
 
-    private func recordVisibleReadingPositionIfNeeded(allowWhileLoading: Bool = false) {
+    private func commitReadingStateIfNeeded(allowWhileLoading: Bool = false) async {
+        guard let request = readingPersistenceRequest(
+            allowWhileLoading: allowWhileLoading
+        ) else { return }
+        let persistenceTask = Self.enqueueReadingPositionRequest(
+            request,
+            threadID: threadID,
+            store: localThreadLibraryStore
+        )
+        let didPersist = await persistenceTask.value
+        guard didPersist, Task.isCancelled == false else { return }
+
+        switch request {
+        case .clear:
+            savedReadingPosition = nil
+            readingTrackingState.lastRecordedPostID = nil
+            readingTrackingState.didMoveAwayFromTop = false
+        case let .record(postID, _):
+            readingTrackingState.lastRecordedPostID = postID
+        }
+    }
+
+    private func readingPersistenceRequest(
+        allowWhileLoading: Bool = false
+    ) -> ThreadReadingPositionRequest? {
+        switch ThreadReadingPersistencePolicy.intent(
+            scrollRegion: readingTrackingState.scrollRegion,
+            didMoveAwayFromTop: readingTrackingState.didMoveAwayFromTop
+        ) {
+        case .clear:
+            return .clear
+        case .record:
+            return visibleReadingPositionRequest(allowWhileLoading: allowWhileLoading)
+        case .none:
+            return nil
+        }
+    }
+
+    private func visibleReadingPositionRequest(
+        allowWhileLoading: Bool = false
+    ) -> ThreadReadingPositionRequest? {
         guard didLoad,
               allowWhileLoading || isLoading == false,
               readingTrackingState.scrollRegion == .away,
-              readingTrackingState.didMoveAwayFromTop else { return }
-        let visibleIDs = Set(readingTrackingState.visiblePostIDs)
+              readingTrackingState.didMoveAwayFromTop else { return nil }
         guard let postID = ThreadReadingVisibilityPolicy.bottomMostVisiblePostID(
             postIDsInDisplayOrder: posts.map(\.id),
-            visiblePostIDs: visibleIDs,
+            visiblePostIDs: readingTrackingState.visiblePostIDs,
             excludedPostID: mainPost?.id
         ),
               postID != readingTrackingState.lastRecordedPostID,
-              let post = posts.first(where: { $0.id == postID }) else { return }
+              let post = posts.first(where: { $0.id == postID }) else { return nil }
+        return .record(postID: post.id, floor: post.floor)
+    }
 
-        let didPersist = localThreadLibraryStore.recordReadingPosition(
-            threadID: threadID,
-            postID: post.id,
-            floor: post.floor
-        )
-        if didPersist {
-            readingTrackingState.lastRecordedPostID = post.id
+    @MainActor
+    private static func enqueueReadingPositionRequest(
+        _ request: ThreadReadingPositionRequest,
+        threadID: Int64,
+        store: LocalThreadLibraryStore
+    ) -> Task<Bool, Never> {
+        switch request {
+        case .clear:
+            return store.enqueueClearReadingPosition(threadID: threadID)
+        case let .record(postID, floor):
+            return store.enqueueReadingPosition(
+                threadID: threadID,
+                postID: postID,
+                floor: floor
+            )
         }
     }
 
@@ -1324,13 +1415,9 @@ struct ThreadDetailView: View {
             readingTrackingState.didMoveAwayFromTop = true
             return
         }
-        guard readingTrackingState.didMoveAwayFromTop, region == .top else { return }
-        guard localThreadLibraryStore.clearReadingPosition(threadID: threadID) else {
-            return
+        if region == .top, readingTrackingState.isScrollIdle {
+            scheduleReadingPositionCommit()
         }
-        savedReadingPosition = nil
-        readingTrackingState.lastRecordedPostID = nil
-        readingTrackingState.didMoveAwayFromTop = false
     }
 
     private func reload() async {
@@ -1339,6 +1426,7 @@ struct ThreadDetailView: View {
         // current container snapshot: if a page-1 refresh returns the same
         // IDs, SwiftUI is not required to publish visibility again.
         readingTrackingState.cancelPendingCommit()
+        readingTrackingState.pendingAutomaticPageLoad = false
         requestGeneration += 1
         isLoading = false
         nextPage = 1
@@ -1372,6 +1460,7 @@ struct ThreadDetailView: View {
         isLoading = true
         errorMessage = nil
         var continuation: LocallyFilteredPaginationDecision?
+        var didCompletePage = false
 
         do {
             let requestedPage = nextPage
@@ -1424,9 +1513,10 @@ struct ThreadDetailView: View {
                     } else if isResumingReadingPosition {
                         // The saved post no longer exists; fall back to the
                         // first page and forget the stale position.
-                        didResolveRequestedPost = localThreadLibraryStore.clearReadingPosition(
-                            threadID: threadID
-                        )
+                        didResolveRequestedPost = await localThreadLibraryStore
+                            .clearReadingPositionInBackground(
+                                threadID: threadID
+                            )
                     }
                     if didResolveRequestedPost {
                         if savedReadingPosition?.postID == requestedPostID {
@@ -1461,6 +1551,7 @@ struct ThreadDetailView: View {
                 serverHasMore: hasMore,
                 consecutiveHiddenPageCount: consecutiveHiddenPageCount
             )
+            didCompletePage = true
         } catch is CancellationError {
             guard generation == requestGeneration,
                   requestedSession == account?.sessionIdentity else { return }
@@ -1486,6 +1577,8 @@ struct ThreadDetailView: View {
                 generation: generation,
                 consecutiveHiddenPageCount: continuation.consecutiveHiddenPageCount
             )
+        } else if didCompletePage {
+            requestPendingAutomaticPageLoadIfPossible()
         }
     }
 
@@ -1616,6 +1709,29 @@ enum ThreadDetailSearchOpenRoutingPolicy {
     }
 }
 
+private struct ThreadFavoriteToolbarButton: View {
+    @ObservedObject var store: LocalThreadLibraryStore
+
+    let threadID: Int64
+    let isEnabled: Bool
+    let onToggle: () -> Void
+
+    private var isFavorite: Bool {
+        store.isFavorite(threadID: threadID)
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            Image(systemName: isFavorite ? "star.fill" : "star")
+        }
+        .disabled(isEnabled == false)
+        .accessibilityLabel(isFavorite ? "取消收藏帖子" : "收藏帖子")
+        .accessibilityValue(isFavorite ? "已收藏" : "未收藏")
+        .accessibilityHint(isFavorite ? "从本机帖子收藏中移除" : "保存到本机帖子收藏")
+        .accessibilityIdentifier("thread-favorite-button")
+    }
+}
+
 private enum ThreadDetailScrollCoordinateSpace {
     static let name = "thread-detail-refresh-scroll"
 }
@@ -1636,17 +1752,69 @@ enum ThreadReadingScrollRegion: Equatable, Sendable {
     }
 }
 
+enum ThreadReadingPersistenceIntent: Equatable, Sendable {
+    case none
+    case record
+    case clear
+}
+
+enum ThreadReadingPositionRequest: Equatable, Sendable {
+    case clear
+    case record(postID: UInt64, floor: Int)
+}
+
+enum ThreadReadingPersistencePolicy {
+    // A short quiet period keeps SwiftData work out of repeated flicks while
+    // still persisting promptly when the reader pauses.
+    static let idleDelay: Duration = .milliseconds(250)
+
+    static func intent(
+        scrollRegion: ThreadReadingScrollRegion,
+        didMoveAwayFromTop: Bool
+    ) -> ThreadReadingPersistenceIntent {
+        guard didMoveAwayFromTop else { return .none }
+        switch scrollRegion {
+        case .top:
+            return .clear
+        case .away:
+            return .record
+        case .nearTop:
+            return .none
+        }
+    }
+}
+
 final class ThreadReadingTrackingState {
-    var visiblePostIDs: [UInt64] = []
+    var visiblePostIDs: Set<UInt64> = []
     var isScrollIdle = true
     var scrollRegion: ThreadReadingScrollRegion = .top
     var lastRecordedPostID: UInt64?
     var didMoveAwayFromTop = false
     var pendingCommitTask: Task<Void, Never>?
+    var pendingCommitID: UUID?
+    var pendingAutomaticPageLoad = false
+
+    @discardableResult
+    func postBecameVisible(_ postID: UInt64) -> Bool {
+        guard postID > 0 else { return false }
+        return visiblePostIDs.insert(postID).inserted
+    }
+
+    @discardableResult
+    func postBecameHidden(_ postID: UInt64) -> Bool {
+        visiblePostIDs.remove(postID) != nil
+    }
+
+    func consumePendingAutomaticPageLoad(canLoad: Bool) -> Bool {
+        guard canLoad, pendingAutomaticPageLoad else { return false }
+        pendingAutomaticPageLoad = false
+        return true
+    }
 
     func cancelPendingCommit() {
         pendingCommitTask?.cancel()
         pendingCommitTask = nil
+        pendingCommitID = nil
     }
 
     func reset() {
@@ -1656,6 +1824,7 @@ final class ThreadReadingTrackingState {
         scrollRegion = .top
         lastRecordedPostID = nil
         didMoveAwayFromTop = false
+        pendingAutomaticPageLoad = false
     }
 }
 
@@ -2079,12 +2248,14 @@ private struct SubpostListSheet: View {
                                 Button {
                                     Task { await loadMore() }
                                 } label: {
-                                    Label("加载更多楼中楼回复", systemImage: "arrow.down.circle")
+                                    Text("加载更多楼中楼回复")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
                                         .frame(maxWidth: .infinity)
                                 }
-                                .buttonStyle(.bordered)
+                                .buttonStyle(.plain)
                                 .minTouchTarget()
-                                .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                                .padding(.vertical, TiebaPureTheme.Spacing.xs)
                                 .accessibilityIdentifier("subposts-load-more")
                             }
 

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -42,22 +42,19 @@ struct ThreadDetailView: View {
     @State private var pendingInitialPostID: UInt64?
     @State private var requestGeneration = 0
     @State private var loadTask: Task<ThreadPage, Error>?
-    @State private var scrollDistanceFromTop: CGFloat = 0
     @State private var showsInlineRefreshAnimation = false
     @State private var inlineRefreshAnimationToken = 0
     @State private var savedReadingPosition: ThreadReadingPosition?
     @State private var restoredReadingFloor: Int?
     @State private var showsRestoredReadingBanner = false
     @State private var restoredBannerHideTask: Task<Void, Never>?
-    @State private var scrollViewportHeight: CGFloat = 0
+    @State private var readingTrackingState = ThreadReadingTrackingState()
     @State private var didResolveSavedReadingPosition = false
     @State private var isResumingReadingPosition = false
     @State private var scrollRequest: ThreadPostScrollRequest?
-    @State private var pendingPreciseScrollPostID: UInt64?
+    @State private var preciseScrollSession: ThreadPreciseScrollSession?
     @State private var preciseScrollRetryCount = 0
-    @State private var preciseScrollDeadline: Date?
-    @State private var lastRecordedReadingPostID: UInt64?
-    @State private var didMoveAwayFromTop = false
+    @State private var preciseScrollTimeoutTask: Task<Void, Never>?
     @State private var updatingPostLikeIDs = Set<UInt64>()
     @State private var postLikeTasks: [UInt64: Task<Void, Never>] = [:]
     @State private var likeActionError: String?
@@ -336,16 +333,14 @@ struct ThreadDetailView: View {
         userResolutionError = nil
         showsInlineRefreshAnimation = false
         pendingInitialPostID = initialPostID
-        scrollDistanceFromTop = 0
         savedReadingPosition = nil
         didResolveSavedReadingPosition = false
         isResumingReadingPosition = false
         restoredReadingFloor = nil
         hideRestoredReadingBanner()
-        pendingPreciseScrollPostID = nil
+        cancelPreciseScroll()
         scrollRequest = nil
-        lastRecordedReadingPostID = nil
-        didMoveAwayFromTop = false
+        readingTrackingState.reset()
         cancelLikeTasks()
         likeActionError = nil
         contentActionError = nil
@@ -360,9 +355,19 @@ struct ThreadDetailView: View {
             currentPage.mainPost = currentPage.mainPost.flatMap(postApplyingCurrentBlocklist)
             threadPage = currentPage
         }
+        if let target = preciseScrollSession?.postID,
+           displayedPostIDs.contains(target) == false {
+            cancelPreciseScroll()
+        }
+    }
+
+    private var displayedPostIDs: Set<UInt64> {
+        Set(posts.map(\.id) + [threadPage?.mainPost?.id].compactMap { $0 })
     }
 
     private func handleDisappear() {
+        readingTrackingState.cancelPendingCommit()
+        recordVisibleReadingPositionIfNeeded(allowWhileLoading: true)
         cancelContentNavigation()
         loadTask?.cancel()
         requestGeneration += 1
@@ -371,6 +376,7 @@ struct ThreadDetailView: View {
         isResumingReadingPosition = false
         hideRestoredReadingBanner()
         scrollRequest = nil
+        cancelPreciseScroll()
         cancelLikeTasks()
         cancelUserResolution()
     }
@@ -408,6 +414,7 @@ struct ThreadDetailView: View {
                     .frame(height: 32)
                     .accessibilityHidden(true)
             }
+            .scrollTargetLayout()
             .readableWidth()
         }
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
@@ -432,7 +439,10 @@ struct ThreadDetailView: View {
                     : nil
             )
             .padding(.bottom, TiebaPureTheme.Spacing.xs)
-            .threadReadingAnchor(post: mainPost)
+            .threadPreciseScrollAnchor(
+                post: mainPost,
+                isEnabled: preciseScrollSession?.postID == mainPost.id
+            )
             .id(mainPost.id)
         }
     }
@@ -488,7 +498,10 @@ struct ThreadDetailView: View {
                         ? { openReplyComposer(for: post) }
                         : nil
                 )
-                .threadReadingAnchor(post: post)
+                .threadPreciseScrollAnchor(
+                    post: post,
+                    isEnabled: preciseScrollSession?.postID == post.id
+                )
                 .id(post.id)
                 .onAppear { prefetchRepliesIfNeeded(index: index) }
             }
@@ -944,21 +957,33 @@ struct ThreadDetailView: View {
                 await reload()
             }
             .coordinateSpace(name: ThreadDetailScrollCoordinateSpace.name)
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.height
-            } action: { height in
-                scrollViewportHeight = height
-            }
             .onPreferenceChange(ThreadPostViewportPreferenceKey.self) { entries in
-                recordReadingPositionIfNeeded(entries: Array(entries.values))
                 correctPendingPreciseScroll(entries: entries, proxy: scrollProxy)
             }
             .onScrollPhaseChange { _, newPhase in
-                guard newPhase == .tracking || newPhase == .interacting else { return }
-                pendingPreciseScrollPostID = nil
+                let isDirectInteraction = newPhase == .tracking || newPhase == .interacting
+                if isDirectInteraction {
+                    cancelPreciseScroll()
+                }
+                readingTrackingState.isScrollIdle = newPhase == .idle
+                if newPhase == .idle {
+                    scheduleReadingPositionCommit()
+                } else {
+                    readingTrackingState.cancelPendingCommit()
+                }
             }
-            .onChange(of: scrollDistanceFromTop) { distance in
-                handleReadingScrollDistanceChange(distance)
+            .onScrollTargetVisibilityChange(idType: UInt64.self, threshold: 0.01) { postIDs in
+                updateVisibleReadingPostIDs(postIDs)
+            }
+            .onScrollGeometryChange(for: ThreadReadingScrollRegion.self) { geometry in
+                ThreadReadingScrollRegion.resolve(
+                    distanceFromTop: ShortPullRefreshPolicy.distanceFromTop(
+                        contentOffsetY: geometry.contentOffset.y,
+                        topInset: geometry.contentInsets.top
+                    )
+                )
+            } action: { _, region in
+                handleReadingScrollRegionChange(region)
             }
             .onChange(of: scrollRequest) { request in
                 guard let request else { return }
@@ -972,7 +997,6 @@ struct ThreadDetailView: View {
                 guard let request = scrollRequest else { return }
                 performInitialScrollRequest(request, proxy: scrollProxy)
             }
-            .trackVerticalScrollDistanceFromTop($scrollDistanceFromTop)
         }
     }
 
@@ -1154,8 +1178,8 @@ struct ThreadDetailView: View {
     private func returnToTopFromRestoredPosition() {
         hideRestoredReadingBanner()
         guard let mainPost else { return }
-        // Reaching the top clears the stored position through the existing
-        // scroll-distance handler, so the next open starts from the beginning.
+        // Reaching the top clears the stored position through the scroll-region
+        // handler, so the next open starts from the beginning.
         requestScroll(to: mainPost.id)
     }
 
@@ -1168,6 +1192,7 @@ struct ThreadDetailView: View {
         _ request: ThreadPostScrollRequest,
         proxy: ScrollViewProxy
     ) {
+        cancelPreciseScroll()
         DispatchQueue.main.async {
             if reduceMotion {
                 proxy.scrollTo(request.postID, anchor: .top)
@@ -1191,14 +1216,25 @@ struct ThreadDetailView: View {
         _ request: ThreadPostScrollRequest,
         proxy: ScrollViewProxy
     ) {
-        pendingPreciseScrollPostID = request.postID
+        cancelPreciseScroll()
+        let session = ThreadPreciseScrollSession(postID: request.postID)
+        preciseScrollSession = session
         preciseScrollRetryCount = 0
-        preciseScrollDeadline = Date().addingTimeInterval(1.5)
-        DispatchQueue.main.async {
-            proxy.scrollTo(request.postID, anchor: .top)
-            if scrollRequest?.id == request.id {
-                scrollRequest = nil
+        if scrollRequest?.id == request.id {
+            scrollRequest = nil
+        }
+        preciseScrollTimeoutTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .milliseconds(1_500))
+            } catch {
+                return
             }
+            guard preciseScrollSession == session else { return }
+            cancelPreciseScroll()
+        }
+        DispatchQueue.main.async {
+            guard preciseScrollSession == session else { return }
+            proxy.scrollTo(session.postID, anchor: .top)
         }
     }
 
@@ -1210,66 +1246,99 @@ struct ThreadDetailView: View {
         entries: [UInt64: ThreadPostViewportEntry],
         proxy: ScrollViewProxy
     ) {
-        guard let target = pendingPreciseScrollPostID else { return }
-        if let deadline = preciseScrollDeadline, Date() > deadline {
-            pendingPreciseScrollPostID = nil
-            preciseScrollDeadline = nil
-            return
-        }
+        guard let session = preciseScrollSession else { return }
+        let target = session.postID
         guard preciseScrollRetryCount < 12 else {
-            pendingPreciseScrollPostID = nil
+            cancelPreciseScroll()
             return
         }
-        guard let entry = entries[target], entry.minY.isFinite,
-              abs(entry.minY) > 4 else { return }
+        guard let entry = entries[target], entry.minY.isFinite else { return }
+        // Being aligned once is not terminal: content above the target can
+        // still settle and move it again. Keep the single target anchor alive
+        // until the independent timeout or a direct user interaction ends it.
+        guard abs(entry.minY) > 4 else { return }
         preciseScrollRetryCount += 1
         DispatchQueue.main.async {
+            guard preciseScrollSession == session else { return }
             proxy.scrollTo(target, anchor: .top)
         }
     }
 
-    private func recordReadingPositionIfNeeded(entries: [ThreadPostViewportEntry]) {
-        // Screen height over-approximates the viewport until the geometry
-        // callback delivers the real one; both only bound the visibility test.
-        let viewportHeight = scrollViewportHeight > 0
-            ? scrollViewportHeight
-            : UIScreen.main.bounds.height
-        guard didLoad,
-              let entry = ThreadReadingViewportPolicy.position(
-                entries: entries,
-                scrollDistanceFromTop: scrollDistanceFromTop,
-                viewportHeight: viewportHeight,
-                excludedPostID: mainPost?.id
-              ),
-              entry.postID != lastRecordedReadingPostID else { return }
+    private func cancelPreciseScroll() {
+        preciseScrollTimeoutTask?.cancel()
+        preciseScrollTimeoutTask = nil
+        preciseScrollSession = nil
+        preciseScrollRetryCount = 0
+    }
 
-        let didPersist = localThreadLibraryStore.recordReadingPosition(
-            threadID: threadID,
-            postID: entry.postID,
-            floor: entry.floor
-        )
-        if didPersist {
-            lastRecordedReadingPostID = entry.postID
+    private func updateVisibleReadingPostIDs(_ postIDs: [UInt64]) {
+        let normalized = postIDs.filter { $0 > 0 }
+        guard readingTrackingState.visiblePostIDs != normalized else { return }
+        readingTrackingState.visiblePostIDs = normalized
+        if readingTrackingState.isScrollIdle {
+            scheduleReadingPositionCommit()
         }
     }
 
-    private func handleReadingScrollDistanceChange(_ distance: CGFloat) {
-        if distance >= ThreadReadingViewportPolicy.minimumRecordingDistance {
-            didMoveAwayFromTop = true
+    private func scheduleReadingPositionCommit() {
+        readingTrackingState.pendingCommitTask?.cancel()
+        readingTrackingState.pendingCommitTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .milliseconds(80))
+            } catch {
+                return
+            }
+            guard readingTrackingState.isScrollIdle else { return }
+            recordVisibleReadingPositionIfNeeded()
+            readingTrackingState.pendingCommitTask = nil
+        }
+    }
+
+    private func recordVisibleReadingPositionIfNeeded(allowWhileLoading: Bool = false) {
+        guard didLoad,
+              allowWhileLoading || isLoading == false,
+              readingTrackingState.scrollRegion == .away,
+              readingTrackingState.didMoveAwayFromTop else { return }
+        let visibleIDs = Set(readingTrackingState.visiblePostIDs)
+        guard let postID = ThreadReadingVisibilityPolicy.bottomMostVisiblePostID(
+            postIDsInDisplayOrder: posts.map(\.id),
+            visiblePostIDs: visibleIDs,
+            excludedPostID: mainPost?.id
+        ),
+              postID != readingTrackingState.lastRecordedPostID,
+              let post = posts.first(where: { $0.id == postID }) else { return }
+
+        let didPersist = localThreadLibraryStore.recordReadingPosition(
+            threadID: threadID,
+            postID: post.id,
+            floor: post.floor
+        )
+        if didPersist {
+            readingTrackingState.lastRecordedPostID = post.id
+        }
+    }
+
+    private func handleReadingScrollRegionChange(_ region: ThreadReadingScrollRegion) {
+        readingTrackingState.scrollRegion = region
+        if region == .away {
+            readingTrackingState.didMoveAwayFromTop = true
             return
         }
-        guard didMoveAwayFromTop,
-              ShortPullRefreshPolicy.isAtTop(distanceFromTop: distance) else { return }
+        guard readingTrackingState.didMoveAwayFromTop, region == .top else { return }
         guard localThreadLibraryStore.clearReadingPosition(threadID: threadID) else {
             return
         }
         savedReadingPosition = nil
-        lastRecordedReadingPostID = nil
-        didMoveAwayFromTop = false
+        readingTrackingState.lastRecordedPostID = nil
+        readingTrackingState.didMoveAwayFromTop = false
     }
 
     private func reload() async {
         loadTask?.cancel()
+        // Stop the pending write before changing the request key. Keep the
+        // current container snapshot: if a page-1 refresh returns the same
+        // IDs, SwiftUI is not required to publish visibility again.
+        readingTrackingState.cancelPendingCommit()
         requestGeneration += 1
         isLoading = false
         nextPage = 1
@@ -1342,7 +1411,10 @@ struct ThreadDetailView: View {
                     )
                 }
                 if let requestedPostID {
-                    let loadedPostIDs = Set(loaded.posts.map(\.id) + [loaded.mainPost?.id].compactMap { $0 })
+                    let loadedPostIDs = Set(
+                        visiblePage.posts.map(\.id)
+                            + [visiblePage.mainPost?.id].compactMap { $0 }
+                    )
                     var didResolveRequestedPost = true
                     if loadedPostIDs.contains(requestedPostID) {
                         requestScroll(to: requestedPostID)
@@ -1548,6 +1620,67 @@ private enum ThreadDetailScrollCoordinateSpace {
     static let name = "thread-detail-refresh-scroll"
 }
 
+enum ThreadReadingScrollRegion: Equatable, Sendable {
+    case top
+    case nearTop
+    case away
+
+    static func resolve(distanceFromTop: CGFloat) -> Self {
+        if ShortPullRefreshPolicy.isAtTop(distanceFromTop: distanceFromTop) {
+            return .top
+        }
+        if distanceFromTop >= ThreadReadingViewportPolicy.minimumRecordingDistance {
+            return .away
+        }
+        return .nearTop
+    }
+}
+
+final class ThreadReadingTrackingState {
+    var visiblePostIDs: [UInt64] = []
+    var isScrollIdle = true
+    var scrollRegion: ThreadReadingScrollRegion = .top
+    var lastRecordedPostID: UInt64?
+    var didMoveAwayFromTop = false
+    var pendingCommitTask: Task<Void, Never>?
+
+    func cancelPendingCommit() {
+        pendingCommitTask?.cancel()
+        pendingCommitTask = nil
+    }
+
+    func reset() {
+        cancelPendingCommit()
+        visiblePostIDs = []
+        isScrollIdle = true
+        scrollRegion = .top
+        lastRecordedPostID = nil
+        didMoveAwayFromTop = false
+    }
+}
+
+struct ThreadPreciseScrollSession: Equatable, Sendable {
+    let id: UUID
+    let postID: UInt64
+
+    init(id: UUID = UUID(), postID: UInt64) {
+        self.id = id
+        self.postID = postID
+    }
+}
+
+enum ThreadReadingVisibilityPolicy {
+    static func bottomMostVisiblePostID(
+        postIDsInDisplayOrder: [UInt64],
+        visiblePostIDs: Set<UInt64>,
+        excludedPostID: UInt64?
+    ) -> UInt64? {
+        postIDsInDisplayOrder.last {
+            $0 > 0 && $0 != excludedPostID && visiblePostIDs.contains($0)
+        }
+    }
+}
+
 struct ThreadPostViewportEntry: Equatable, Sendable {
     var postID: UInt64
     var floor: Int
@@ -1557,30 +1690,6 @@ struct ThreadPostViewportEntry: Equatable, Sendable {
 
 enum ThreadReadingViewportPolicy {
     static let minimumRecordingDistance: CGFloat = 44
-
-    /// Returns the bottom-most reply visible in the viewport. Floors are not
-    /// part of the condition: hot-sorted responses omit floor numbers, and the
-    /// position is restored by post ID. The main post is excluded so a long
-    /// first floor never records a position of its own.
-    static func position(
-        entries: [ThreadPostViewportEntry],
-        scrollDistanceFromTop: CGFloat,
-        viewportHeight: CGFloat,
-        excludedPostID: UInt64?
-    ) -> ThreadPostViewportEntry? {
-        guard scrollDistanceFromTop >= minimumRecordingDistance,
-              viewportHeight > 0 else { return nil }
-        return entries
-            .filter { entry in
-                entry.postID > 0
-                    && entry.postID != excludedPostID
-                    && entry.minY.isFinite
-                    && entry.maxY.isFinite
-                    && entry.minY < viewportHeight
-                    && entry.maxY > 0
-            }
-            .max(by: { $0.maxY < $1.maxY })
-    }
 }
 
 private struct ThreadPostScrollRequest: Equatable {
@@ -1600,22 +1709,27 @@ private struct ThreadPostViewportPreferenceKey: PreferenceKey {
 }
 
 private extension View {
-    func threadReadingAnchor(post: Post) -> some View {
-        background {
-            GeometryReader { proxy in
-                let frame = proxy.frame(in: .named(ThreadDetailScrollCoordinateSpace.name))
-                Color.clear.preference(
-                    key: ThreadPostViewportPreferenceKey.self,
-                    value: [
-                        post.id: ThreadPostViewportEntry(
-                            postID: post.id,
-                            floor: post.floor,
-                            minY: frame.minY,
-                            maxY: frame.maxY
-                        )
-                    ]
-                )
+    @ViewBuilder
+    func threadPreciseScrollAnchor(post: Post, isEnabled: Bool) -> some View {
+        if isEnabled {
+            background {
+                GeometryReader { proxy in
+                    let frame = proxy.frame(in: .named(ThreadDetailScrollCoordinateSpace.name))
+                    Color.clear.preference(
+                        key: ThreadPostViewportPreferenceKey.self,
+                        value: [
+                            post.id: ThreadPostViewportEntry(
+                                postID: post.id,
+                                floor: post.floor,
+                                minY: frame.minY,
+                                maxY: frame.maxY
+                            )
+                        ]
+                    )
+                }
             }
+        } else {
+            self
         }
     }
 }

--- a/TiebaPureTests/EmoticonResourceTests.swift
+++ b/TiebaPureTests/EmoticonResourceTests.swift
@@ -181,7 +181,9 @@ final class EmoticonResourceTests: XCTestCase {
         let repository = TiebaEmoticonRepository(
             cache: cache,
             downloader: downloader,
-            onArtworkAvailable: { await notifications.record() }
+            onArtworkAvailable: { imageName in
+                await notifications.record(imageName)
+            }
         )
 
         async let first = repository.fetch("image_emoticon25")
@@ -190,10 +192,12 @@ final class EmoticonResourceTests: XCTestCase {
         let results = await [first, second, third]
         let requestCount = await downloader.requestCount()
         let notificationCount = await notifications.count()
+        let notifiedImageNames = await notifications.recordedImageNames()
 
         XCTAssertEqual(results, [true, true, true])
         XCTAssertEqual(requestCount, 1)
         XCTAssertEqual(notificationCount, 1)
+        XCTAssertEqual(notifiedImageNames, ["image_emoticon25"])
         XCTAssertNotNil(cache.image(for: "image_emoticon25"))
     }
 
@@ -208,7 +212,9 @@ final class EmoticonResourceTests: XCTestCase {
         let repository = TiebaEmoticonRepository(
             cache: reader,
             downloader: downloader,
-            onArtworkAvailable: { await notifications.record() }
+            onArtworkAvailable: { imageName in
+                await notifications.record(imageName)
+            }
         )
 
         XCTAssertNil(reader.memoryImage(for: "image_emoticon25"))
@@ -219,6 +225,25 @@ final class EmoticonResourceTests: XCTestCase {
         XCTAssertNotNil(reader.memoryImage(for: "image_emoticon25"))
         XCTAssertEqual(requestCount, 0)
         XCTAssertEqual(notificationCount, 1)
+    }
+
+    @MainActor
+    func testArtworkObserversOnlyRefreshForMatchingCoalescedImageNames() async {
+        let first = TiebaEmoticonArtworkObserver(imageNames: ["image_emoticon1"])
+        let second = TiebaEmoticonArtworkObserver(imageNames: ["image_emoticon2"])
+
+        TiebaEmoticonArtwork.shared.didFetch("image_emoticon1")
+        TiebaEmoticonArtwork.shared.didFetch("image_emoticon1")
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(first.revision, 1)
+        XCTAssertEqual(second.revision, 0)
+
+        TiebaEmoticonArtwork.shared.didFetch("image_emoticon2")
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(first.revision, 1)
+        XCTAssertEqual(second.revision, 1)
     }
 
     func testRepositorySuppressesFailureUntilFiniteRetryDeadline() async throws {
@@ -463,8 +488,13 @@ private actor EmoticonDownloaderStub: TiebaEmoticonDownloading {
 
 private actor EmoticonNotificationRecorder {
     private var value = 0
-    func record() { value += 1 }
+    private var imageNames: [String] = []
+    func record(_ imageName: String) {
+        value += 1
+        imageNames.append(imageName)
+    }
     func count() -> Int { value }
+    func recordedImageNames() -> [String] { imageNames }
 }
 
 private final class EmoticonTestClock: @unchecked Sendable {

--- a/TiebaPureTests/SecurityRegressionTests.swift
+++ b/TiebaPureTests/SecurityRegressionTests.swift
@@ -10,6 +10,7 @@ final class SecurityRegressionTests: XCTestCase {
         SecurityURLProtocol.delay = 0
         SecurityURLProtocol.chunkDelay = 0
         SecurityURLProtocol.declaredContentLength = nil
+        SecurityURLProtocol.resetMetrics()
         super.tearDown()
     }
 
@@ -264,11 +265,140 @@ final class SecurityRegressionTests: XCTestCase {
         }
     }
 
+    func testImageMetadataUsesBodyFreeHeadWithoutRangeFallback() async throws {
+        SecurityURLProtocol.payload = Data()
+        SecurityURLProtocol.mimeType = "image/jpeg"
+        SecurityURLProtocol.declaredContentLength = 3_670_016
+        let client = TiebaImageMetadataClient(session: Self.session())
+        let url = try XCTUnwrap(URL(string: "https://example.com/original.jpg"))
+
+        let contentLength = try await client.contentLength(from: url)
+
+        XCTAssertEqual(contentLength, 3_670_016)
+        XCTAssertEqual(SecurityURLProtocol.startCount, 1)
+        XCTAssertEqual(SecurityURLProtocol.lastRequestMethod, "HEAD")
+        XCTAssertNil(SecurityURLProtocol.lastRangeHeader)
+    }
+
     func testImageDecodePolicyRejectsPixelBombDimensions() {
         XCTAssertTrue(TiebaImageDecodePolicy.allows(width: 4_096, height: 4_096))
+        XCTAssertEqual(TiebaImageDecodePolicy.maximumPreviewDecodedPixelSize, 2_560)
+        XCTAssertEqual(TiebaImageDecodePolicy.maximumPreviewDisplayScale, 3)
+        XCTAssertEqual(
+            TiebaImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 36, height: 36),
+                displayScale: 3
+            ),
+            128
+        )
+        XCTAssertEqual(
+            TiebaImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 180, height: 120),
+                displayScale: 3
+            ),
+            640
+        )
+        XCTAssertEqual(
+            TiebaImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 1_024, height: 768),
+                displayScale: 3
+            ),
+            2_560
+        )
         XCTAssertFalse(TiebaImageDecodePolicy.allows(width: 100_000, height: 1))
         XCTAssertFalse(TiebaImageDecodePolicy.allows(width: 20_000, height: 20_000))
         XCTAssertFalse(TiebaImageDecodePolicy.allows(width: Int.max, height: 2))
+    }
+
+    @MainActor
+    func testImagePipelineDownsamplesEachRequestedPreviewTier() async throws {
+        SecurityURLProtocol.payload = try XCTUnwrap(Self.largePNGData())
+        SecurityURLProtocol.mimeType = "image/png"
+        let pipeline = Self.imagePipeline()
+        let url = try XCTUnwrap(URL(string: "https://example.com/large-preview.png"))
+
+        let small = try await pipeline.image(from: [url], targetPixelSize: 128)
+        let medium = try await pipeline.image(from: [url], targetPixelSize: 512)
+
+        XCTAssertLessThanOrEqual(max(
+            try XCTUnwrap(small.cgImage).width,
+            try XCTUnwrap(small.cgImage).height
+        ), 128)
+        XCTAssertLessThanOrEqual(max(
+            try XCTUnwrap(medium.cgImage).width,
+            try XCTUnwrap(medium.cgImage).height
+        ), 512)
+        XCTAssertGreaterThan(
+            max(try XCTUnwrap(medium.cgImage).width, try XCTUnwrap(medium.cgImage).height),
+            max(try XCTUnwrap(small.cgImage).width, try XCTUnwrap(small.cgImage).height)
+        )
+        XCTAssertEqual(SecurityURLProtocol.startCount, 2)
+    }
+
+    func testImagePipelineCancelsDownloadAfterLastWaiterLeaves() async throws {
+        SecurityURLProtocol.payload = Self.onePixelPNGData
+        SecurityURLProtocol.mimeType = "image/png"
+        SecurityURLProtocol.delay = 5
+        let pipeline = Self.imagePipeline()
+        let url = try XCTUnwrap(URL(string: "https://example.com/cancelled-preview.png"))
+        let task = Task {
+            try await pipeline.image(from: [url], targetPixelSize: 128)
+        }
+
+        try await Self.waitForImageRequestStart()
+        task.cancel()
+        try await Self.waitForImageRequestStop()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .cancelled)
+        }
+        XCTAssertEqual(SecurityURLProtocol.startCount, 1)
+        XCTAssertEqual(SecurityURLProtocol.stopCount, 1)
+    }
+
+    @MainActor
+    func testImagePipelineKeepsSharedDownloadUntilEveryWaiterLeaves() async throws {
+        SecurityURLProtocol.payload = Self.onePixelPNGData
+        SecurityURLProtocol.mimeType = "image/png"
+        SecurityURLProtocol.delay = 1
+        let pipeline = Self.imagePipeline()
+        let url = try XCTUnwrap(URL(string: "https://example.com/shared-preview.png"))
+        let first = Task {
+            try await pipeline.image(from: [url], targetPixelSize: 128)
+        }
+        let second = Task {
+            try await pipeline.image(from: [url], targetPixelSize: 128)
+        }
+
+        try await Self.waitForImageWaiterCount(2, pipeline: pipeline)
+        first.cancel()
+        let cancelled = expectation(description: "Cancelled waiter returns before shared response")
+        Task {
+            do {
+                _ = try await first.value
+                XCTFail("Cancelled waiter unexpectedly succeeded")
+                cancelled.fulfill()
+            } catch is CancellationError {
+                cancelled.fulfill()
+            } catch let error as URLError where error.code == .cancelled {
+                cancelled.fulfill()
+            } catch {
+                XCTFail("Unexpected cancellation error: \(error)")
+            }
+        }
+
+        await fulfillment(of: [cancelled], timeout: 0.4)
+        XCTAssertEqual(SecurityURLProtocol.stopCount, 0)
+        let remainingWaiters = await pipeline.inFlightWaiterCountForTesting()
+        XCTAssertEqual(remainingWaiters, 1)
+
+        let image = try await second.value
+        XCTAssertNotNil(image.cgImage)
+        XCTAssertEqual(SecurityURLProtocol.startCount, 1)
     }
 
     func testImageDownloadValidatesDataAndUsesDetectedFileType() async throws {
@@ -428,6 +558,57 @@ final class SecurityRegressionTests: XCTestCase {
         configuration.protocolClasses = [SecurityURLProtocol.self]
         return URLSession(configuration: configuration)
     }
+
+    private static func imagePipeline() -> TiebaImagePipeline {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [SecurityURLProtocol.self]
+        configuration.urlCache = URLCache(
+            memoryCapacity: 1 * 1_024 * 1_024,
+            diskCapacity: 0,
+            diskPath: nil
+        )
+        return TiebaImagePipeline(configuration: configuration)
+    }
+
+    @MainActor
+    private static func largePNGData() -> Data? {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 1_024, height: 768))
+        return renderer.image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 1_024, height: 768))
+        }.pngData()
+    }
+
+    private static let onePixelPNGData = Data(base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )!
+
+    private static func waitForImageRequestStart() async throws {
+        for _ in 0..<100 {
+            if SecurityURLProtocol.startCount > 0 { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for image request to start")
+    }
+
+    private static func waitForImageRequestStop() async throws {
+        for _ in 0..<100 {
+            if SecurityURLProtocol.stopCount > 0 { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for image request cancellation")
+    }
+
+    private static func waitForImageWaiterCount(
+        _ expectedCount: Int,
+        pipeline: TiebaImagePipeline
+    ) async throws {
+        for _ in 0..<100 {
+            if await pipeline.inFlightWaiterCountForTesting() == expectedCount { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for \(expectedCount) image waiters")
+    }
 }
 
 private final class InMemoryKeychainSecurityOperations: KeychainSecurityOperating, @unchecked Sendable {
@@ -511,6 +692,11 @@ private final class SecurityURLProtocol: URLProtocol {
     static var chunkDelay: TimeInterval = 0
     static var declaredContentLength: Int?
     static var lastRequestURL: URL?
+    private static let metricsLock = NSLock()
+    private static var recordedStartCount = 0
+    private static var recordedStopCount = 0
+    private static var recordedLastRequestMethod: String?
+    private static var recordedLastRangeHeader: String?
     private let stateLock = NSLock()
     private var workItems: [DispatchWorkItem] = []
     private var stopped = false
@@ -518,7 +704,37 @@ private final class SecurityURLProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+    static var startCount: Int {
+        metricsLock.withLock { recordedStartCount }
+    }
+
+    static var stopCount: Int {
+        metricsLock.withLock { recordedStopCount }
+    }
+
+    static var lastRequestMethod: String? {
+        metricsLock.withLock { recordedLastRequestMethod }
+    }
+
+    static var lastRangeHeader: String? {
+        metricsLock.withLock { recordedLastRangeHeader }
+    }
+
+    static func resetMetrics() {
+        metricsLock.withLock {
+            recordedStartCount = 0
+            recordedStopCount = 0
+            recordedLastRequestMethod = nil
+            recordedLastRangeHeader = nil
+        }
+    }
+
     override func startLoading() {
+        Self.metricsLock.withLock {
+            Self.recordedStartCount += 1
+            Self.recordedLastRequestMethod = request.httpMethod
+            Self.recordedLastRangeHeader = request.value(forHTTPHeaderField: "Range")
+        }
         Self.lastRequestURL = request.url
         let payload = Self.payload
         let chunks = Self.chunks ?? [payload]
@@ -554,6 +770,7 @@ private final class SecurityURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {
+        Self.metricsLock.withLock { Self.recordedStopCount += 1 }
         stateLock.lock()
         stopped = true
         let items = workItems

--- a/TiebaPureTests/StateRegressionTests.swift
+++ b/TiebaPureTests/StateRegressionTests.swift
@@ -495,6 +495,76 @@ final class StateRegressionTests: XCTestCase {
     }
 
     @MainActor
+    func testReadingPositionBackgroundQueuePreservesMutationOrder() async throws {
+        let container = try makeInMemoryModelContainer()
+        let defaults = try makeScratchDefaults()
+        var tick: TimeInterval = 0
+        let store = LocalThreadLibraryStore(
+            defaults: defaults,
+            favoritesKey: "background-favorites",
+            readingPositionsKey: "background-positions",
+            favoriteLimit: 4,
+            readingPositionLimit: 4,
+            modelContainer: container
+        ) {
+            tick += 1
+            return Date(timeIntervalSince1970: tick)
+        }
+
+        let firstPosition = store.enqueueReadingPosition(
+            threadID: 1,
+            postID: 1_001,
+            floor: 1
+        )
+        let newerPosition = store.enqueueReadingPosition(
+            threadID: 1,
+            postID: 1_002,
+            floor: 2
+        )
+        let firstPositionSucceeded = await firstPosition.value
+        let newerPositionSucceeded = await newerPosition.value
+        XCTAssertTrue(firstPositionSucceeded)
+        XCTAssertTrue(newerPositionSucceeded)
+        XCTAssertEqual(store.position(for: 1)?.postID, 1_002)
+
+        let pendingInsert = store.enqueueReadingPosition(
+            threadID: 2,
+            postID: 2_001,
+            floor: 3
+        )
+        let deleteAfterPendingInsert = store.enqueueClearReadingPosition(threadID: 2)
+        let pendingInsertSucceeded = await pendingInsert.value
+        let deleteAfterPendingInsertSucceeded = await deleteAfterPendingInsert.value
+        XCTAssertTrue(pendingInsertSucceeded)
+        XCTAssertTrue(deleteAfterPendingInsertSucceeded)
+        XCTAssertNil(store.position(for: 2))
+
+        let pendingDelete = store.enqueueClearReadingPosition(threadID: 1)
+        let insertAfterPendingDelete = store.enqueueReadingPosition(
+            threadID: 1,
+            postID: 1_002,
+            floor: 2
+        )
+        let pendingDeleteSucceeded = await pendingDelete.value
+        let insertAfterPendingDeleteSucceeded = await insertAfterPendingDelete.value
+        XCTAssertTrue(pendingDeleteSucceeded)
+        XCTAssertTrue(insertAfterPendingDeleteSucceeded)
+        await store.waitForPendingReadingPositionMutations()
+        XCTAssertEqual(store.position(for: 1)?.postID, 1_002)
+
+        let reloaded = LocalThreadLibraryStore(
+            defaults: defaults,
+            favoritesKey: "background-favorites",
+            readingPositionsKey: "background-positions",
+            favoriteLimit: 4,
+            readingPositionLimit: 4,
+            modelContainer: container
+        )
+        XCTAssertEqual(reloaded.readingPositions.map(\.threadID), [1])
+        XCTAssertEqual(reloaded.position(for: 1)?.postID, 1_002)
+    }
+
+    @MainActor
     func testReadingPositionUpdatesRowsInPlaceAndPrunesOnlyTheOldestRecord() throws {
         let container = try makeInMemoryModelContainer()
         let defaults = try makeScratchDefaults()
@@ -1457,6 +1527,37 @@ final class StateRegressionTests: XCTestCase {
         )
     }
 
+    func testThreadReadingPersistenceWaitsForIdleAndSelectsOneAction() {
+        XCTAssertEqual(
+            ThreadReadingPersistencePolicy.intent(
+                scrollRegion: .away,
+                didMoveAwayFromTop: true
+            ),
+            .record
+        )
+        XCTAssertEqual(
+            ThreadReadingPersistencePolicy.intent(
+                scrollRegion: .top,
+                didMoveAwayFromTop: true
+            ),
+            .clear
+        )
+        XCTAssertEqual(
+            ThreadReadingPersistencePolicy.intent(
+                scrollRegion: .nearTop,
+                didMoveAwayFromTop: true
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            ThreadReadingPersistencePolicy.intent(
+                scrollRegion: .away,
+                didMoveAwayFromTop: false
+            ),
+            .none
+        )
+    }
+
     func testThreadReadingTrackingCancelsPendingCommitWithoutDiscardingViewport() {
         let state = ThreadReadingTrackingState()
         state.visiblePostIDs = [2002, 2003]
@@ -1474,6 +1575,31 @@ final class StateRegressionTests: XCTestCase {
         XCTAssertTrue(state.didMoveAwayFromTop)
     }
 
+    func testThreadReadingTrackingUsesViewportVisibilityWithoutDuplicates() {
+        let state = ThreadReadingTrackingState()
+
+        XCTAssertTrue(state.postBecameVisible(2002))
+        XCTAssertTrue(state.postBecameVisible(2003))
+        XCTAssertFalse(state.postBecameVisible(2002))
+        XCTAssertFalse(state.postBecameVisible(0))
+        XCTAssertEqual(state.visiblePostIDs, [2002, 2003])
+
+        XCTAssertTrue(state.postBecameHidden(2002))
+        XCTAssertFalse(state.postBecameHidden(2002))
+        XCTAssertEqual(state.visiblePostIDs, [2003])
+    }
+
+    func testThreadReadingTrackingKeepsDeferredPageLoadUntilItCanStart() {
+        let state = ThreadReadingTrackingState()
+        XCTAssertFalse(state.consumePendingAutomaticPageLoad(canLoad: true))
+
+        state.pendingAutomaticPageLoad = true
+        XCTAssertFalse(state.consumePendingAutomaticPageLoad(canLoad: false))
+        XCTAssertTrue(state.pendingAutomaticPageLoad)
+        XCTAssertTrue(state.consumePendingAutomaticPageLoad(canLoad: true))
+        XCTAssertFalse(state.consumePendingAutomaticPageLoad(canLoad: true))
+    }
+
     func testThreadReadingTrackingResetClearsViewportAndRegion() {
         let state = ThreadReadingTrackingState()
         state.visiblePostIDs = [2002, 2003]
@@ -1482,6 +1608,7 @@ final class StateRegressionTests: XCTestCase {
         state.lastRecordedPostID = 2003
         state.didMoveAwayFromTop = true
         state.pendingCommitTask = Task {}
+        state.pendingAutomaticPageLoad = true
 
         state.reset()
 
@@ -1491,6 +1618,7 @@ final class StateRegressionTests: XCTestCase {
         XCTAssertNil(state.lastRecordedPostID)
         XCTAssertFalse(state.didMoveAwayFromTop)
         XCTAssertNil(state.pendingCommitTask)
+        XCTAssertFalse(state.pendingAutomaticPageLoad)
     }
 
     func testPreciseScrollSessionsDistinguishRepeatedRestoreToSamePost() {

--- a/TiebaPureTests/StateRegressionTests.swift
+++ b/TiebaPureTests/StateRegressionTests.swift
@@ -1394,46 +1394,111 @@ final class StateRegressionTests: XCTestCase {
         )
     }
 
-    func testThreadReadingViewportPolicyRecordsBottomMostVisibleReply() {
+    func testThreadReadingVisibilityPolicyRecordsBottomMostVisibleReply() {
         let mainPostID: UInt64 = 2001
-        let entries = [
-            ThreadPostViewportEntry(postID: 2001, floor: 1, minY: -240, maxY: 80),
-            ThreadPostViewportEntry(postID: 2002, floor: 0, minY: 80, maxY: 240),
-            ThreadPostViewportEntry(postID: 2003, floor: 0, minY: 240, maxY: 400),
-            // Prefetched below the viewport; must not be recorded.
-            ThreadPostViewportEntry(postID: 2004, floor: 0, minY: 700, maxY: 900)
-        ]
+        let postIDs: [UInt64] = [2001, 2002, 2003, 2004]
+        let visiblePostIDs: Set<UInt64> = [2001, 2002, 2003]
 
-        XCTAssertNil(ThreadReadingViewportPolicy.position(
-            entries: entries,
-            scrollDistanceFromTop: 20,
-            viewportHeight: 600,
-            excludedPostID: mainPostID
-        ))
-        // Floors are absent under hot sort (floor == 0); the bottom-most
-        // visible reply is still recorded by post ID.
         XCTAssertEqual(
-            ThreadReadingViewportPolicy.position(
-                entries: entries,
-                scrollDistanceFromTop: 240,
-                viewportHeight: 600,
+            ThreadReadingVisibilityPolicy.bottomMostVisiblePostID(
+                postIDsInDisplayOrder: postIDs,
+                visiblePostIDs: visiblePostIDs,
                 excludedPostID: mainPostID
-            )?.postID,
+            ),
             2003
         )
-        // A long main post alone never records a position of its own.
-        XCTAssertNil(ThreadReadingViewportPolicy.position(
-            entries: [ThreadPostViewportEntry(postID: 2001, floor: 1, minY: 0, maxY: 200)],
-            scrollDistanceFromTop: 100,
-            viewportHeight: 600,
+        XCTAssertEqual(
+            ThreadReadingVisibilityPolicy.bottomMostVisiblePostID(
+                postIDsInDisplayOrder: [2001, 2004, 2003, 2002],
+                visiblePostIDs: visiblePostIDs,
+                excludedPostID: mainPostID
+            ),
+            2002,
+            "倒序或热门列表必须按当前显示顺序选择最下方可见回复"
+        )
+        XCTAssertNil(ThreadReadingVisibilityPolicy.bottomMostVisiblePostID(
+            postIDsInDisplayOrder: [mainPostID],
+            visiblePostIDs: [mainPostID],
             excludedPostID: mainPostID
         ))
-        XCTAssertNil(ThreadReadingViewportPolicy.position(
-            entries: entries,
-            scrollDistanceFromTop: 240,
-            viewportHeight: 0,
+        XCTAssertNil(ThreadReadingVisibilityPolicy.bottomMostVisiblePostID(
+            postIDsInDisplayOrder: postIDs,
+            visiblePostIDs: [],
             excludedPostID: mainPostID
         ))
+    }
+
+    func testThreadReadingScrollRegionUsesStableBoundaries() {
+        XCTAssertEqual(ThreadReadingScrollRegion.resolve(distanceFromTop: -1), .top)
+        XCTAssertEqual(ThreadReadingScrollRegion.resolve(distanceFromTop: 0), .top)
+        XCTAssertEqual(
+            ThreadReadingScrollRegion.resolve(
+                distanceFromTop: ShortPullRefreshPolicy.topTolerance
+            ),
+            .top
+        )
+        XCTAssertEqual(
+            ThreadReadingScrollRegion.resolve(
+                distanceFromTop: ShortPullRefreshPolicy.topTolerance + 0.5
+            ),
+            .nearTop
+        )
+        XCTAssertEqual(
+            ThreadReadingScrollRegion.resolve(
+                distanceFromTop: ThreadReadingViewportPolicy.minimumRecordingDistance - 0.5
+            ),
+            .nearTop
+        )
+        XCTAssertEqual(
+            ThreadReadingScrollRegion.resolve(
+                distanceFromTop: ThreadReadingViewportPolicy.minimumRecordingDistance
+            ),
+            .away
+        )
+    }
+
+    func testThreadReadingTrackingCancelsPendingCommitWithoutDiscardingViewport() {
+        let state = ThreadReadingTrackingState()
+        state.visiblePostIDs = [2002, 2003]
+        state.scrollRegion = .away
+        state.lastRecordedPostID = 2002
+        state.didMoveAwayFromTop = true
+        state.pendingCommitTask = Task {}
+
+        state.cancelPendingCommit()
+
+        XCTAssertEqual(state.visiblePostIDs, [2002, 2003])
+        XCTAssertEqual(state.scrollRegion, .away)
+        XCTAssertNil(state.pendingCommitTask)
+        XCTAssertEqual(state.lastRecordedPostID, 2002)
+        XCTAssertTrue(state.didMoveAwayFromTop)
+    }
+
+    func testThreadReadingTrackingResetClearsViewportAndRegion() {
+        let state = ThreadReadingTrackingState()
+        state.visiblePostIDs = [2002, 2003]
+        state.isScrollIdle = false
+        state.scrollRegion = .away
+        state.lastRecordedPostID = 2003
+        state.didMoveAwayFromTop = true
+        state.pendingCommitTask = Task {}
+
+        state.reset()
+
+        XCTAssertEqual(state.visiblePostIDs, [])
+        XCTAssertTrue(state.isScrollIdle)
+        XCTAssertEqual(state.scrollRegion, .top)
+        XCTAssertNil(state.lastRecordedPostID)
+        XCTAssertFalse(state.didMoveAwayFromTop)
+        XCTAssertNil(state.pendingCommitTask)
+    }
+
+    func testPreciseScrollSessionsDistinguishRepeatedRestoreToSamePost() {
+        let first = ThreadPreciseScrollSession(postID: 2002)
+        let second = ThreadPreciseScrollSession(postID: 2002)
+
+        XCTAssertEqual(first.postID, second.postID)
+        XCTAssertNotEqual(first, second)
     }
 
     func testFixtureSearchCarriesPostIDAndCancellationPropagates() async throws {

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -84,6 +84,52 @@ final class TiebaPureSmokeTests: XCTestCase {
         )
     }
 
+    func testInlinePlainTextPolicyOnlyAcceptsTextBlocks() {
+        XCTAssertEqual(
+            InlinePlainTextPolicy.text(from: [.text("第一段"), .text("第二段")]),
+            "第一段第二段"
+        )
+        XCTAssertEqual(InlinePlainTextPolicy.text(from: []), "")
+        XCTAssertNil(InlinePlainTextPolicy.text(from: [
+            .text("正文"),
+            .link(title: "链接", url: URL(string: "https://tieba.baidu.com"))
+        ]))
+        XCTAssertNil(InlinePlainTextPolicy.text(from: [
+            .mention(userID: 1, text: "用户")
+        ]))
+        XCTAssertNil(InlinePlainTextPolicy.text(from: [
+            .emoticon(code: "滑稽")
+        ]))
+    }
+
+    func testInlineNativeTextPolicyUsesSwiftUIOnlyForTextAndEmoticons() {
+        XCTAssertTrue(InlineNativeTextPolicy.supports([
+            .text("正文"),
+            .emoticon(code: "滑稽"),
+            .text("结尾")
+        ]))
+        XCTAssertFalse(InlineNativeTextPolicy.supports([]))
+        XCTAssertFalse(InlineNativeTextPolicy.supports([
+            .text("正文"),
+            .link(title: "链接", url: URL(string: "https://tieba.baidu.com"))
+        ]))
+        XCTAssertFalse(InlineNativeTextPolicy.supports([
+            .mention(userID: 1, text: "用户")
+        ]))
+        XCTAssertEqual(
+            InlineNativeTextPolicy.artworkImageNames(in: [
+                .emoticon(code: "滑稽"),
+                .emoticon(code: "image_emoticon25")
+            ]),
+            ["image_emoticon25"]
+        )
+    }
+
+    func testInlineContentTextOnlyMeasuresGlyphOutlinesForCombiningMarks() {
+        XCTAssertFalse(InlineContentTextLayout.requiresGlyphOutlineMeasurement("普通中文回复"))
+        XCTAssertTrue(InlineContentTextLayout.requiresGlyphOutlineMeasurement("a\u{0301}"))
+    }
+
     func testThreadPaginationContinuesAfterServerLocatedPostPage() {
         XCTAssertEqual(
             TiebaPaginationPolicy.nextPage(requestedPage: 1, responseCurrentPage: 7),
@@ -1207,6 +1253,66 @@ final class TiebaPureSmokeTests: XCTestCase {
         XCTAssertEqual(thumbnailOnly.previewURL, thumbnail)
         XCTAssertNil(thumbnailOnly.originalURL)
         XCTAssertEqual(thumbnailOnly.downloadURL, thumbnail)
+
+        XCTAssertEqual(
+            FullScreenImageSourcePolicy.automaticPreviewURLs(
+                primary: thumbnail,
+                fallback: original,
+                original: original
+            ),
+            [thumbnail],
+            "自动预览和相邻页预取不得回退到独立原图"
+        )
+        XCTAssertEqual(
+            FullScreenImageSourcePolicy.automaticPreviewURLs(
+                primary: original,
+                fallback: thumbnail,
+                original: original
+            ),
+            [thumbnail],
+            "即使输入顺序异常，也应优先保留非原图预览源"
+        )
+        XCTAssertEqual(
+            FullScreenImageSourcePolicy.automaticPreviewURLs(
+                primary: original,
+                fallback: nil,
+                original: original
+            ),
+            [original],
+            "只有单一地址的旧数据仍需提供低分辨率解码预览"
+        )
+    }
+
+    func testFullScreenPreviewDecodeMatchesNativeScreenPixelsWithinItsCeiling() {
+        XCTAssertEqual(
+            FullScreenImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 390, height: 844),
+                displayScale: 3
+            ),
+            2_532
+        )
+        XCTAssertEqual(
+            FullScreenImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 320, height: 568),
+                displayScale: 3
+            ),
+            1_704
+        )
+        XCTAssertEqual(
+            FullScreenImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 1_366, height: 1_024),
+                displayScale: 2
+            ),
+            2_732
+        )
+        XCTAssertEqual(
+            FullScreenImageDecodePolicy.previewTargetPixelSize(
+                for: CGSize(width: 1_366, height: 1_024),
+                displayScale: 3
+            ),
+            FullScreenImageDecodePolicy.maximumPreviewDecodedPixelSize
+        )
+        XCTAssertEqual(TiebaImageDecodePolicy.maximumDecodedPixelSize, 4_096)
     }
 
     func testOriginalImageOnlyLoadsFromAnExplicitAvailableOrRetryState() {
@@ -1279,6 +1385,40 @@ final class TiebaPureSmokeTests: XCTestCase {
             didFinishPresentation: false,
             prefetchesAdjacentPages: false
         ))
+
+        XCTAssertTrue(FullScreenImageMetadataSchedulingPolicy.allowsLoading(
+            pageIndex: 2,
+            currentIndex: 2,
+            didFinishPresentation: true
+        ))
+        XCTAssertFalse(FullScreenImageMetadataSchedulingPolicy.allowsLoading(
+            pageIndex: 3,
+            currentIndex: 2,
+            didFinishPresentation: true
+        ))
+        XCTAssertFalse(FullScreenImageMetadataSchedulingPolicy.allowsLoading(
+            pageIndex: 2,
+            currentIndex: 2,
+            didFinishPresentation: false
+        ))
+    }
+
+    func testNativeInlineEmoticonIdentityChangesWithArtworkSet() {
+        let first: [ContentBlock] = [.text("a"), .emoticon(code: "image_emoticon1")]
+        let refreshed: [ContentBlock] = [.text("a"), .emoticon(code: "image_emoticon2")]
+        let sameArtwork: [ContentBlock] = [
+            .text("changed"),
+            .emoticon(code: "image_emoticon1")
+        ]
+
+        XCTAssertNotEqual(
+            InlineNativeTextPolicy.artworkIdentity(in: first),
+            InlineNativeTextPolicy.artworkIdentity(in: refreshed)
+        )
+        XCTAssertEqual(
+            InlineNativeTextPolicy.artworkIdentity(in: first),
+            InlineNativeTextPolicy.artworkIdentity(in: sameArtwork)
+        )
     }
 
     func testSyntheticFixtureImageFailureNeverUsesNetwork() throws {

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -1568,6 +1568,59 @@ final class TiebaPureSmokeTests: XCTestCase {
     }
 
     @MainActor
+    func testImagePreviewSourceReaderMovesReusedViewBetweenAnchorAndIdentity() {
+        let firstIdentity = "fixture-reused-image-a"
+        let secondIdentity = "fixture-reused-image-b"
+        let firstAnchor = ImagePreviewSourceAnchor(sourceIdentity: firstIdentity)
+        let secondAnchor = ImagePreviewSourceAnchor(sourceIdentity: firstIdentity)
+        let firstImage = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image {
+            UIColor.systemBlue.setFill()
+            $0.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        }
+        let secondImage = UIGraphicsImageRenderer(size: CGSize(width: 5, height: 5)).image {
+            UIColor.systemGreen.setFill()
+            $0.fill(CGRect(x: 0, y: 0, width: 5, height: 5))
+        }
+        let thirdImage = UIGraphicsImageRenderer(size: CGSize(width: 6, height: 6)).image {
+            UIColor.systemOrange.setFill()
+            $0.fill(CGRect(x: 0, y: 0, width: 6, height: 6))
+        }
+        firstAnchor.store(image: firstImage, sourceIdentity: firstIdentity)
+        secondAnchor.store(image: secondImage, sourceIdentity: firstIdentity)
+
+        let sourceView = ImagePreviewSourceView()
+        let coordinator = ImagePreviewSourceAnchorReader.Coordinator(anchor: firstAnchor)
+        firstAnchor.attach(sourceView, sourceIdentity: firstIdentity)
+        ImagePreviewSourceRegistry.shared.register(sourceView, identity: firstIdentity)
+        coordinator.registeredIdentity = firstIdentity
+        defer {
+            ImagePreviewSourceAnchorReader.dismantleUIView(sourceView, coordinator: coordinator)
+        }
+
+        coordinator.update(
+            sourceView,
+            anchor: secondAnchor,
+            sourceIdentity: firstIdentity,
+            onTransitionTap: nil
+        )
+        XCTAssertNil(firstAnchor.view)
+        XCTAssertTrue(secondAnchor.view === sourceView)
+        XCTAssertTrue(sourceView.image === secondImage)
+
+        secondAnchor.store(image: thirdImage, sourceIdentity: secondIdentity)
+        coordinator.update(
+            sourceView,
+            anchor: secondAnchor,
+            sourceIdentity: secondIdentity,
+            onTransitionTap: nil
+        )
+        XCTAssertEqual(coordinator.registeredIdentity, secondIdentity)
+        XCTAssertEqual(secondAnchor.sourceIdentity, secondIdentity)
+        XCTAssertTrue(secondAnchor.view === sourceView)
+        XCTAssertTrue(sourceView.image === thirdImage)
+    }
+
+    @MainActor
     func testImagePreviewHeroLeaseKeepsCanonicalAndProxyMutuallyExclusive() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
         let controller = UIViewController()
@@ -2419,7 +2472,16 @@ final class TiebaPureSmokeTests: XCTestCase {
         )
 
         let scrolled = ShortPullRefreshGeometry(contentOffsetY: 41, topInset: 59)
-        XCTAssertEqual(scrolled.distanceFromTop, 100)
+        let scrolledFurther = ShortPullRefreshGeometry(contentOffsetY: 2_941, topInset: 59)
+        XCTAssertEqual(
+            scrolled.distanceFromTop,
+            ShortPullRefreshGeometry.awayFromTopDistance
+        )
+        XCTAssertEqual(
+            scrolledFurther,
+            scrolled,
+            "离开顶部后，普通滚动不应逐帧发布不同的刷新几何状态"
+        )
         XCTAssertEqual(scrolled.pullDistance, 0)
         XCTAssertEqual(scrolled.fingerEquivalentPullDistance, 0)
     }

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -1991,7 +1991,10 @@ final class TiebaPureUITests: XCTestCase {
     }
 
     func testSavedReadingPositionAutoRestoresAndReturnsToTop() {
-        let app = launchApp(additionalArguments: ["UITEST_SEED_LOCAL_THREAD_LIBRARY"])
+        let app = launchApp(
+            scenario: "imageGesture",
+            additionalArguments: ["UITEST_SEED_LOCAL_THREAD_LIBRARY"]
+        )
         rootTab("我的", in: app).tap()
 
         let favoritesEntry = app.buttons["thread-favorites-entry"]
@@ -2012,11 +2015,20 @@ final class TiebaPureUITests: XCTestCase {
         // The fixture marks post-ID-targeted loads with this distinct reply
         // body, proving the first request itself carried the saved post ID.
         XCTAssertTrue((replyText.value as? String)?.contains("已定位搜索命中回复") == true)
+        let restoredReplyMinY = replyText.frame.minY
+        RunLoop.current.run(until: Date().addingTimeInterval(1.8))
+        XCTAssertEqual(
+            replyText.frame.minY,
+            restoredReplyMinY,
+            accuracy: 4,
+            "目标上方的成功图片完成布局后，恢复楼层不能再次漂移"
+        )
 
         let banner = app.otherElements["restored-reading-banner"]
-        XCTAssertTrue(banner.waitForExistence(timeout: 5))
+        XCTAssertTrue(banner.exists)
         let returnToTop = app.buttons["restored-reading-return-top"]
-        XCTAssertTrue(returnToTop.waitForExistence(timeout: 5))
+        XCTAssertTrue(returnToTop.exists)
+        XCTAssertTrue(returnToTop.isHittable)
         returnToTop.tap()
 
         let mainText = app.textViews["thread-main-text"].firstMatch
@@ -2025,6 +2037,33 @@ final class TiebaPureUITests: XCTestCase {
         expectation(for: mainBecameVisible, evaluatedWith: mainText)
         waitForExpectations(timeout: 5)
         XCTAssertFalse(banner.exists)
+    }
+
+    func testScrollingThreadRecordsAndRestoresReadingPosition() {
+        let app = launchApp(scenario: "readingPosition")
+        openFirstThread(in: app)
+
+        let scrollView = app.scrollViews["thread-detail-scroll-view"]
+        XCTAssertTrue(scrollView.waitForExistence(timeout: 8))
+        for _ in 0..<5 {
+            scrollView.swipeUp(velocity: .fast)
+        }
+
+        let backButton = app.navigationBars.buttons.firstMatch
+        XCTAssertTrue(waitForHittable(backButton, expected: true, timeout: 5))
+        backButton.tap()
+        XCTAssertTrue(threadRows(in: app).firstMatch.waitForExistence(timeout: 8))
+
+        openFirstThread(in: app)
+        let restoredBanner = app.otherElements["restored-reading-banner"]
+        XCTAssertTrue(
+            restoredBanner.waitForExistence(timeout: 8),
+            "实际滚动后再次进入同帖时应恢复最近阅读位置"
+        )
+        XCTAssertFalse(
+            (restoredBanner.value as? String)?.isEmpty ?? true,
+            "恢复提示必须携带已保存的具体楼层"
+        )
     }
 
     func testBrowsingHistorySearchAndBatchDeleteManageVisibleRecords() {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -834,7 +834,7 @@ final class TiebaPureUITests: XCTestCase {
         )
         openFirstThread(in: app)
 
-        let mainText = app.textViews["thread-main-text"]
+        let mainText = app.descendants(matching: .any)["thread-main-text"]
         XCTAssertTrue(mainText.waitForExistence(timeout: 8))
         mainText.coordinate(withNormalizedOffset: CGVector(dx: 0.12, dy: 0.18)).tap()
 
@@ -848,8 +848,12 @@ final class TiebaPureUITests: XCTestCase {
         )
         app.navigationBars["回复用户"].buttons["取消"].tap()
 
-        let floorText = app.textViews.matching(identifier: "thread-reply-text")
-            .matching(NSPredicate(format: "value CONTAINS %@", "确定性回复内容"))
+        let floorText = app.descendants(matching: .any).matching(identifier: "thread-reply-text")
+            .matching(NSPredicate(
+                format: "label CONTAINS %@ OR value CONTAINS %@",
+                "确定性回复内容",
+                "确定性回复内容"
+            ))
             .firstMatch
         XCTAssertTrue(revealBySwipingUp(floorText, in: app, maxSwipes: 12))
         floorText.coordinate(withNormalizedOffset: CGVector(dx: 0.18, dy: 0.35)).tap()
@@ -864,8 +868,13 @@ final class TiebaPureUITests: XCTestCase {
         app.buttons["查看全部4条回复"].tap()
         XCTAssertTrue(app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8))
 
-        let subpostText = app.textViews.matching(identifier: "thread-subpost-text")
-            .matching(NSPredicate(format: "value CONTAINS %@", "楼中楼参考布局回复2"))
+        let subpostText = app.descendants(matching: .any)
+            .matching(identifier: "thread-subpost-text")
+            .matching(NSPredicate(
+                format: "label CONTAINS %@ OR value CONTAINS %@",
+                "楼中楼参考布局回复2",
+                "楼中楼参考布局回复2"
+            ))
             .firstMatch
         XCTAssertTrue(revealBySwipingUp(subpostText, in: app, maxSwipes: 8))
         subpostText.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.5)).tap()
@@ -1311,15 +1320,22 @@ final class TiebaPureUITests: XCTestCase {
         let app = launchApp(scenario: "refreshUpdate")
         openFirstThread(in: app)
 
-        let mainText = app.textViews["thread-main-text"]
+        let mainText = app.descendants(matching: .any)["thread-main-text"]
         XCTAssertTrue(mainText.waitForExistence(timeout: 8))
-        XCTAssertFalse((mainText.value as? String)?.contains("帖子下拉刷新已更新") == true)
+        XCTAssertFalse(
+            mainText.label.contains("帖子下拉刷新已更新") ||
+                (mainText.value as? String)?.contains("帖子下拉刷新已更新") == true
+        )
 
         let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.20))
         let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.34))
         start.press(forDuration: 0.1, thenDragTo: end)
 
-        let refreshed = NSPredicate(format: "value CONTAINS %@", "帖子下拉刷新已更新")
+        let refreshed = NSPredicate(
+            format: "label CONTAINS %@ OR value CONTAINS %@",
+            "帖子下拉刷新已更新",
+            "帖子下拉刷新已更新"
+        )
         expectation(for: refreshed, evaluatedWith: mainText)
         waitForExpectations(timeout: 8)
     }
@@ -2007,14 +2023,17 @@ final class TiebaPureUITests: XCTestCase {
 
         // The saved position restores automatically: the targeted reply is
         // scrolled into view without any manual step.
-        let replyText = app.textViews["thread-reply-text"].firstMatch
+        let replyText = app.descendants(matching: .any)["thread-reply-text"].firstMatch
         XCTAssertTrue(replyText.waitForExistence(timeout: 8))
         let replyBecameVisible = NSPredicate(format: "hittable == true")
         expectation(for: replyBecameVisible, evaluatedWith: replyText)
         waitForExpectations(timeout: 5)
         // The fixture marks post-ID-targeted loads with this distinct reply
         // body, proving the first request itself carried the saved post ID.
-        XCTAssertTrue((replyText.value as? String)?.contains("已定位搜索命中回复") == true)
+        XCTAssertTrue(
+            replyText.label.contains("已定位搜索命中回复") ||
+                (replyText.value as? String)?.contains("已定位搜索命中回复") == true
+        )
         let restoredReplyMinY = replyText.frame.minY
         RunLoop.current.run(until: Date().addingTimeInterval(1.8))
         XCTAssertEqual(
@@ -2031,7 +2050,7 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(returnToTop.isHittable)
         returnToTop.tap()
 
-        let mainText = app.textViews["thread-main-text"].firstMatch
+        let mainText = app.descendants(matching: .any)["thread-main-text"].firstMatch
         XCTAssertTrue(mainText.waitForExistence(timeout: 8))
         let mainBecameVisible = NSPredicate(format: "hittable == true")
         expectation(for: mainBecameVisible, evaluatedWith: mainText)
@@ -2064,6 +2083,46 @@ final class TiebaPureUITests: XCTestCase {
             (restoredBanner.value as? String)?.isEmpty ?? true,
             "恢复提示必须携带已保存的具体楼层"
         )
+    }
+
+    func testThreadVerticalScrollFrameProbe() {
+        runThreadVerticalScrollFrameProbe(variant: "mixed")
+    }
+
+    func testThreadVerticalScrollFrameProbeTextOnly() {
+        runThreadVerticalScrollFrameProbe(variant: "text")
+    }
+
+    func testThreadVerticalScrollFrameProbeEmoticonsOnly() {
+        runThreadVerticalScrollFrameProbe(variant: "emoticons")
+    }
+
+    func testThreadVerticalScrollFrameProbeImagesOnly() {
+        runThreadVerticalScrollFrameProbe(variant: "images")
+    }
+
+    func testThreadVerticalScrollFrameProbeProductionMixed() {
+        runThreadVerticalScrollFrameProbe(variant: "production")
+    }
+
+    private func runThreadVerticalScrollFrameProbe(variant: String) {
+        let app = launchApp(
+            scenario: "scrollPerformance",
+            additionalArguments: ["UITEST_SCROLL_FRAME_PROBE"],
+            additionalEnvironment: ["TIEBAPURE_SCROLL_FIXTURE_VARIANT": variant],
+            disableAnimations: false
+        )
+        openFirstThread(in: app)
+
+        let scrollView = app.scrollViews["thread-detail-scroll-view"]
+        XCTAssertTrue(scrollView.waitForExistence(timeout: 8))
+        for _ in 0..<8 {
+            scrollView.swipeUp(velocity: .fast)
+        }
+        for _ in 0..<8 {
+            scrollView.swipeDown(velocity: .fast)
+        }
+        Thread.sleep(forTimeInterval: 0.8)
     }
 
     func testBrowsingHistorySearchAndBatchDeleteManageVisibleRecords() {
@@ -2584,7 +2643,7 @@ final class TiebaPureUITests: XCTestCase {
                 "第\(iteration + 1)次真正点按图片仍应打开全屏预览"
             )
             XCTAssertFalse(app.navigationBars["回复用户"].exists, "点击媒体不得触发回帖编辑器")
-            app.buttons["关闭图片"].tap()
+            dismissFullScreenImageBySingleTap(in: app)
 
             let sourceIsHittable = XCTNSPredicateExpectation(
                 predicate: NSPredicate(format: "hittable == true"),
@@ -2636,7 +2695,7 @@ final class TiebaPureUITests: XCTestCase {
             app.descendants(matching: .any)["full-screen-image-pager"]
                 .waitForExistence(timeout: 5)
         )
-        app.buttons["关闭图片"].tap()
+        dismissFullScreenImageBySingleTap(in: app)
         XCTAssertTrue(media.waitForExistence(timeout: 5))
 
         let feed = app.scrollViews["home-feed-scroll-view"]
@@ -2930,9 +2989,7 @@ final class TiebaPureUITests: XCTestCase {
                     && app.staticTexts["image-page-indicator"].label == "第1张，共4张",
                 "第\(cycle)轮应打开第一张图"
             )
-            let closeButton = app.buttons["关闭图片"]
-            XCTAssertTrue(closeButton.waitForExistence(timeout: 2))
-            closeButton.tap()
+            dismissFullScreenImageBySingleTap(in: app, timeout: 2)
             XCTAssertTrue(
                 pager.waitForNonExistence(timeout: 2),
                 "第\(cycle)轮第一张图的 dismissal 未完成"
@@ -2951,9 +3008,7 @@ final class TiebaPureUITests: XCTestCase {
                     && app.staticTexts["image-page-indicator"].label == "第2张，共4张",
                 "第\(cycle)轮应直接打开第二张图，而不是残留第一张会话"
             )
-            let secondCloseButton = app.buttons["关闭图片"]
-            XCTAssertTrue(secondCloseButton.waitForExistence(timeout: 2))
-            secondCloseButton.tap()
+            dismissFullScreenImageBySingleTap(in: app, timeout: 2)
             XCTAssertTrue(
                 pager.waitForNonExistence(timeout: 2),
                 "第\(cycle)轮第二张图的 dismissal 未完成"
@@ -3272,7 +3327,10 @@ final class TiebaPureUITests: XCTestCase {
             .firstMatch
         XCTAssertTrue(replyText.waitForExistence(timeout: 5))
         XCTAssertTrue(waitForHittable(replyText, expected: true, timeout: 5))
-        XCTAssertTrue((replyText.value as? String)?.contains("被回复用户") == true)
+        XCTAssertTrue(
+            replyText.label.contains("被回复用户") ||
+                (replyText.value as? String)?.contains("被回复用户") == true
+        )
         attachScreenshot(named: "fixture-expanded-subpost-secondary-usernames")
 
         authorButton.tap()
@@ -3364,7 +3422,7 @@ final class TiebaPureUITests: XCTestCase {
         )
         openFirstThread(in: app)
 
-        let mainText = app.textViews["thread-main-text"]
+        let mainText = app.descendants(matching: .any)["thread-main-text"]
         XCTAssertTrue(mainText.waitForExistence(timeout: 8))
         XCTAssertTrue(waitForHittable(mainText, expected: true, timeout: 5))
         mainText.coordinate(withNormalizedOffset: CGVector(dx: 0.45, dy: 0.2))
@@ -3482,7 +3540,7 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [metadataLoaded], timeout: 5), .completed)
         XCTAssertTrue(originalButton.label.contains("查看原图"))
         XCTAssertEqual(saveButton.label, "下载图片")
-        XCTAssertTrue(app.buttons["关闭图片"].exists)
+        XCTAssertFalse(app.buttons["关闭图片"].exists)
         XCTAssertTrue(app.descendants(matching: .any)["full-screen-image-pager"].exists)
 
         let zoomSurface = app.images["full-screen-image-zoom-surface-0"]
@@ -3501,7 +3559,11 @@ final class TiebaPureUITests: XCTestCase {
                 object: zoomSurface
             )
             XCTAssertEqual(XCTWaiter.wait(for: [zoomed], timeout: 5), .completed)
-            XCTAssertTrue(app.buttons["关闭图片"].exists, "捏合缩放不应关闭图片页")
+            XCTAssertTrue(
+                app.descendants(matching: .any)["full-screen-image-pager"].exists,
+                "捏合缩放不应关闭图片页"
+            )
+            XCTAssertFalse(app.buttons["关闭图片"].exists)
 
             let enlargedPercentage = Int(
                 (zoomSurface.value as? String ?? "").filter(\.isNumber)
@@ -3647,7 +3709,7 @@ final class TiebaPureUITests: XCTestCase {
         let reopened = app.descendants(matching: .any)["full-screen-image-pager"]
             .waitForExistence(timeout: 5)
         XCTAssertTrue(reopened, "缩回来源位置后应能再次从同一图片放大")
-        app.buttons["关闭图片"].tap()
+        dismissFullScreenImageBySingleTap(in: app)
         let sourceIsHittableAgain = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "hittable == true"),
             object: sourceImage
@@ -3921,7 +3983,11 @@ final class TiebaPureUITests: XCTestCase {
         )
         XCTAssertEqual(XCTWaiter.wait(for: [loadedOriginal], timeout: 5), .completed)
         image.tap()
-        XCTAssertTrue(app.buttons["关闭图片"].waitForExistence(timeout: 8))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["full-screen-image-pager"]
+                .waitForExistence(timeout: 8)
+        )
+        XCTAssertFalse(app.buttons["关闭图片"].exists)
     }
 
     func testManualVideoCoverFailureStillAllowsPlayback() {
@@ -4019,8 +4085,7 @@ final class TiebaPureUITests: XCTestCase {
 
         XCTAssertTrue(app.descendants(matching: .any)["full-screen-image-pager"]
             .waitForExistence(timeout: 8))
-        XCTAssertTrue(app.buttons["关闭图片"].waitForExistence(timeout: 3))
-        app.buttons["关闭图片"].tap()
+        dismissFullScreenImageBySingleTap(in: app)
 
         let sourceImage = app.descendants(matching: .any)["image-viewer-source-image"]
         XCTAssertTrue(sourceImage.waitForExistence(timeout: 5))
@@ -4255,8 +4320,11 @@ final class TiebaPureUITests: XCTestCase {
         )
         XCTAssertEqual(XCTWaiter.wait(for: [loaded], timeout: 5), .completed)
         inlineImage?.tap()
-        XCTAssertTrue(app.buttons["关闭图片"].waitForExistence(timeout: 8))
-        app.buttons["关闭图片"].tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["full-screen-image-pager"]
+                .waitForExistence(timeout: 8)
+        )
+        dismissFullScreenImageBySingleTap(in: app)
 
         // A saved reading position must still restore in deterministic floor
         // order even when the persisted default for new threads is descending.
@@ -4290,7 +4358,7 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertNotNil(retry)
         retry?.tap()
 
-        XCTAssertFalse(app.buttons["关闭图片"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["full-screen-image-pager"].exists)
         XCTAssertTrue(app.buttons["更多"].exists)
     }
 
@@ -4342,12 +4410,16 @@ final class TiebaPureUITests: XCTestCase {
             "首行包含可点击用户名",
             "多行回复用于触发"
         ]
-        let replyQuery = app.textViews.matching(identifier: "thread-reply-text")
+        let replyQuery = app.descendants(matching: .any).matching(identifier: "thread-reply-text")
         let visibleFrame = app.windows.firstMatch.frame
 
         for (index, fragment) in expectedReplies.enumerated() {
             let reply = replyQuery.matching(
-                NSPredicate(format: "value CONTAINS %@", fragment)
+                NSPredicate(
+                    format: "label CONTAINS %@ OR value CONTAINS %@",
+                    fragment,
+                    fragment
+                )
             ).firstMatch
             for _ in 0..<16 {
                 if reply.exists, reply.frame.intersects(visibleFrame) { break }
@@ -4367,7 +4439,11 @@ final class TiebaPureUITests: XCTestCase {
             app.swipeDown()
         }
         let reusedReply = replyQuery.matching(
-            NSPredicate(format: "value CONTAINS %@", expectedReplies.last!)
+            NSPredicate(
+                format: "label CONTAINS %@ OR value CONTAINS %@",
+                expectedReplies.last!,
+                expectedReplies.last!
+            )
         ).firstMatch
         for _ in 0..<20 {
             if reusedReply.exists, reusedReply.frame.intersects(visibleFrame) { break }
@@ -4930,13 +5006,14 @@ final class TiebaPureUITests: XCTestCase {
         scenario: String = "success",
         account: String? = nil,
         additionalArguments: [String] = [],
+        additionalEnvironment: [String: String] = [:],
         resetAppearance: Bool = true,
-        resetReadingPreferences: Bool = true
+        resetReadingPreferences: Bool = true,
+        disableAnimations: Bool = true
     ) -> XCUIApplication {
         let app = XCUIApplication()
         var launchArguments = [
             "UITEST_USE_FIXTURES",
-            "UITEST_DISABLE_ANIMATIONS",
             "UITEST_RESET_SEARCH_HISTORY",
             "UITEST_RESET_BROWSING_HISTORY",
             "UITEST_RESET_RECENT_FORUMS",
@@ -4944,6 +5021,9 @@ final class TiebaPureUITests: XCTestCase {
             "UITEST_RESET_BLOCKLIST",
             "UITEST_RESET_FORUM_THREAD_SORT"
         ]
+        if disableAnimations {
+            launchArguments.append("UITEST_DISABLE_ANIMATIONS")
+        }
         if resetAppearance {
             launchArguments.append("UITEST_RESET_APPEARANCE")
         }
@@ -4952,6 +5032,9 @@ final class TiebaPureUITests: XCTestCase {
         }
         app.launchArguments = launchArguments + additionalArguments
         app.launchEnvironment["TIEBAPURE_FIXTURE_SCENARIO"] = scenario
+        for (key, value) in additionalEnvironment {
+            app.launchEnvironment[key] = value
+        }
         if let account {
             app.launchEnvironment["TIEBAPURE_FIXTURE_ACCOUNT"] = account
         }
@@ -5270,6 +5353,21 @@ final class TiebaPureUITests: XCTestCase {
         return expected
             ? (element.exists && element.isHittable)
             : (!element.exists || !element.isHittable)
+    }
+
+    private func dismissFullScreenImageBySingleTap(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 5
+    ) {
+        let pager = app.descendants(matching: .any)["full-screen-image-pager"]
+        XCTAssertTrue(pager.waitForExistence(timeout: timeout))
+        XCTAssertFalse(app.buttons["关闭图片"].exists, "图片详情页不应显示独立关闭按钮")
+
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.2, dy: 0.3)).tap()
+        XCTAssertTrue(
+            pager.waitForNonExistence(timeout: timeout),
+            "轻点图片应返回来源页面"
+        )
     }
 
     private func waitForAnyLabel(

--- a/TiebaPureUITests/UserProfileManagementUITests.swift
+++ b/TiebaPureUITests/UserProfileManagementUITests.swift
@@ -46,7 +46,7 @@ final class UserProfileManagementUITests: XCTestCase {
         thread.tap()
 
         XCTAssertTrue(
-            app.textViews["thread-main-text"].waitForExistence(timeout: 8),
+            app.descendants(matching: .any)["thread-main-text"].waitForExistence(timeout: 8),
             "必须等本人主题详情和作者身份校验完成后再打开更多菜单"
         )
 

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.1
-        CURRENT_PROJECT_VERSION: 31
+        MARKETING_VERSION: 1.4.2
+        CURRENT_PROJECT_VERSION: 32
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.1
-        CURRENT_PROJECT_VERSION: 31
+        MARKETING_VERSION: 1.4.2
+        CURRENT_PROJECT_VERSION: 32
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## Changes

- Reduce per-frame SwiftUI invalidations while scrolling thread replies.
- Stabilize pull-to-refresh scroll-view attachment and image preview anchors.
- Preserve and restore reading position without stale asynchronous scroll callbacks.
- Bump the app version to 1.4.2 (32).

## Validation

- iOS 18.6: 590 unit tests, 0 failures; 8 targeted UI tests, 0 failures.
- iOS 26.5: 15 targeted unit and UI tests, 0 failures.
- Debug build, Release analysis, and unsigned IPA packaging passed.