### PR TITLE
进吧方块化与最近浏览管理

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1247,7 +1247,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 35;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1264,7 +1264,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 35;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1317,7 +1317,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 35;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1337,7 +1337,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 35;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -68,7 +68,7 @@ final class AppEnvironment: ObservableObject {
             )
         }
         if arguments.contains("UITEST_SEED_SCROLLABLE_RECENT_FORUMS") {
-            for index in 1...6 {
+            for index in 1...24 {
                 requireUIFixturePersistence(
                     RecentForumStore.shared.save(Forum(
                         id: Int64(10_000 + index),

--- a/TiebaPure/Domain/Models/RecentForum.swift
+++ b/TiebaPure/Domain/Models/RecentForum.swift
@@ -233,7 +233,30 @@ final class RecentForumStore: ObservableObject {
             persistenceAvailability = .unavailable
             return false
         }
-        let updated = RecentForumPolicy.sanitized([recent] + items, limit: limit)
+        return persist(
+            RecentForumPolicy.sanitized([recent] + items, limit: limit),
+            operation: "save recent forums"
+        )
+    }
+
+    /// Removes individual entries. The identifier is the case-insensitive forum
+    /// name, matching `RecentForum.id`, so a row removed in the list matches
+    /// the stored record even when the two differ in case.
+    @discardableResult
+    func remove(ids: Set<String>) -> Bool {
+        guard ids.isEmpty == false else { return true }
+        let normalizedIDs = Set(ids.map { $0.lowercased() })
+        let updated = items.filter { normalizedIDs.contains($0.id) == false }
+        guard updated.count != items.count else { return true }
+        guard persistentBackendIsAvailable else {
+            persistenceAvailability = .unavailable
+            return false
+        }
+        guard updated.isEmpty == false else { return clear() }
+        return persist(updated, operation: "remove recent forums")
+    }
+
+    private func persist(_ updated: [RecentForum], operation: String) -> Bool {
         do {
             try PersistedRecordStore.replaceAll(
                 RecentForumRecord.self,
@@ -246,7 +269,7 @@ final class RecentForumStore: ObservableObject {
             markPersistenceSucceeded()
             return true
         } catch {
-            PersistenceDiagnostics.report(error, operation: "save recent forums")
+            PersistenceDiagnostics.report(error, operation: operation)
             persistenceAvailability = .unavailable
             return false
         }

--- a/TiebaPure/Features/ForumHub/ForumHubView.swift
+++ b/TiebaPure/Features/ForumHub/ForumHubView.swift
@@ -16,6 +16,8 @@ struct ForumHubView: View {
     @State private var splitDetailPath: [ReaderSplitThreadRoute] = []
     @State private var requestGeneration = 0
     @State private var loadTask: Task<[Forum], Error>?
+    @State private var showsClearRecentConfirmation = false
+    @State private var showsRecentStorageError = false
 
     var body: some View {
         ReaderSplitLayout(
@@ -60,7 +62,7 @@ struct ForumHubView: View {
             }
 
             if visibleRecentForums.isEmpty == false {
-                Section("最近浏览") {
+                Section {
                     ForEach(visibleRecentForums) { recent in
                         ForumHubForumButton(
                             title: recent.displayName,
@@ -69,6 +71,27 @@ struct ForumHubView: View {
                         ) {
                             openForum(recent.forum)
                         }
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                removeRecentForums(ids: [recent.id])
+                            } label: {
+                                Label("删除", systemImage: "trash")
+                            }
+                            .accessibilityIdentifier("forum-hub-recent-delete")
+                        }
+                    }
+                    .onDelete(perform: removeRecentForums(at:))
+                } header: {
+                    HStack {
+                        Text("最近浏览")
+                        Spacer(minLength: TiebaPureTheme.Spacing.sm)
+                        Button("清空") {
+                            showsClearRecentConfirmation = true
+                        }
+                        .font(.footnote)
+                        .textCase(nil)
+                        .accessibilityLabel("清空最近浏览的贴吧")
+                        .accessibilityIdentifier("forum-hub-recent-clear")
                     }
                 }
             }
@@ -132,6 +155,21 @@ struct ForumHubView: View {
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
         .navigationTitle("进吧")
         .navigationBarTitleDisplayMode(.inline)
+        .confirmationDialog(
+            "清空最近浏览的贴吧？",
+            isPresented: $showsClearRecentConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("清空", role: .destructive, action: clearRecentForums)
+            Button("取消", role: .cancel) {}
+        } message: {
+            Text("只会清除本机记录，不影响你关注的贴吧。")
+        }
+        .alert("无法更新最近浏览", isPresented: $showsRecentStorageError) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text("本机存储暂时不可用，请稍后再试。")
+        }
         .interactiveNavigationPopRevealSource()
         .task {
             guard let account, didLoadFollowed == false else { return }
@@ -222,6 +260,29 @@ struct ForumHubView: View {
 
     private var visibleRecentForums: [RecentForum] {
         recentStore.items.filter { TiebaContentFilter.shouldKeep(forum: $0.forum) }
+    }
+
+    // Offsets index the filtered list shown on screen, so they are mapped back
+    // to identifiers before the store removes anything.
+    private func removeRecentForums(at offsets: IndexSet) {
+        let visible = visibleRecentForums
+        let ids = Set(offsets.compactMap { offset in
+            visible.indices.contains(offset) ? visible[offset].id : nil
+        })
+        removeRecentForums(ids: ids)
+    }
+
+    private func removeRecentForums(ids: Set<String>) {
+        guard ids.isEmpty == false else { return }
+        if recentStore.remove(ids: ids) == false {
+            showsRecentStorageError = true
+        }
+    }
+
+    private func clearRecentForums() {
+        if recentStore.clear() == false {
+            showsRecentStorageError = true
+        }
     }
 
     private var visibleFollowedForums: [Forum] {

--- a/TiebaPure/Features/ForumHub/ForumHubView.swift
+++ b/TiebaPure/Features/ForumHub/ForumHubView.swift
@@ -16,6 +16,7 @@ struct ForumHubView: View {
     @State private var splitDetailPath: [ReaderSplitThreadRoute] = []
     @State private var requestGeneration = 0
     @State private var loadTask: Task<[Forum], Error>?
+    @State private var isManagingRecentForums = false
     @State private var showsClearRecentConfirmation = false
     @State private var showsRecentStorageError = false
 
@@ -63,35 +64,48 @@ struct ForumHubView: View {
 
             if visibleRecentForums.isEmpty == false {
                 Section {
-                    ForEach(visibleRecentForums) { recent in
-                        ForumHubForumButton(
-                            title: recent.displayName,
-                            subtitle: "最近 \(ReaderDateText.string(from: recent.updatedAt))",
-                            avatarURL: recent.avatarURL
-                        ) {
-                            openForum(recent.forum)
-                        }
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                removeRecentForums(ids: [recent.id])
-                            } label: {
-                                Label("删除", systemImage: "trash")
-                            }
-                            .accessibilityIdentifier("forum-hub-recent-delete")
-                        }
-                    }
-                    .onDelete(perform: removeRecentForums(at:))
+                    ForumTileGrid(
+                        tiles: visibleRecentForums.map { recent in
+                            ForumTile(
+                                id: recent.id,
+                                title: recent.displayName,
+                                avatarURL: recent.avatarURL,
+                                forum: recent.forum
+                            )
+                        },
+                        isManaging: isManagingRecentForums,
+                        onOpen: openForum,
+                        onDelete: { id in removeRecentForums(ids: [id]) }
+                    )
                 } header: {
                     HStack {
                         Text("最近浏览")
                         Spacer(minLength: TiebaPureTheme.Spacing.sm)
-                        Button("清空") {
-                            showsClearRecentConfirmation = true
+                        if isManagingRecentForums {
+                            Button("清空") {
+                                showsClearRecentConfirmation = true
+                            }
+                            .font(.footnote)
+                            .textCase(nil)
+                            .accessibilityLabel("清空最近浏览的贴吧")
+                            .accessibilityIdentifier("forum-hub-recent-clear")
+
+                            Button("完成") {
+                                isManagingRecentForums = false
+                            }
+                            .font(.footnote.weight(.semibold))
+                            .textCase(nil)
+                            .padding(.leading, TiebaPureTheme.Spacing.sm)
+                            .accessibilityIdentifier("forum-hub-recent-manage-done")
+                        } else {
+                            Button("管理") {
+                                isManagingRecentForums = true
+                            }
+                            .font(.footnote)
+                            .textCase(nil)
+                            .accessibilityLabel("管理最近浏览的贴吧")
+                            .accessibilityIdentifier("forum-hub-recent-manage")
                         }
-                        .font(.footnote)
-                        .textCase(nil)
-                        .accessibilityLabel("清空最近浏览的贴吧")
-                        .accessibilityIdentifier("forum-hub-recent-clear")
                     }
                 }
             }
@@ -124,15 +138,19 @@ struct ForumHubView: View {
                                 Task { await loadFollowed(account: account) }
                             }
                         }
-                        ForEach(visibleFollowedForums) { forum in
-                            ForumHubForumButton(
-                                title: forum.displayName,
-                                subtitle: forumMetadata(forum),
-                                avatarURL: forum.avatarURL
-                            ) {
-                                openForum(forum)
-                            }
-                        }
+                        ForumTileGrid(
+                            tiles: visibleFollowedForums.map { forum in
+                                ForumTile(
+                                    id: "\(forum.id)-\(forum.name)",
+                                    title: forum.displayName,
+                                    avatarURL: forum.avatarURL,
+                                    forum: forum
+                                )
+                            },
+                            isManaging: false,
+                            onOpen: openForum,
+                            onDelete: nil
+                        )
                     }
                 } else {
                     Text("登录后显示关注的贴吧")
@@ -262,27 +280,25 @@ struct ForumHubView: View {
         recentStore.items.filter { TiebaContentFilter.shouldKeep(forum: $0.forum) }
     }
 
-    // Offsets index the filtered list shown on screen, so they are mapped back
-    // to identifiers before the store removes anything.
-    private func removeRecentForums(at offsets: IndexSet) {
-        let visible = visibleRecentForums
-        let ids = Set(offsets.compactMap { offset in
-            visible.indices.contains(offset) ? visible[offset].id : nil
-        })
-        removeRecentForums(ids: ids)
-    }
-
     private func removeRecentForums(ids: Set<String>) {
         guard ids.isEmpty == false else { return }
         if recentStore.remove(ids: ids) == false {
             showsRecentStorageError = true
+            return
+        }
+        // The section disappears with its last tile, taking the done button
+        // with it, so managing has to end here rather than on the next tap.
+        if visibleRecentForums.isEmpty {
+            isManagingRecentForums = false
         }
     }
 
     private func clearRecentForums() {
         if recentStore.clear() == false {
             showsRecentStorageError = true
+            return
         }
+        isManagingRecentForums = false
     }
 
     private var visibleFollowedForums: [Forum] {
@@ -568,54 +584,89 @@ enum ForumHubTapPolicy {
     }
 }
 
-private struct ForumHubForumButton: View {
+struct ForumTile: Identifiable, Equatable {
+    let id: String
     let title: String
-    let subtitle: String
     let avatarURL: URL?
-    let action: () -> Void
+    let forum: Forum
+}
+
+/// Forums read as a wall of small squares rather than a list of rows: the name
+/// and avatar are the whole point, and a grid fits several times as many on
+/// screen.
+private struct ForumTileGrid: View {
+    let tiles: [ForumTile]
+    let isManaging: Bool
+    let onOpen: (Forum) -> Void
+    let onDelete: ((String) -> Void)?
+
+    private let columns = [
+        GridItem(.adaptive(minimum: 76, maximum: 120), spacing: TiebaPureTheme.Spacing.sm)
+    ]
 
     var body: some View {
-        Button(action: action) {
-            ForumSummaryRow(title: title, subtitle: subtitle, avatarURL: avatarURL)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+        LazyVGrid(columns: columns, spacing: TiebaPureTheme.Spacing.md) {
+            ForEach(tiles) { tile in
+                ForumTileButton(
+                    tile: tile,
+                    isManaging: isManaging,
+                    onOpen: { onOpen(tile.forum) },
+                    onDelete: onDelete.map { delete in { delete(tile.id) } }
+                )
+            }
+        }
+        .padding(.vertical, TiebaPureTheme.Spacing.xs)
+        .listRowInsets(EdgeInsets(
+            top: TiebaPureTheme.Spacing.xs,
+            leading: TiebaPureTheme.Spacing.md,
+            bottom: TiebaPureTheme.Spacing.xs,
+            trailing: TiebaPureTheme.Spacing.md
+        ))
+    }
+}
+
+private struct ForumTileButton: View {
+    let tile: ForumTile
+    let isManaging: Bool
+    let onOpen: () -> Void
+    let onDelete: (() -> Void)?
+
+    var body: some View {
+        Button {
+            // Managing is a separate mode: a tap there is almost always aimed
+            // at the delete badge, so opening the forum would fight the user.
+            guard isManaging == false else { return }
+            onOpen()
+        } label: {
+            VStack(spacing: TiebaPureTheme.Spacing.xs) {
+                AvatarView(url: tile.avatarURL, title: tile.title, size: 52)
+
+                Text(tile.title)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("进入\(title)")
+        .accessibilityLabel(isManaging ? tile.title : "进入\(tile.title)")
         .accessibilityIdentifier("forum-hub-forum-row")
-    }
-}
-
-private struct ForumSummaryRow: View {
-    let title: String
-    let subtitle: String
-    let avatarURL: URL?
-
-    var body: some View {
-        HStack(spacing: TiebaPureTheme.Spacing.sm) {
-            AvatarView(url: avatarURL, title: title)
-
-            VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
-                Text(title)
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(.primary)
-
-                if subtitle.isEmpty == false {
-                    Text(subtitle)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+        .overlay(alignment: .topTrailing) {
+            if isManaging, let onDelete {
+                Button(action: onDelete) {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.system(size: 20))
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(Color.white, Color.red)
                 }
+                .buttonStyle(.plain)
+                .minTouchTarget()
+                .accessibilityLabel("删除\(tile.title)")
+                .accessibilityIdentifier("forum-hub-recent-delete")
             }
-
-            Spacer(minLength: TiebaPureTheme.Spacing.sm)
-
-            Image(systemName: "chevron.right")
-                .font(.system(size: TiebaPureTheme.IconSize.inline, weight: .semibold))
-                .foregroundStyle(.tertiary)
-                .accessibilityHidden(true)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .minTouchTarget()
     }
 }
+

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -75,20 +75,7 @@ struct HomeView: View {
         .navigationTitle("首页")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItemGroup(placement: .topBarTrailing) {
-                // Runs the same path as a tab re-tap: scroll to the top, show
-                // the refresh indicator, then reload page one.
-                Button {
-                    requestManualRefresh()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .minTouchTarget()
-                .disabled(isLoading)
-                .accessibilityLabel("刷新")
-                .accessibilityHint("重新加载推荐帖子")
-                .accessibilityIdentifier("home-refresh-button")
-
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     activeSearch = SearchRoute(keyword: "")
                 } label: {
@@ -211,11 +198,6 @@ struct HomeView: View {
 
     private var usesSplitDetailLayout: Bool {
         horizontalSizeClass == .regular
-    }
-
-    private func requestManualRefresh() {
-        guard isLoading == false else { return }
-        programmaticRefreshToken &+= 1
     }
 
     // Search presents in exactly one column per layout: the feed stack when

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -75,7 +75,20 @@ struct HomeView: View {
         .navigationTitle("首页")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                // Runs the same path as a tab re-tap: scroll to the top, show
+                // the refresh indicator, then reload page one.
+                Button {
+                    requestManualRefresh()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .minTouchTarget()
+                .disabled(isLoading)
+                .accessibilityLabel("刷新")
+                .accessibilityHint("重新加载推荐帖子")
+                .accessibilityIdentifier("home-refresh-button")
+
                 Button {
                     activeSearch = SearchRoute(keyword: "")
                 } label: {
@@ -198,6 +211,11 @@ struct HomeView: View {
 
     private var usesSplitDetailLayout: Bool {
         horizontalSizeClass == .regular
+    }
+
+    private func requestManualRefresh() {
+        guard isLoading == false else { return }
+        programmaticRefreshToken &+= 1
     }
 
     // Search presents in exactly one column per layout: the feed stack when

--- a/TiebaPureTests/StateRegressionTests.swift
+++ b/TiebaPureTests/StateRegressionTests.swift
@@ -273,6 +273,34 @@ final class StateRegressionTests: XCTestCase {
     }
 
     @MainActor
+    func testRecentForumStoreRemovesSelectedEntriesDurably() throws {
+        let container = try makeInMemoryModelContainer()
+        let defaults = try makeScratchDefaults()
+        var tick: TimeInterval = 0
+        let store = RecentForumStore(defaults: defaults, limit: 30, modelContainer: container) {
+            tick += 1
+            return Date(timeIntervalSince1970: tick)
+        }
+        store.save(name: "Alpha")
+        store.save(name: "beta")
+        store.save(name: "gamma")
+
+        // Identifiers are case-insensitive, matching `RecentForum.id`.
+        XCTAssertTrue(store.remove(ids: ["ALPHA"]))
+        XCTAssertEqual(store.items.map(\.name), ["gamma", "beta"])
+        XCTAssertTrue(store.remove(ids: ["missing"]), "删除不存在的条目不应视为失败")
+        XCTAssertEqual(store.items.count, 2)
+
+        let reloaded = RecentForumStore(defaults: defaults, limit: 30, modelContainer: container)
+        XCTAssertEqual(reloaded.items.map(\.name), ["gamma", "beta"])
+
+        XCTAssertTrue(store.remove(ids: ["gamma", "beta"]))
+        XCTAssertTrue(store.items.isEmpty)
+        let emptied = RecentForumStore(defaults: defaults, limit: 30, modelContainer: container)
+        XCTAssertTrue(emptied.items.isEmpty)
+    }
+
+    @MainActor
     func testSearchHistoryPersistsDeduplicatesLimitsAndDeletes() throws {
         let container = try makeInMemoryModelContainer()
         let defaults = try makeScratchDefaults()

--- a/project.yml
+++ b/project.yml
@@ -35,7 +35,7 @@ targets:
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         MARKETING_VERSION: 1.4.2
-        CURRENT_PROJECT_VERSION: 32
+        CURRENT_PROJECT_VERSION: 35
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -55,7 +55,7 @@ targets:
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
         MARKETING_VERSION: 1.4.2
-        CURRENT_PROJECT_VERSION: 32
+        CURRENT_PROJECT_VERSION: 35
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
进吧的贴吧从整行改成方块，一屏能看到的吧更多。

- 最近浏览新增「管理」：进入后每个方块带删除角标，可单删或清空，删完自动退出
- 关注贴吧同样方块化，取关仍在吧内进行，这里不提供删除
- 移除首页刷新按钮，下拉刷新与重点标签页已经覆盖

已验证：单元测试 586 项通过，进吧 UI 测试 3 项通过，模拟器实机确认。