### PR TITLE
修复进吧页面的 301 提示

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1243,7 +1243,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1260,7 +1260,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1313,7 +1313,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1333,7 +1333,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TiebaPure/Core/Network/TiebaEndpoint.swift
+++ b/TiebaPure/Core/Network/TiebaEndpoint.swift
@@ -104,7 +104,10 @@ enum TiebaEndpoint {
         case .followers:
             return Self.socialBase.appending(path: "/c/u/fans/page")
         case .resolveForumID:
-            return Self.base.appending(path: "/f/commit/share/fnameShareApi")
+            // The www host answers this path with a 301 down to plain http,
+            // which the client refuses to follow; the app host serves the same
+            // JSON over https.
+            return Self.appBase.appending(path: "/f/commit/share/fnameShareApi")
         case .forumMembership:
             return Self.socialBase.appending(path: "/c/f/forum/getUserForumLevelInfo")
         case .followForum:

--- a/project.yml
+++ b/project.yml
@@ -35,7 +35,7 @@ targets:
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         MARKETING_VERSION: 1.4.1
-        CURRENT_PROJECT_VERSION: 31
+        CURRENT_PROJECT_VERSION: 32
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -55,7 +55,7 @@ targets:
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
         MARKETING_VERSION: 1.4.1
-        CURRENT_PROJECT_VERSION: 31
+        CURRENT_PROJECT_VERSION: 32
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
按吧名进入贴吧时会弹「服务器暂时不可用（301）」，但帖子照常加载。

原因：解析吧 ID 的 tieba.baidu.com 接口现在把 https 301 降级到 http，客户端不跟随降级跳转，于是关注状态请求失败并弹错误。改用同样内容、支持 https 的 app 域名。

已用真实账号在模拟器验证：从最近浏览按吧名进入贴吧不再报错，关注状态正常显示。