### PR TITLE
帖子页：跨行复用段落高度与文本视图

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		DEF7E4F5C3BB5C3AC25E89EF /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C482CF17BA5520B13F1B03 /* AppAppearance.swift */; };
 		DFDB57457FFB61942BC48E4E /* MediaPreviewHeroAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034D76B7DA1D80733B718828 /* MediaPreviewHeroAnimator.swift */; };
 		E1835BAE94DEB0B7D30F0B13 /* ReadingPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638DEF254549D0D4DE625487 /* ReadingPreferences.swift */; };
+		E209C76E1A8310E8F94F6A32 /* InlineTextReuseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D55E6E9D9C9BE0630B5C89 /* InlineTextReuseTests.swift */; };
 		E3CF1C9A62133316FF6D93E2 /* UserProfileMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F7C671CDA66E5F18CEC24 /* UserProfileMapper.swift */; };
 		E4BC7D1B10FF88D762725986 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E2287E1195B4261B0B88E8 /* SettingsView.swift */; };
 		E6FCA5689969E1EE7020CF44 /* ReadingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432F97822473B7D42DB148EC /* ReadingSettingsView.swift */; };
@@ -322,6 +323,7 @@
 		944D4064677A9BAB7CD156BC /* ForumListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumListView.swift; sourceTree = "<group>"; };
 		946B2D7B6BCE7C2C716A3EB2 /* ThreadMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadMapper.swift; sourceTree = "<group>"; };
 		994E9D3128F82A0683DA39E0 /* CapsuleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleLabel.swift; sourceTree = "<group>"; };
+		99D55E6E9D9C9BE0630B5C89 /* InlineTextReuseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineTextReuseTests.swift; sourceTree = "<group>"; };
 		9CE43843ABF0E6FE36F6A7BD /* TiebaURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaURLTests.swift; sourceTree = "<group>"; };
 		9D3DFA01DD01FD4EA295E006 /* ForumHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumHubView.swift; sourceTree = "<group>"; };
 		9F1C4599FA7188B0D810AE19 /* UserProfileMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileMutationTests.swift; sourceTree = "<group>"; };
@@ -630,6 +632,7 @@
 				83A586DD3DD949672854FF9E /* ContentSubmissionNetworkTests.swift */,
 				5E2FAEA095A18F41BED60B8D /* EmoticonResourceTests.swift */,
 				7F4A700D0BB079E5CEC104C1 /* FixtureDecodingTests.swift */,
+				99D55E6E9D9C9BE0630B5C89 /* InlineTextReuseTests.swift */,
 				DE6967B15A66331DA9F947F0 /* MessageAPITests.swift */,
 				2758D17C77814946EB5560DA /* MultipartFormDataTests.swift */,
 				C60B7C87AF367770BAF70762 /* SearchAPITests.swift */,
@@ -1123,6 +1126,7 @@
 				2E614B406807B5BAFBCA4918 /* ContentSubmissionNetworkTests.swift in Sources */,
 				7670D2DD682E7DA328CABB62 /* EmoticonResourceTests.swift in Sources */,
 				34511F43DA6B267EB2816388 /* FixtureDecodingTests.swift in Sources */,
+				E209C76E1A8310E8F94F6A32 /* InlineTextReuseTests.swift in Sources */,
 				80D70D09DAD45ED618094984 /* MessageAPITests.swift in Sources */,
 				D92FF26A20CE55595F45B81F /* MultipartFormDataTests.swift in Sources */,
 				FA2D7EBC13B9CDAE43B9DAC0 /* SearchAPITests.swift in Sources */,

--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -478,6 +478,10 @@ struct KeywordHighlightedText: View {
 final class InlineContentTextView: UITextView {
     var allowsTextSelection = false
 
+    // UITextView installs its own tap recognizers for links and selection, so
+    // reuse may only remove the one this app added.
+    private weak var plainTextTapRecognizer: UITapGestureRecognizer?
+
     private var appliedDisplayScale: CGFloat = 0
     private var appliedRenderID: UInt?
     private var cachedFittingText: NSAttributedString?
@@ -521,6 +525,45 @@ final class InlineContentTextView: UITextView {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func installPlainTextTap(_ recognizer: UITapGestureRecognizer) {
+        if let plainTextTapRecognizer {
+            removeGestureRecognizer(plainTextTapRecognizer)
+        }
+        plainTextTapRecognizer = recognizer
+        addGestureRecognizer(recognizer)
+    }
+
+    /// Returns a view the lazy stack dropped to a blank state. Everything the
+    /// representable configures in `makeUIView` is reapplied there, so this only
+    /// has to drop the content, this app's own recognizer, and the metrics
+    /// memoized for the previous run.
+    func prepareForReuse() {
+        delegate = nil
+        if let plainTextTapRecognizer {
+            removeGestureRecognizer(plainTextTapRecognizer)
+            self.plainTextTapRecognizer = nil
+        }
+        if textStorage.length > 0 {
+            textStorage.setAttributedString(NSAttributedString())
+        }
+        textContainerInset = .zero
+        textContainer.maximumNumberOfLines = 0
+        textContainer.lineBreakMode = .byWordWrapping
+        allowsTextSelection = false
+        accessibilityIdentifier = nil
+        accessibilityValue = nil
+        appliedDisplayScale = 0
+        appliedRenderID = nil
+        cachedFittingText = nil
+        cachedFittingRenderID = nil
+        cachedFittingWidth = 0
+        cachedFittingMaximumNumberOfLines = 0
+        cachedFittingLineBreakMode = .byWordWrapping
+        cachedFittingDisplayScale = 0
+        cachedFittingSize = .zero
+        setContentOffset(.zero, animated: false)
     }
 
     func apply(
@@ -608,6 +651,36 @@ final class InlineContentTextView: UITextView {
             lineBreakMode: lineBreakMode
         )
         configureTextContainer(forViewWidth: width)
+
+        // A row scrolled out of the lazy stack and back in arrives with a new
+        // view whose own memo is empty, so the same paragraph would be laid out
+        // from scratch again. The height depends only on the run, the width and
+        // the text environment, so it is shared across views. The text is still
+        // applied above — only the two layout passes below are skipped, and
+        // TextKit lays the glyphs out lazily when the view actually draws.
+        let sharedKey = InlineContentTextMeasurementCache.Key(
+            attributedText: attributedText,
+            width: width,
+            maximumNumberOfLines: maximumNumberOfLines,
+            lineBreakMode: lineBreakMode.rawValue,
+            displayScale: displayScale,
+            contentSizeCategory: UITraitCollection.current.preferredContentSizeCategory.rawValue,
+            legibilityWeight: UITraitCollection.current.legibilityWeight.rawValue
+        )
+        if let sharedHeight = InlineContentTextMeasurementCache.height(for: sharedKey) {
+            let size = CGSize(width: width, height: sharedHeight)
+            memoizeFittingSize(
+                size,
+                attributedText: attributedText,
+                renderID: renderID,
+                width: width,
+                maximumNumberOfLines: maximumNumberOfLines,
+                lineBreakMode: lineBreakMode,
+                displayScale: displayScale
+            )
+            return size
+        }
+
         layoutManager.ensureLayout(for: textContainer)
 
         let usedRect = layoutManager.usedRect(for: textContainer)
@@ -625,6 +698,28 @@ final class InlineContentTextView: UITextView {
         ).height
         let liveLayoutHeight = ceil(max(geometryHeight, nativeHeight))
         let size = CGSize(width: width, height: liveLayoutHeight)
+        InlineContentTextMeasurementCache.store(height: size.height, for: sharedKey)
+        memoizeFittingSize(
+            size,
+            attributedText: attributedText,
+            renderID: renderID,
+            width: width,
+            maximumNumberOfLines: maximumNumberOfLines,
+            lineBreakMode: lineBreakMode,
+            displayScale: displayScale
+        )
+        return size
+    }
+
+    private func memoizeFittingSize(
+        _ size: CGSize,
+        attributedText: NSAttributedString,
+        renderID: UInt?,
+        width: CGFloat,
+        maximumNumberOfLines: Int,
+        lineBreakMode: NSLineBreakMode,
+        displayScale: CGFloat
+    ) {
         cachedFittingText = renderID == nil
             ? attributedText.copy() as? NSAttributedString
             : nil
@@ -634,7 +729,6 @@ final class InlineContentTextView: UITextView {
         cachedFittingLineBreakMode = lineBreakMode
         cachedFittingDisplayScale = displayScale
         cachedFittingSize = size
-        return size
     }
 
     var renderedTextBoundsInView: CGRect {
@@ -715,6 +809,102 @@ final class InlineContentTextView: UITextView {
         )
         setNeedsLayout()
         setNeedsDisplay()
+    }
+}
+
+/// Recycles the hosted text views themselves.
+///
+/// Building a `UITextView` costs roughly as much as measuring the paragraph it
+/// will show — it brings up a TextKit stack, gesture recognizers and text
+/// interactions — and SwiftUI builds a new one for every row that scrolls in.
+///
+/// Views are only taken back a runloop turn after SwiftUI says it is done with
+/// them, and only if SwiftUI has actually detached them by then. Reclaiming a
+/// view that is still installed hands the next row a view the previous one can
+/// still write to, which is how an earlier attempt lost the links inside
+/// rebuilt rows.
+@MainActor
+enum InlineContentTextViewPool {
+    static let capacity = 24
+
+    private static var reusableViews: [InlineContentTextView] = []
+
+    static var pooledViewCount: Int { reusableViews.count }
+
+    static func dequeue() -> InlineContentTextView {
+        guard let view = reusableViews.popLast() else {
+            return InlineContentTextView()
+        }
+        view.prepareForReuse()
+        return view
+    }
+
+    static func recycle(_ view: InlineContentTextView) {
+        DispatchQueue.main.async {
+            guard view.superview == nil,
+                  view.window == nil,
+                  reusableViews.count < capacity,
+                  reusableViews.contains(where: { $0 === view }) == false else {
+                return
+            }
+            view.prepareForReuse()
+            reusableViews.append(view)
+        }
+    }
+
+    static func drain() {
+        reusableViews.removeAll(keepingCapacity: false)
+    }
+}
+
+/// Paragraph heights shared by every hosted text run.
+///
+/// SwiftUI has no cell reuse, so scrolling a thread back over rows it already
+/// showed rebuilds their text views from nothing. Measuring a paragraph is the
+/// expensive half of that, and it is a pure function of the run, the proposed
+/// width and the text environment.
+@MainActor
+enum InlineContentTextMeasurementCache {
+    struct Key: Hashable {
+        let attributedText: NSAttributedString
+        let width: CGFloat
+        let maximumNumberOfLines: Int
+        let lineBreakMode: Int
+        let displayScale: CGFloat
+        let contentSizeCategory: String
+        let legibilityWeight: Int
+    }
+
+    // A few screens of runs at a couple of widths. Entries are tiny, and the
+    // oldest half is dropped wholesale rather than tracked per use: an exact
+    // LRU would cost more bookkeeping than the measurement it saves.
+    static let capacity = 512
+
+    private static var heights: [Key: CGFloat] = [:]
+    private static var insertionOrder: [Key] = []
+
+    static var cachedHeightCount: Int { heights.count }
+
+    static func height(for key: Key) -> CGFloat? {
+        heights[key]
+    }
+
+    static func store(height: CGFloat, for key: Key) {
+        guard height.isFinite else { return }
+        if heights.updateValue(height, forKey: key) == nil {
+            insertionOrder.append(key)
+        }
+        guard heights.count > capacity else { return }
+        let overflow = heights.count - capacity / 2
+        for key in insertionOrder.prefix(overflow) {
+            heights.removeValue(forKey: key)
+        }
+        insertionOrder.removeFirst(overflow)
+    }
+
+    static func drain() {
+        heights.removeAll(keepingCapacity: false)
+        insertionOrder.removeAll(keepingCapacity: false)
     }
 }
 
@@ -841,7 +1031,7 @@ struct InlineContentText: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> InlineContentTextView {
-        let textView = InlineContentTextView()
+        let textView = InlineContentTextViewPool.dequeue()
         textView.backgroundColor = .clear
         textView.isOpaque = false
         textView.isEditable = false
@@ -873,9 +1063,14 @@ struct InlineContentText: UIViewRepresentable {
             action: #selector(Coordinator.handlePlainTextTap(_:))
         )
         plainTextTap.cancelsTouchesInView = false
-        textView.addGestureRecognizer(plainTextTap)
+        textView.installPlainTextTap(plainTextTap)
         context.coordinator.textView = textView
         return textView
+    }
+
+    static func dismantleUIView(_ uiView: InlineContentTextView, coordinator: Coordinator) {
+        coordinator.detachFromTextView()
+        InlineContentTextViewPool.recycle(uiView)
     }
 
     func updateUIView(_ textView: InlineContentTextView, context: Context) {
@@ -1006,6 +1201,15 @@ struct InlineContentText: UIViewRepresentable {
         private func invalidateRenderedContent() {
             cachedRenderKey = nil
             cachedRenderedContent = nil
+        }
+
+        /// Called when the representable goes away, so a late artwork
+        /// notification cannot redraw this run into a view another row now owns.
+        func detachFromTextView() {
+            stopObservingArtwork()
+            rerenderArtwork = nil
+            observedArtworkImageNames = []
+            textView = nil
         }
 
         private func stopObservingArtwork() {

--- a/TiebaPureTests/InlineTextReuseTests.swift
+++ b/TiebaPureTests/InlineTextReuseTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import TiebaPure
+
+/// Covers the two caches that make a row scrolling back into view cheap:
+/// paragraph heights are shared between views, and the text views themselves
+/// are recycled.
+final class InlineTextReuseTests: XCTestCase {
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        InlineContentTextMeasurementCache.drain()
+        InlineContentTextViewPool.drain()
+    }
+
+    @MainActor
+    override func tearDown() {
+        InlineContentTextMeasurementCache.drain()
+        InlineContentTextViewPool.drain()
+        super.tearDown()
+    }
+
+    private func paragraph(_ text: String) -> NSAttributedString {
+        NSAttributedString(
+            string: text,
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .callout)]
+        )
+    }
+
+    @MainActor
+    func testHeightMeasuredOnceIsReusedByAnotherView() {
+        let text = paragraph("回到这一行时不应该重新排版的合成回复内容。")
+        let first = InlineContentTextView()
+        let firstSize = first.fittingSize(
+            width: 320,
+            attributedText: text,
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+        XCTAssertGreaterThan(firstSize.height, 0)
+        XCTAssertEqual(InlineContentTextMeasurementCache.cachedHeightCount, 1)
+
+        // A different view is what scrolling back actually produces.
+        let second = InlineContentTextView()
+        let secondSize = second.fittingSize(
+            width: 320,
+            attributedText: paragraph("回到这一行时不应该重新排版的合成回复内容。"),
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+
+        XCTAssertEqual(secondSize, firstSize)
+        XCTAssertEqual(
+            InlineContentTextMeasurementCache.cachedHeightCount,
+            1,
+            "同一段文字在同一宽度下只应测量一次"
+        )
+        // The cached height must not skip applying the run: the view still has
+        // to be able to draw it.
+        XCTAssertEqual(second.textStorage.string, text.string)
+    }
+
+    @MainActor
+    func testWidthChangeIsMeasuredSeparately() {
+        let text = paragraph("换宽度必须重新测量。")
+        let view = InlineContentTextView()
+        let narrow = view.fittingSize(
+            width: 200,
+            attributedText: text,
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+        let wide = view.fittingSize(
+            width: 400,
+            attributedText: text,
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+
+        XCTAssertEqual(InlineContentTextMeasurementCache.cachedHeightCount, 2)
+        XCTAssertGreaterThanOrEqual(narrow.height, wide.height)
+    }
+
+    @MainActor
+    func testMeasurementCacheStaysBounded() {
+        for index in 0..<(InlineContentTextMeasurementCache.capacity + 32) {
+            InlineContentTextMeasurementCache.store(
+                height: CGFloat(index),
+                for: InlineContentTextMeasurementCache.Key(
+                    attributedText: paragraph("回复\(index)"),
+                    width: 320,
+                    maximumNumberOfLines: 0,
+                    lineBreakMode: NSLineBreakMode.byWordWrapping.rawValue,
+                    displayScale: 3,
+                    contentSizeCategory: UIContentSizeCategory.large.rawValue,
+                    legibilityWeight: UILegibilityWeight.regular.rawValue
+                )
+            )
+        }
+
+        XCTAssertLessThanOrEqual(
+            InlineContentTextMeasurementCache.cachedHeightCount,
+            InlineContentTextMeasurementCache.capacity
+        )
+        XCTAssertGreaterThan(InlineContentTextMeasurementCache.cachedHeightCount, 0)
+    }
+
+    @MainActor
+    func testDetachedViewIsRecycledBlankAndReused() async {
+        let view = InlineContentTextView()
+        view.accessibilityIdentifier = "thread-reply-text"
+        view.allowsTextSelection = true
+        view.apply(
+            attributedText: paragraph("上一行回复"),
+            renderID: 1,
+            maximumNumberOfLines: 2,
+            lineBreakMode: .byTruncatingTail
+        )
+
+        InlineContentTextViewPool.recycle(view)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(InlineContentTextViewPool.pooledViewCount, 1)
+
+        let reused = InlineContentTextViewPool.dequeue()
+        XCTAssertTrue(reused === view, "回收的文本视图应被下一行复用")
+        XCTAssertEqual(reused.textStorage.string, "")
+        XCTAssertNil(reused.accessibilityIdentifier)
+        XCTAssertFalse(reused.allowsTextSelection)
+        XCTAssertEqual(reused.textContainer.maximumNumberOfLines, 0)
+
+        // A fresh coordinator restarts render IDs at 1, so a recycled view must
+        // not mistake the next row's first run for one it already applied.
+        reused.apply(
+            attributedText: paragraph("下一行回复"),
+            renderID: 1,
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+        XCTAssertEqual(reused.textStorage.string, "下一行回复")
+    }
+
+    @MainActor
+    func testViewStillInAHierarchyIsNotReclaimed() async {
+        let container = UIView()
+        let view = InlineContentTextView()
+        container.addSubview(view)
+
+        InlineContentTextViewPool.recycle(view)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(
+            InlineContentTextViewPool.pooledViewCount,
+            0,
+            "SwiftUI 还持有的视图不能回收，否则下一行会和上一行抢同一个视图"
+        )
+    }
+
+    @MainActor
+    func testPoolStopsGrowingAtCapacity() async {
+        for _ in 0..<(InlineContentTextViewPool.capacity + 4) {
+            InlineContentTextViewPool.recycle(InlineContentTextView())
+        }
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            InlineContentTextViewPool.pooledViewCount,
+            InlineContentTextViewPool.capacity
+        )
+    }
+}


### PR DESCRIPTION
在 `fix/ios18-scroll-performance` 之上继续优化帖子页帧率，base 指向该分支。

## 改动

SwiftUI 没有 cell 复用，往回滚动时每行都从零重建。两处缓存：

- **段落高度跨视图共享**。高度只取决于富文本、宽度和文字环境，命中时跳过 `ensureLayout` 和 `super.sizeThatFits` 两趟排版。命中时仍然把文本装进视图——上次把整个 `fittingSize` 短路撞裂了文字裁切测试，因为它同时负责交付内容给实时视图。
- **文本视图复用池**。SwiftUI 交还一个 runloop 之后才回收，且只收已脱离层级的（`superview == nil && window == nil`）。

## 实测（每个文本块，40 段样本）

| 冷启动 | 命中高度缓存 | 视图也复用 |
|---|---|---|
| 1161µs | 546µs | 38µs |

其中 270µs 是 `UITextView()` 构造本身。

## 验证

- 单元测试 610 项全绿，新增 6 项：跨视图复用高度、换宽度重测、命中后视图仍持有正确文本、容量上限、挂在层级里的视图不回收、回收后 renderID 不串
- UI 测试：文字换行、复制选中、纯文本点击、楼中楼预览分隔、sheet 右滑关闭 全部通过
- 模拟器上下反复滚动，回收的视图无串内容

## 附带发现

`testSubpostPreviewAuthorAndReplyTargetOpenIndependentProfiles`、`testSubpostPreviewLayoutRemainsStableAfterProfileRoundTrip`、`testExpandedSubpostUsesSecondaryInteractiveUserNames` 在**未改动的 base 上同样失败**（stash 后 3/3 复现），均断言"点楼中楼预览里的用户名后个人主页出现"。这三个不在 CI 的 9 个用例里，所以 base 显示绿。建议单独查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)