### PR TITLE
吧页点击图片打开图片预览

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1247,7 +1247,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 39;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1264,7 +1264,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 39;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1317,7 +1317,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 39;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1337,7 +1337,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 39;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -12,6 +12,7 @@ struct ForumThreadsView: View {
     private let openSearchInParent: ((ForumSearchLaunchRoute) -> Void)?
     private let openUserInParent: ((UserSummary) -> Void)?
 
+    @Environment(\.readingPreferences) private var readingPreferences
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     @State private var threads: [ThreadSummary] = []
     @State private var page = 1
@@ -457,7 +458,17 @@ struct ForumThreadsView: View {
                                 forumID: thread.forumID ?? forum.id
                             )
                         },
-                        onOpenUser: openUser
+                        onOpenUser: openUser,
+                        onOpenMedia: { item, mediaItems, sourceFrame, sourceImage, sourceAnchor in
+                            openMedia(
+                                item,
+                                in: mediaItems,
+                                sourceFrame: sourceFrame,
+                                sourceImage: sourceImage,
+                                sourceAnchor: sourceAnchor,
+                                fallbackThread: thread
+                            )
+                        }
                     )
                     .onAppear {
                         guard PaginationPrefetchPolicy.shouldLoadMore(
@@ -723,6 +734,45 @@ struct ForumThreadsView: View {
     private var newThreadAccessibilityHint: String {
         guard account != nil else { return "登录后可以在本吧发布新帖" }
         return resolvedPostingForum == nil ? "正在获取贴吧信息" : "打开新帖编辑器"
+    }
+
+    /// Media in the list opens the picture or the video, the same as the home
+    /// feed; only media that carries neither falls back to the thread.
+    private func openMedia(
+        _ item: ReaderMediaItem,
+        in mediaItems: [ReaderMediaItem],
+        sourceFrame: CGRect?,
+        sourceImage: UIImage?,
+        sourceAnchor: ImagePreviewSourceAnchor?,
+        fallbackThread: ThreadSummary
+    ) {
+        switch HomeMediaActionPolicy.action(for: item, in: mediaItems) {
+        case let .previewImages(images, index):
+            ImagePreviewCoordinator.shared.present(
+                ImagePreviewSession(
+                    images: images,
+                    initialIndex: index,
+                    sourceFrame: sourceFrame,
+                    sourceImage: sourceImage,
+                    sourceAnchor: sourceAnchor,
+                    prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
+                )
+            )
+        case let .playVideo(video):
+            VideoPreviewCoordinator.shared.present(
+                VideoPreviewSession(
+                    video: video,
+                    sourceFrame: sourceFrame,
+                    sourceImage: sourceImage,
+                    sourceAnchor: sourceAnchor
+                )
+            )
+        case .openThread:
+            openThread(
+                threadID: fallbackThread.id,
+                forumID: fallbackThread.forumID ?? forum.id
+            )
+        }
     }
 
     private func openUser(_ user: UserSummary) {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -4653,7 +4653,7 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
-    func testForumListMediaAndWholeRowOpenThread() {
+    func testForumListMediaOpensPreviewAndWholeRowOpensThread() {
         let app = launchApp(scenario: "forumPinned")
         rootTab("进吧", in: app).tap()
         let forumField = app.textFields["输入吧名"]
@@ -4687,15 +4687,20 @@ final class TiebaPureUITests: XCTestCase {
         let media = app.buttons["media-item-image-1001-1"]
         XCTAssertTrue(media.waitForExistence(timeout: 5))
         XCTAssertTrue(
-            media.label.hasPrefix("打开帖子"),
-            "吧页媒体的 VoiceOver 动作必须说明真实目的地是帖子"
+            media.label.hasPrefix("帖子图片"),
+            "吧页媒体点开的是图片，VoiceOver 不能再说要进入帖子"
         )
+        media.tap()
+        let pager = app.descendants(matching: .any)["full-screen-image-pager"]
+        XCTAssertTrue(pager.waitForExistence(timeout: 8), "吧页点击图片应打开全屏预览")
+        dismissFullScreenImageBySingleTap(in: app)
+        XCTAssertTrue(pager.waitForNonExistence(timeout: 5))
 
         row.tap()
         XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
     }
 
-    func testForumManualMediaLoadsBeforeOpeningThread() {
+    func testForumManualMediaLoadsBeforeOpeningPreview() {
         let app = launchApp(
             scenario: "imageGesture",
             additionalArguments: ["UITEST_READING_MEDIA_MANUAL"]
@@ -4723,9 +4728,13 @@ final class TiebaPureUITests: XCTestCase {
             object: media
         )
         XCTAssertEqual(XCTWaiter.wait(for: [loaded], timeout: 5), .completed)
-        XCTAssertTrue(media.label.hasPrefix("打开帖子"))
+        XCTAssertTrue(media.label.hasPrefix("帖子图片"))
         media.tap()
-        XCTAssertTrue(app.buttons["thread-favorite-button"].waitForExistence(timeout: 8))
+        let pager = app.descendants(matching: .any)["full-screen-image-pager"]
+        XCTAssertTrue(pager.waitForExistence(timeout: 8), "加载完成后点击图片应打开全屏预览")
+        dismissFullScreenImageBySingleTap(in: app)
+        XCTAssertTrue(pager.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(app.navigationBars["测试吧"].exists)
     }
 
     func testForumLatestMenuSwitchesReplyPublishAndFeaturedCategories() {

--- a/project.yml
+++ b/project.yml
@@ -35,7 +35,7 @@ targets:
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         MARKETING_VERSION: 1.4.2
-        CURRENT_PROJECT_VERSION: 32
+        CURRENT_PROJECT_VERSION: 39
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -55,7 +55,7 @@ targets:
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
         MARKETING_VERSION: 1.4.2
-        CURRENT_PROJECT_VERSION: 32
+        CURRENT_PROJECT_VERSION: 39
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
首页、搜索和用户主页点击列表图片都会打开全屏图片，只有吧页把图片当装饰、点击进入帖子。现在统一为打开图片。

- 吧页列表的图片和视频改为打开预览 / 播放，没有图片或视频的媒体仍进入帖子
- 两个相关 UI 测试改为验证新行为，已在本地通过