### PR TITLE
修复 LiveContainer 视频无声音

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		7670D2DD682E7DA328CABB62 /* EmoticonResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2FAEA095A18F41BED60B8D /* EmoticonResourceTests.swift */; };
 		78CB3ACAE3BBCC622A4F0BDE /* ExternalRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFA01B546626F59DF261F1 /* ExternalRoute.swift */; };
 		7A6AB3811639046A81C2CB53 /* TiebaPostingBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC28DAC5B04603ABECBEBF97 /* TiebaPostingBootstrap.swift */; };
+		7ABBC168BCF747C297537AB6 /* VideoAudioSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FE6EA296C633FE6B2A0AD3 /* VideoAudioSessionTests.swift */; };
 		8013F79EDBAB28236D574DAD /* VoicePlaybackControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABAA8240FEE5D60D5C61349 /* VoicePlaybackControlTests.swift */; };
 		80239D3CC75F3B5A44A8BEDA /* TiebaPureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB433765723C53B6E8A6CA9B /* TiebaPureUITests.swift */; };
 		8028A9708BDE36C7BB815CEF /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DDB351392A69BC42810B9E /* SearchResult.swift */; };
@@ -133,6 +134,7 @@
 		C688BDA6203F519CDC265CA3 /* Agree.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8567BF0F4AD60813192B13FB /* Agree.pb.swift */; };
 		C7A32644A038BA4FDE2C2864 /* TiebaSocialAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B099CE340C14B26B97B9E57 /* TiebaSocialAPI.swift */; };
 		C9381BB37A6F1CDB5053291B /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68DE1DD356B7AC4AB669F8 /* UserProfile.swift */; };
+		CB1D4902DD8D6734B4DCE7FE /* VideoAudioSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328F6E71F4E2BC1211B413DF /* VideoAudioSessionController.swift */; };
 		CCA17993A164DE84409AF929 /* InteractiveNavigationPop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78FABF04E476AC1533EBDFA2 /* InteractiveNavigationPop.swift */; };
 		CDB537530EE8B4DF3E313407 /* ThreadFavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BC57D4AB4F3F67B48877D9 /* ThreadFavoritesView.swift */; };
 		CDEA6D379FC8528CC2581C94 /* ShortPullRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E53AE6B81F63DC0CDEC38B8 /* ShortPullRefresh.swift */; };
@@ -252,11 +254,13 @@
 		2758D17C77814946EB5560DA /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		277C554E042BEC92DDCC065C /* MediaGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaGridView.swift; sourceTree = "<group>"; };
 		2792F6DFB423B6000542ADFB /* TiebaPostingBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPostingBootstrapTests.swift; sourceTree = "<group>"; };
+		28FE6EA296C633FE6B2A0AD3 /* VideoAudioSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionTests.swift; sourceTree = "<group>"; };
 		2C32C727ADE31C67A3B02736 /* BrowsingHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingHistoryView.swift; sourceTree = "<group>"; };
 		2E36ED28464DB4F8E2D7BD1D /* TiebaPureUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TiebaPureUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E5B4C5570D72B5D840721B1 /* SocialMutationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialMutationCoordinator.swift; sourceTree = "<group>"; };
 		2EEC46053EBCA8CC54720306 /* TiebaPure.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = TiebaPure.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F8B5E81584991818D0E2DA6 /* PbPage_PbPageRequest.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PbPage_PbPageRequest.pb.swift; sourceTree = "<group>"; };
+		328F6E71F4E2BC1211B413DF /* VideoAudioSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionController.swift; sourceTree = "<group>"; };
 		333F591DE0CE0B528CDEFA2F /* SearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsView.swift; sourceTree = "<group>"; };
 		33822A8A48EC0393DD592DDA /* TiebaEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaEndpoint.swift; sourceTree = "<group>"; };
 		356FA7F667F83C07E1845A80 /* ContentComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentComposerView.swift; sourceTree = "<group>"; };
@@ -669,6 +673,7 @@
 				9CE43843ABF0E6FE36F6A7BD /* TiebaURLTests.swift */,
 				9F1C4599FA7188B0D810AE19 /* UserProfileMutationTests.swift */,
 				3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */,
+				28FE6EA296C633FE6B2A0AD3 /* VideoAudioSessionTests.swift */,
 				DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */,
 				3ABAA8240FEE5D60D5C61349 /* VoicePlaybackControlTests.swift */,
 				273C5E55B0D298678C72F894 /* VoicePlaybackTests.swift */,
@@ -704,6 +709,7 @@
 				AF02A66EF1B9089518F9ED99 /* ImageViewer.swift */,
 				034D76B7DA1D80733B718828 /* MediaPreviewHeroAnimator.swift */,
 				87A89193F661C5F61F3470AC /* MediaPreviewPresentationArbiter.swift */,
+				328F6E71F4E2BC1211B413DF /* VideoAudioSessionController.swift */,
 				094DB1CB5AD5C781A07443AB /* VideoDownloadService.swift */,
 				AABE9716DCC2C5720A003041 /* VideoPlayerView.swift */,
 				FF513D0BD122423A4CA7423D /* VideoPreviewTransition.swift */,
@@ -1129,6 +1135,7 @@
 				C9381BB37A6F1CDB5053291B /* UserProfile.swift in Sources */,
 				E3CF1C9A62133316FF6D93E2 /* UserProfileMapper.swift in Sources */,
 				470AA98A8CA5F65598F45AFF /* UserProfileView.swift in Sources */,
+				CB1D4902DD8D6734B4DCE7FE /* VideoAudioSessionController.swift in Sources */,
 				C15EE49DE3EBED2B54FBC650 /* VideoDownloadService.swift in Sources */,
 				AA3AF8E9A9956DD4FAEA8638 /* VideoInfo.pb.swift in Sources */,
 				CE70750547AFB3CB53EDE288 /* VideoPlayerView.swift in Sources */,
@@ -1172,6 +1179,7 @@
 				450F423517B8D1DEFD51B15B /* TiebaURLTests.swift in Sources */,
 				B673FC1D9439E3D10DF147C0 /* UserProfileMutationTests.swift in Sources */,
 				DE64CDA4FA60F57188F7BC53 /* UserProfileTests.swift in Sources */,
+				7ABBC168BCF747C297537AB6 /* VideoAudioSessionTests.swift in Sources */,
 				3E9872C838729BB48E4DD67A /* VideoPreviewTests.swift in Sources */,
 				8013F79EDBAB28236D574DAD /* VoicePlaybackControlTests.swift in Sources */,
 				07DE68396A13E2AD45D1B77F /* VoicePlaybackTests.swift in Sources */,
@@ -1279,13 +1287,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1296,14 +1304,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1349,14 +1357,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1369,13 +1377,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.3;
+				MARKETING_VERSION = 1.4.4;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Features/Media/VideoAudioSessionController.swift
+++ b/TiebaPure/Features/Media/VideoAudioSessionController.swift
@@ -1,0 +1,289 @@
+import AVFoundation
+
+struct MediaAudioSessionConfiguration: Equatable {
+    let category: AVAudioSession.Category
+    let mode: AVAudioSession.Mode
+    let options: AVAudioSession.CategoryOptions
+
+    static let moviePlayback = MediaAudioSessionConfiguration(
+        category: .playback,
+        mode: .moviePlayback,
+        options: []
+    )
+
+    static let voicePlayback = MediaAudioSessionConfiguration(
+        category: .playback,
+        mode: .spokenAudio,
+        options: []
+    )
+}
+
+enum MediaAudioSessionOwner: Equatable {
+    case video
+    case voice
+}
+
+struct MediaAudioSessionLease: Equatable {
+    fileprivate let token: UUID
+    let owner: MediaAudioSessionOwner
+}
+
+@MainActor
+protocol MediaAudioSessionBackend: AnyObject {
+    var configuration: MediaAudioSessionConfiguration { get }
+
+    func setConfiguration(_ configuration: MediaAudioSessionConfiguration) throws
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
+}
+
+@MainActor
+final class SystemMediaAudioSessionBackend: MediaAudioSessionBackend {
+    private let session: AVAudioSession
+
+    init(session: AVAudioSession = .sharedInstance()) {
+        self.session = session
+    }
+
+    var configuration: MediaAudioSessionConfiguration {
+        MediaAudioSessionConfiguration(
+            category: session.category,
+            mode: session.mode,
+            options: session.categoryOptions
+        )
+    }
+
+    func setConfiguration(_ configuration: MediaAudioSessionConfiguration) throws {
+        try session.setCategory(
+            configuration.category,
+            mode: configuration.mode,
+            options: configuration.options
+        )
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        try session.setActive(active, options: options)
+    }
+}
+
+@MainActor
+protocol MediaAudioSessionCoordinating: AnyObject {
+    func acquire(
+        owner: MediaAudioSessionOwner,
+        configuration: MediaAudioSessionConfiguration
+    ) throws -> MediaAudioSessionLease
+    func release(_ lease: MediaAudioSessionLease) -> Bool
+    func isCurrent(_ lease: MediaAudioSessionLease) -> Bool
+}
+
+@MainActor
+final class MediaAudioSessionCoordinator: MediaAudioSessionCoordinating {
+    static let shared = MediaAudioSessionCoordinator()
+
+    private let backend: any MediaAudioSessionBackend
+    private let releaseRetryDelays: [UInt64]
+    private var baselineConfiguration: MediaAudioSessionConfiguration?
+    private var currentLease: MediaAudioSessionLease?
+    private var currentConfiguration: MediaAudioSessionConfiguration?
+    private var releaseRetryTask: Task<Void, Never>?
+
+    init(
+        backend: (any MediaAudioSessionBackend)? = nil,
+        releaseRetryDelays: [UInt64] = [100_000_000, 300_000_000, 900_000_000]
+    ) {
+        self.backend = backend ?? SystemMediaAudioSessionBackend()
+        self.releaseRetryDelays = releaseRetryDelays
+    }
+
+    func acquire(
+        owner: MediaAudioSessionOwner,
+        configuration: MediaAudioSessionConfiguration
+    ) throws -> MediaAudioSessionLease {
+        cancelReleaseRetry()
+        let nextLease = MediaAudioSessionLease(token: UUID(), owner: owner)
+
+        if let currentLease,
+           currentLease.owner == owner,
+           currentConfiguration == configuration {
+            do {
+                try backend.setConfiguration(configuration)
+                try backend.setActive(true, options: [])
+                self.currentLease = nextLease
+                return nextLease
+            } catch {
+                scheduleReleaseRetry(for: currentLease)
+                throw error
+            }
+        }
+
+        if baselineConfiguration == nil {
+            baselineConfiguration = backend.configuration
+        }
+
+        if let previousLease = currentLease,
+           let previousConfiguration = currentConfiguration {
+            do {
+                try backend.setActive(false, options: .notifyOthersOnDeactivation)
+                try backend.setConfiguration(configuration)
+                try backend.setActive(true, options: [])
+                currentLease = nextLease
+                currentConfiguration = configuration
+                return nextLease
+            } catch {
+                let handoffError = error
+                var restoredPreviousOwner = true
+                do {
+                    try backend.setConfiguration(previousConfiguration)
+                } catch {
+                    restoredPreviousOwner = false
+                }
+                do {
+                    try backend.setActive(true, options: [])
+                } catch {
+                    restoredPreviousOwner = false
+                }
+                if restoredPreviousOwner == false {
+                    scheduleReleaseRetry(for: previousLease)
+                }
+                throw handoffError
+            }
+        }
+
+        do {
+            try backend.setConfiguration(configuration)
+            try backend.setActive(true, options: [])
+            currentLease = nextLease
+            currentConfiguration = configuration
+            return nextLease
+        } catch {
+            let activationError = error
+            currentLease = nextLease
+            currentConfiguration = configuration
+            if restoreBaseline(for: nextLease) == false {
+                scheduleReleaseRetry(for: nextLease)
+            }
+            throw activationError
+        }
+    }
+
+    func release(_ lease: MediaAudioSessionLease) -> Bool {
+        guard isCurrent(lease) else { return true }
+        cancelReleaseRetry()
+        guard restoreBaseline(for: lease) else {
+            scheduleReleaseRetry(for: lease)
+            return false
+        }
+        return true
+    }
+
+    func isCurrent(_ lease: MediaAudioSessionLease) -> Bool {
+        currentLease == lease
+    }
+
+    private func restoreBaseline(for lease: MediaAudioSessionLease) -> Bool {
+        guard isCurrent(lease), let baselineConfiguration else { return true }
+        do {
+            try backend.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            return false
+        }
+        do {
+            try backend.setConfiguration(baselineConfiguration)
+        } catch {
+            return false
+        }
+        currentLease = nil
+        currentConfiguration = nil
+        self.baselineConfiguration = nil
+        return true
+    }
+
+    private func scheduleReleaseRetry(for lease: MediaAudioSessionLease) {
+        guard isCurrent(lease),
+              releaseRetryTask == nil,
+              releaseRetryDelays.isEmpty == false else {
+            return
+        }
+        releaseRetryTask = Task { @MainActor [self] in
+            for delay in releaseRetryDelays {
+                do {
+                    try await Task.sleep(nanoseconds: delay)
+                } catch {
+                    releaseRetryTask = nil
+                    return
+                }
+                guard isCurrent(lease) else {
+                    releaseRetryTask = nil
+                    return
+                }
+                if restoreBaseline(for: lease) {
+                    releaseRetryTask = nil
+                    return
+                }
+            }
+            releaseRetryTask = nil
+        }
+    }
+
+    private func cancelReleaseRetry() {
+        releaseRetryTask?.cancel()
+        releaseRetryTask = nil
+    }
+}
+
+@MainActor
+final class VideoAudioSessionLifecycle {
+    private let coordinator: any MediaAudioSessionCoordinating
+    private var lease: MediaAudioSessionLease?
+
+    private(set) var hasActiveLease = false
+
+    init(coordinator: (any MediaAudioSessionCoordinating)? = nil) {
+        self.coordinator = coordinator ?? MediaAudioSessionCoordinator.shared
+    }
+
+    func activate() throws {
+        guard hasActiveLease == false else { return }
+        let lease = try coordinator.acquire(
+            owner: .video,
+            configuration: .moviePlayback
+        )
+        self.lease = lease
+        hasActiveLease = true
+    }
+
+    func deactivate() {
+        hasActiveLease = false
+        guard let lease else { return }
+        if coordinator.release(lease) {
+            self.lease = nil
+        }
+    }
+
+    @discardableResult
+    func relinquishForExternalPlayback() -> Bool {
+        hasActiveLease = false
+        guard let lease else { return true }
+        let didRelease = coordinator.release(lease)
+        if didRelease {
+            self.lease = nil
+        }
+        return didRelease
+    }
+}
+
+enum VideoAudioSessionPlaybackPolicy {
+    static func requiresActiveSession(for status: AVPlayer.TimeControlStatus) -> Bool {
+        switch status {
+        case .playing, .waitingToPlayAtSpecifiedRate:
+            return true
+        case .paused:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    static func shouldPauseForRouteChange(_ reason: AVAudioSession.RouteChangeReason) -> Bool {
+        reason == .oldDeviceUnavailable
+    }
+}

--- a/TiebaPure/Features/Media/VideoPreviewTransition.swift
+++ b/TiebaPure/Features/Media/VideoPreviewTransition.swift
@@ -470,6 +470,7 @@ private final class VideoPreviewController: UIViewController,
     private let videoURL: URL
     private let player = AVPlayer()
     private let playerController = AVPlayerViewController()
+    private let audioSessionLifecycle: VideoAudioSessionLifecycle
     private let posterView = UIImageView()
     private let loadingIndicator = UIActivityIndicatorView(style: .medium)
     private let failureView = UIView()
@@ -486,6 +487,8 @@ private final class VideoPreviewController: UIViewController,
     private var failedToPlayObserver: NSObjectProtocol?
     private var voicePlaybackObserver: NSObjectProtocol?
     private var backgroundObserver: NSObjectProtocol?
+    private var routeChangeObserver: NSObjectProtocol?
+    private var interruptionObserver: NSObjectProtocol?
     private var posterAnimator: UIViewPropertyAnimator?
     private var gestureRestoreAnimator: UIViewPropertyAnimator?
     private var dismissalInteractionGate: MediaPreviewDismissalInteractionGate?
@@ -511,10 +514,12 @@ private final class VideoPreviewController: UIViewController,
         onDismissalBegan: @escaping (UUID) -> Void,
         onDismissalFinished: @escaping (UUID) -> Void,
         onPresentationCancelled: @escaping (UUID) -> Void,
-        onDismissalCancelled: @escaping (UUID) -> Void
+        onDismissalCancelled: @escaping (UUID) -> Void,
+        audioSessionLifecycle: VideoAudioSessionLifecycle? = nil
     ) {
         self.session = session
         self.videoURL = videoURL
+        self.audioSessionLifecycle = audioSessionLifecycle ?? VideoAudioSessionLifecycle()
         self.onDismissalBegan = onDismissalBegan
         self.onDismissalFinished = onDismissalFinished
         self.onPresentationCancelled = onPresentationCancelled
@@ -828,6 +833,7 @@ private final class VideoPreviewController: UIViewController,
 
     private func startVideoPreparation() {
         cancelVideoPreparation(removePreparedFile: true, clearsPlayerItem: true)
+        failureLabel.text = "视频加载失败\n请检查网络后重试"
         failureView.isHidden = true
         firstFrameReady = false
         isPreparingVideo = true
@@ -921,10 +927,11 @@ private final class VideoPreviewController: UIViewController,
         timeControlObservation = player.observe(
             \.timeControlStatus,
             options: [.new]
-        ) { _, change in
-            guard change.newValue == .playing else { return }
+        ) { [weak self] player, change in
+            guard let status = change.newValue else { return }
             DispatchQueue.main.async {
-                VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
+                guard player.timeControlStatus == status else { return }
+                self?.handleTimeControlStatus(status)
             }
         }
         voicePlaybackObserver = NotificationCenter.default.addObserver(
@@ -932,14 +939,62 @@ private final class VideoPreviewController: UIViewController,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.player.pause()
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.player.pause()
+                _ = self.audioSessionLifecycle.relinquishForExternalPlayback()
+            }
         }
         backgroundObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.didEnterBackgroundNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.player.pause()
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.player.pause()
+                self.audioSessionLifecycle.deactivate()
+            }
+        }
+        routeChangeObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                guard let rawReason = (notification.userInfo?[AVAudioSessionRouteChangeReasonKey]
+                    as? NSNumber)?.uintValue,
+                    let reason = AVAudioSession.RouteChangeReason(rawValue: rawReason),
+                    VideoAudioSessionPlaybackPolicy.shouldPauseForRouteChange(reason) else {
+                    return
+                }
+                guard let self else { return }
+                self.player.pause()
+                self.audioSessionLifecycle.deactivate()
+            }
+        }
+        interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                guard let rawType = (notification.userInfo?[AVAudioSessionInterruptionTypeKey]
+                    as? NSNumber)?.uintValue,
+                    AVAudioSession.InterruptionType(rawValue: rawType) == .began else {
+                    return
+                }
+                guard let self else { return }
+                self.player.pause()
+                self.audioSessionLifecycle.deactivate()
+            }
+        }
+    }
+
+    private func handleTimeControlStatus(_ status: AVPlayer.TimeControlStatus) {
+        guard didReleasePlayer == false else { return }
+        if VideoAudioSessionPlaybackPolicy.requiresActiveSession(for: status) {
+            _ = activateAudioSessionIfNeeded()
         }
     }
 
@@ -960,12 +1015,16 @@ private final class VideoPreviewController: UIViewController,
         }
     }
 
-    private func showPlaybackFailure() {
+    private func showPlaybackFailure(message: String? = nil) {
         guard didReleasePlayer == false else { return }
         player.pause()
+        audioSessionLifecycle.deactivate()
         isPreparingVideo = false
         hasPlaybackFailure = true
         updateLoadingIndicator()
+        if let message {
+            failureLabel.text = message
+        }
         failureView.isHidden = false
     }
 
@@ -984,12 +1043,38 @@ private final class VideoPreviewController: UIViewController,
             presentationFinished: didFinishPresentation,
             dismissalStarted: dismissalLifecycle.dismissalStarted,
             applicationIsActive: UIApplication.shared.applicationState == .active
-        ), didReleasePlayer == false else {
+        ), didReleasePlayer == false,
+           player.currentItem != nil else {
             player.pause()
+            audioSessionLifecycle.deactivate()
             return
         }
-        VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart()
+        guard activateAudioSessionIfNeeded() else { return }
         player.play()
+    }
+
+    @discardableResult
+    private func activateAudioSessionIfNeeded() -> Bool {
+        guard didReleasePlayer == false,
+              dismissalLifecycle.dismissalStarted == false,
+              UIApplication.shared.applicationState == .active,
+              player.currentItem != nil else {
+            player.pause()
+            audioSessionLifecycle.deactivate()
+            return false
+        }
+        guard audioSessionLifecycle.hasActiveLease == false else { return true }
+        guard VoicePlaybackCoordinator.shared.handleVideoPlaybackWillStart() else {
+            showPlaybackFailure(message: "无法切换视频声音\n请稍后重试")
+            return false
+        }
+        do {
+            try audioSessionLifecycle.activate()
+            return true
+        } catch {
+            showPlaybackFailure(message: "无法启用视频声音\n请稍后重试")
+            return false
+        }
     }
 
     private func updatePosterVisibility(animated: Bool) {
@@ -1034,6 +1119,7 @@ private final class VideoPreviewController: UIViewController,
         updateLoadingIndicator()
         cancelVideoPreparation(removePreparedFile: true, clearsPlayerItem: false)
         player.pause()
+        audioSessionLifecycle.deactivate()
         playerController.showsPlaybackControls = false
         updatePosterVisibility(animated: false)
     }
@@ -1173,7 +1259,16 @@ private final class VideoPreviewController: UIViewController,
             NotificationCenter.default.removeObserver(backgroundObserver)
             self.backgroundObserver = nil
         }
+        if let routeChangeObserver {
+            NotificationCenter.default.removeObserver(routeChangeObserver)
+            self.routeChangeObserver = nil
+        }
+        if let interruptionObserver {
+            NotificationCenter.default.removeObserver(interruptionObserver)
+            self.interruptionObserver = nil
+        }
         player.pause()
+        audioSessionLifecycle.deactivate()
         player.replaceCurrentItem(with: nil)
         playerController.player = nil
     }

--- a/TiebaPure/Features/Voice/VoicePlaybackCoordinator.swift
+++ b/TiebaPure/Features/Voice/VoicePlaybackCoordinator.swift
@@ -181,59 +181,36 @@ private final class SystemVoiceAudioPlayer: NSObject, VoiceAudioPlayer, AVAudioP
 
 @MainActor
 final class SystemVoiceAudioSessionController: VoiceAudioSessionControlling {
-    private struct Configuration {
-        let category: AVAudioSession.Category
-        let mode: AVAudioSession.Mode
-        let options: AVAudioSession.CategoryOptions
+    private let coordinator: any MediaAudioSessionCoordinating
+    private var lease: MediaAudioSessionLease?
+
+    init(coordinator: (any MediaAudioSessionCoordinating)? = nil) {
+        self.coordinator = coordinator ?? MediaAudioSessionCoordinator.shared
     }
 
-    private var previousConfiguration: Configuration?
-
     func activate() throws {
-        let session = AVAudioSession.sharedInstance()
-        if previousConfiguration == nil {
-            previousConfiguration = Configuration(
-                category: session.category,
-                mode: session.mode,
-                options: session.categoryOptions
-            )
-        }
-        try session.setCategory(.playback, mode: .spokenAudio, options: [])
-        try session.setActive(true)
+        lease = try coordinator.acquire(
+            owner: .voice,
+            configuration: .voicePlayback
+        )
     }
 
     func deactivate() throws {
-        guard let previousConfiguration else { return }
-        let session = AVAudioSession.sharedInstance()
-        var firstError: (any Error)?
-        do {
-            try session.setActive(
-                false,
-                options: .notifyOthersOnDeactivation
-            )
-        } catch {
-            firstError = error
+        guard let lease else { return }
+        guard coordinator.release(lease) else {
+            throw MediaAudioSessionReleaseError.deactivationFailed
         }
-        do {
-            try session.setCategory(
-                previousConfiguration.category,
-                mode: previousConfiguration.mode,
-                options: previousConfiguration.options
-            )
-        } catch {
-            if firstError == nil {
-                firstError = error
-            }
-        }
-        if let firstError {
-            throw firstError
-        }
-        self.previousConfiguration = nil
+        self.lease = nil
     }
 
     func relinquish() {
-        previousConfiguration = nil
+        guard let lease, coordinator.isCurrent(lease) == false else { return }
+        self.lease = nil
     }
+}
+
+private enum MediaAudioSessionReleaseError: Error {
+    case deactivationFailed
 }
 
 @MainActor
@@ -404,10 +381,14 @@ final class VoicePlaybackCoordinator: ObservableObject {
         wasPlayingBeforeInterruption = false
     }
 
-    func handleVideoPlaybackWillStart() {
+    @discardableResult
+    func handleVideoPlaybackWillStart() -> Bool {
         generation &+= 1
-        tearDownCurrentPlayback(releasePolicy: .transferToExternalPlayback)
+        let didReleaseAudioSession = tearDownCurrentPlayback(
+            releasePolicy: .transferToExternalPlayback
+        )
         state = .idle
+        return didReleaseAudioSession
     }
 
     private func beginLoading(key: String) {
@@ -612,9 +593,10 @@ final class VoicePlaybackCoordinator: ObservableObject {
         case transferToExternalPlayback
     }
 
+    @discardableResult
     private func tearDownCurrentPlayback(
         releasePolicy: AudioSessionReleasePolicy = .retry
-    ) {
+    ) -> Bool {
         loadTask?.cancel()
         loadTask = nil
         progressTask?.cancel()
@@ -626,8 +608,9 @@ final class VoicePlaybackCoordinator: ObservableObject {
         switch releasePolicy {
         case .retry:
             deactivateOwnedAudioSession()
+            return true
         case .transferToExternalPlayback:
-            relinquishAudioSessionToExternalPlayback()
+            return relinquishAudioSessionToExternalPlayback()
         }
     }
 
@@ -638,14 +621,22 @@ final class VoicePlaybackCoordinator: ObservableObject {
         try audioSession.activate()
     }
 
-    private func relinquishAudioSessionToExternalPlayback() {
+    private func relinquishAudioSessionToExternalPlayback() -> Bool {
         audioSessionLeaseGeneration &+= 1
         cancelAudioSessionReleaseRetry()
-        if ownsAudioSession {
-            try? audioSession.deactivate()
+        guard ownsAudioSession else {
+            audioSession.relinquish()
+            return true
         }
-        audioSession.relinquish()
-        ownsAudioSession = false
+        do {
+            try audioSession.deactivate()
+            audioSession.relinquish()
+            ownsAudioSession = false
+            return true
+        } catch {
+            scheduleAudioSessionReleaseRetry()
+            return false
+        }
     }
 
     private func deactivateOwnedAudioSession() {

--- a/TiebaPureTests/VideoAudioSessionTests.swift
+++ b/TiebaPureTests/VideoAudioSessionTests.swift
@@ -1,0 +1,283 @@
+import AVFoundation
+import XCTest
+@testable import TiebaPure
+
+@MainActor
+final class VideoAudioSessionTests: XCTestCase {
+    private let hostConfiguration = MediaAudioSessionConfiguration(
+        category: .ambient,
+        mode: .default,
+        options: [.mixWithOthers]
+    )
+
+    func testMoviePlaybackIgnoresSilentSwitchAndRestoresHostConfiguration() throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(backend: backend)
+        let lifecycle = VideoAudioSessionLifecycle(coordinator: coordinator)
+
+        try lifecycle.activate()
+
+        XCTAssertTrue(lifecycle.hasActiveLease)
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+        XCTAssertEqual(backend.activeCalls.map(\.active), [true])
+
+        lifecycle.deactivate()
+
+        XCTAssertFalse(lifecycle.hasActiveLease)
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+        XCTAssertEqual(backend.activeCalls.map(\.active), [true, false])
+        XCTAssertTrue(backend.activeCalls[1].options.contains(.notifyOthersOnDeactivation))
+    }
+
+    func testActivationFailureRollsBackHostConfigurationBeforeRetry() throws {
+        let backend = FakeMediaAudioSessionBackend(
+            configuration: hostConfiguration,
+            activationFailuresRemaining: 1
+        )
+        let coordinator = MediaAudioSessionCoordinator(backend: backend)
+        let lifecycle = VideoAudioSessionLifecycle(coordinator: coordinator)
+
+        XCTAssertThrowsError(try lifecycle.activate())
+        XCTAssertFalse(lifecycle.hasActiveLease)
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+        XCTAssertEqual(backend.activeCalls.map(\.active), [true, false])
+
+        try lifecycle.activate()
+        XCTAssertTrue(lifecycle.hasActiveLease)
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+    }
+
+    func testLifecycleActivationAndExitReleaseAreIdempotent() throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(backend: backend)
+        let lifecycle = VideoAudioSessionLifecycle(coordinator: coordinator)
+
+        try lifecycle.activate()
+        try lifecycle.activate()
+        XCTAssertEqual(backend.activeCalls.map(\.active), [true])
+
+        lifecycle.deactivate()
+        lifecycle.deactivate()
+        XCTAssertEqual(backend.activeCalls.map(\.active), [true, false])
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+    }
+
+    func testBackgroundStyleReleaseRetriesTransientDeactivationFailure() async throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(
+            backend: backend,
+            releaseRetryDelays: [1_000_000]
+        )
+        let lifecycle = VideoAudioSessionLifecycle(coordinator: coordinator)
+        try lifecycle.activate()
+        backend.failNextDeactivations(1)
+
+        lifecycle.deactivate()
+
+        XCTAssertFalse(lifecycle.hasActiveLease)
+        try await waitUntil {
+            backend.configuration == self.hostConfiguration
+                && backend.activeCalls.filter { $0.active == false }.count == 2
+        }
+        XCTAssertEqual(backend.configurationCalls.filter { $0 == hostConfiguration }.count, 1)
+    }
+
+    func testStaleVideoLeaseCannotDeactivateNewVoiceOwner() throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(backend: backend)
+        let videoLease = try coordinator.acquire(
+            owner: .video,
+            configuration: .moviePlayback
+        )
+        let voiceLease = try coordinator.acquire(
+            owner: .voice,
+            configuration: .voicePlayback
+        )
+        let callsBeforeStaleRelease = backend.activeCalls.count
+
+        XCTAssertTrue(coordinator.release(videoLease))
+
+        XCTAssertEqual(backend.activeCalls.count, callsBeforeStaleRelease)
+        XCTAssertTrue(coordinator.isCurrent(voiceLease))
+        XCTAssertEqual(backend.configuration, .voicePlayback)
+
+        XCTAssertTrue(coordinator.release(voiceLease))
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+        XCTAssertEqual(backend.configurationCalls.filter { $0 == hostConfiguration }.count, 1)
+    }
+
+    func testSameOwnerReacquisitionIssuesNewTokenAndMakesOldVideoLeaseStale() throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(backend: backend)
+        let firstLease = try coordinator.acquire(
+            owner: .video,
+            configuration: .moviePlayback
+        )
+        let secondLease = try coordinator.acquire(
+            owner: .video,
+            configuration: .moviePlayback
+        )
+        let callsBeforeStaleRelease = backend.activeCalls.count
+
+        XCTAssertNotEqual(firstLease, secondLease)
+        XCTAssertTrue(coordinator.release(firstLease))
+        XCTAssertEqual(backend.activeCalls.count, callsBeforeStaleRelease)
+        XCTAssertTrue(coordinator.isCurrent(secondLease))
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+
+        XCTAssertTrue(coordinator.release(secondLease))
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+    }
+
+    func testFailedOwnerHandoffKeepsPreviousLeaseCurrentUntilReleaseSucceeds() throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(
+            backend: backend,
+            releaseRetryDelays: []
+        )
+        let videoLease = try coordinator.acquire(
+            owner: .video,
+            configuration: .moviePlayback
+        )
+        backend.failNextDeactivations(1)
+
+        XCTAssertThrowsError(try coordinator.acquire(
+            owner: .voice,
+            configuration: .voicePlayback
+        ))
+
+        XCTAssertTrue(coordinator.isCurrent(videoLease))
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+        XCTAssertTrue(coordinator.release(videoLease))
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+    }
+
+    func testRecoveredOwnerHandoffFailureDoesNotLaterReleasePreviousLease() async throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(
+            backend: backend,
+            releaseRetryDelays: [5_000_000]
+        )
+        let videoLease = try coordinator.acquire(
+            owner: .video,
+            configuration: .moviePlayback
+        )
+        backend.failNextDeactivations(1)
+
+        XCTAssertThrowsError(try coordinator.acquire(
+            owner: .voice,
+            configuration: .voicePlayback
+        ))
+        try await Task.sleep(nanoseconds: 25_000_000)
+
+        XCTAssertTrue(coordinator.isCurrent(videoLease))
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+        XCTAssertEqual(backend.activeCalls.filter { $0.active == false }.count, 1)
+
+        XCTAssertTrue(coordinator.release(videoLease))
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+    }
+
+    func testVideoAndVoiceControllersShareTokenizedProcessCoordinator() throws {
+        let backend = FakeMediaAudioSessionBackend(configuration: hostConfiguration)
+        let coordinator = MediaAudioSessionCoordinator(backend: backend)
+        let video = VideoAudioSessionLifecycle(coordinator: coordinator)
+        let voice = SystemVoiceAudioSessionController(coordinator: coordinator)
+
+        try video.activate()
+        try voice.activate()
+        XCTAssertEqual(backend.configuration, .voicePlayback)
+
+        video.deactivate()
+        XCTAssertEqual(backend.configuration, .voicePlayback)
+
+        try voice.deactivate()
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+
+        try voice.activate()
+        try video.activate()
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+
+        XCTAssertNoThrow(try voice.deactivate())
+        XCTAssertEqual(backend.configuration, .moviePlayback)
+        video.deactivate()
+        XCTAssertEqual(backend.configuration, hostConfiguration)
+    }
+
+    func testWaitingAndPlayingRequireSessionButPausedDoesNotReleaseByStatusAlone() {
+        XCTAssertTrue(VideoAudioSessionPlaybackPolicy.requiresActiveSession(for: .playing))
+        XCTAssertTrue(VideoAudioSessionPlaybackPolicy.requiresActiveSession(
+            for: .waitingToPlayAtSpecifiedRate
+        ))
+        XCTAssertFalse(VideoAudioSessionPlaybackPolicy.requiresActiveSession(for: .paused))
+    }
+
+    func testOnlyHeadphoneStyleRouteLossRequiresProtectivePause() {
+        XCTAssertTrue(VideoAudioSessionPlaybackPolicy.shouldPauseForRouteChange(
+            .oldDeviceUnavailable
+        ))
+        XCTAssertFalse(VideoAudioSessionPlaybackPolicy.shouldPauseForRouteChange(.newDeviceAvailable))
+        XCTAssertFalse(VideoAudioSessionPlaybackPolicy.shouldPauseForRouteChange(.categoryChange))
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 500_000_000,
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while condition() == false {
+            guard DispatchTime.now().uptimeNanoseconds < deadline else {
+                return XCTFail("Timed out waiting for audio session state")
+            }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+}
+
+@MainActor
+private final class FakeMediaAudioSessionBackend: MediaAudioSessionBackend {
+    struct ActiveCall {
+        let active: Bool
+        let options: AVAudioSession.SetActiveOptions
+    }
+
+    var configuration: MediaAudioSessionConfiguration
+    private(set) var configurationCalls: [MediaAudioSessionConfiguration] = []
+    private(set) var activeCalls: [ActiveCall] = []
+    private var activationFailuresRemaining: Int
+    private var deactivationFailuresRemaining = 0
+
+    init(
+        configuration: MediaAudioSessionConfiguration,
+        activationFailuresRemaining: Int = 0
+    ) {
+        self.configuration = configuration
+        self.activationFailuresRemaining = activationFailuresRemaining
+    }
+
+    func failNextDeactivations(_ count: Int) {
+        deactivationFailuresRemaining = count
+    }
+
+    func setConfiguration(_ configuration: MediaAudioSessionConfiguration) throws {
+        configurationCalls.append(configuration)
+        self.configuration = configuration
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        activeCalls.append(ActiveCall(active: active, options: options))
+        if active, activationFailuresRemaining > 0 {
+            activationFailuresRemaining -= 1
+            throw FakeMediaAudioSessionError.activationFailed
+        }
+        if active == false, deactivationFailuresRemaining > 0 {
+            deactivationFailuresRemaining -= 1
+            throw FakeMediaAudioSessionError.deactivationFailed
+        }
+    }
+}
+
+private enum FakeMediaAudioSessionError: Error {
+    case activationFailed
+    case deactivationFailed
+}

--- a/TiebaPureTests/VoicePlaybackTests.swift
+++ b/TiebaPureTests/VoicePlaybackTests.swift
@@ -386,7 +386,7 @@ final class VoicePlaybackCoordinatorTests: XCTestCase {
         XCTAssertEqual(audioSession.deactivationCount, 0)
     }
 
-    func testVideoTakeoverCancelsFailedReleaseRetryAndRelinquishesLease() async throws {
+    func testVideoTakeoverWaitsForFailedVoiceReleaseBeforeRelinquishingLease() async throws {
         let loader = ControlledVoiceAudioLoader()
         let playerFactory = FakeVoiceAudioPlayerFactory()
         let audioSession = FakeVoiceAudioSessionController(
@@ -407,14 +407,17 @@ final class VoicePlaybackCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.state.phase, .paused)
         XCTAssertEqual(audioSession.deactivationCount, 1)
 
-        coordinator.handleVideoPlaybackWillStart()
+        XCTAssertFalse(coordinator.handleVideoPlaybackWillStart())
         XCTAssertEqual(coordinator.state, .idle)
         XCTAssertEqual(audioSession.deactivationCount, 2)
-        XCTAssertEqual(audioSession.relinquishCount, 1)
+        XCTAssertEqual(audioSession.relinquishCount, 0)
 
-        try await Task.sleep(nanoseconds: 1_100_000_000)
-        coordinator.handleApplicationDidEnterBackground()
-        XCTAssertEqual(audioSession.deactivationCount, 2)
+        try await waitUntil {
+            audioSession.deactivationCount == 3
+        }
+        XCTAssertTrue(coordinator.handleVideoPlaybackWillStart())
+        XCTAssertEqual(audioSession.deactivationCount, 3)
+        XCTAssertEqual(audioSession.relinquishCount, 1)
     }
 
     func testLoadingAndDownloadFailureDoNotDeactivateUnownedAudioSession() async throws {

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.3
-        CURRENT_PROJECT_VERSION: 47
+        MARKETING_VERSION: 1.4.4
+        CURRENT_PROJECT_VERSION: 48
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.3
-        CURRENT_PROJECT_VERSION: 47
+        MARKETING_VERSION: 1.4.4
+        CURRENT_PROJECT_VERSION: 48
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容

- 视频播放前显式启用 `playback / moviePlayback` 音频会话，避免受静音开关或宿主默认会话影响
- 统一视频与语音的音频会话所有权，处理快速重开、互相切换和旧页面释放
- 在后台、播放失败、退出、音频打断及耳机断开时可靠暂停并释放会话
- 版本更新为 1.4.4 (48)

## 验证

- VideoAudioSessionTests
- VoiceAudioClientTests
- VoicePlaybackCoordinatorTests
- VideoPreviewTests
- Debug 模拟器构建

Closes #26
