### PR TITLE
优化 iPad 横屏帖子列表宽度

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,23 @@ jobs:
             -retry-tests-on-failure -test-iterations 2 \
             -test-repetition-relaunch-enabled YES
 
+      - name: Reset simulator for iPad layout test
+        run: |
+          source scripts/ci-simulator.sh
+          udid="$(ci_reset_simulator "$SIMULATOR_UDID" "$(ci_ipad_device_type)" 'TiebaPure CI iPad')"
+          test -n "$udid"
+          echo "SIMULATOR_UDID=$udid" >> "$GITHUB_ENV"
+
+      - name: iPad split layout smoke test
+        run: |
+          xcodebuild -project TiebaPure.xcodeproj -scheme TiebaPure \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -parallel-testing-enabled NO \
+            test \
+            -only-testing:TiebaPureUITests/TiebaPureUITests/testIPadLandscapeReaderListUsesAvailableWidth
+
       - name: Release build and bundled notices
         run: |
           xcodebuild -project TiebaPure.xcodeproj -scheme TiebaPure \

--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1287,13 +1287,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1304,14 +1304,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1357,14 +1357,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1377,13 +1377,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Core/UI/ReaderSplitLayout.swift
+++ b/TiebaPure/Core/UI/ReaderSplitLayout.swift
@@ -37,10 +37,35 @@ private struct ReaderSplitOpenThreadKey: EnvironmentKey {
     static let defaultValue: ReaderSplitOpenThreadAction? = nil
 }
 
+private struct ReaderSplitListColumnKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
 extension EnvironmentValues {
     var readerSplitOpenThread: ReaderSplitOpenThreadAction? {
         get { self[ReaderSplitOpenThreadKey.self] }
         set { self[ReaderSplitOpenThreadKey.self] = newValue }
+    }
+
+    var isReaderSplitListColumn: Bool {
+        get { self[ReaderSplitListColumnKey.self] }
+        set { self[ReaderSplitListColumnKey.self] = newValue }
+    }
+}
+
+enum ReaderSplitColumnWidthPolicy {
+    private static let minimumListWidth: CGFloat = 320
+    private static let maximumListWidth: CGFloat = 560
+    private static let minimumDetailWidth: CGFloat = 440
+    private static let listFraction: CGFloat = 0.4
+
+    static func preferredWidth(containerWidth: CGFloat) -> CGFloat {
+        guard containerWidth.isFinite, containerWidth > 0 else { return 400 }
+        let maximumLeavingDetail = max(containerWidth - minimumDetailWidth, 0)
+        return min(
+            max(containerWidth * listFraction, minimumListWidth),
+            min(maximumListWidth, maximumLeavingDetail)
+        )
     }
 }
 
@@ -93,46 +118,60 @@ struct ReaderSplitLayout<Route: Hashable, ListColumn: View, DetailRoot: View>: V
 
     var body: some View {
         if horizontalSizeClass == .regular {
-            NavigationSplitView(columnVisibility: .constant(.doubleColumn)) {
-                NavigationStack(path: $navigationPath) {
-                    listColumn()
-                }
-                // The columns are fixed. A sidebar toggle could hide the list
-                // and strand the detail thread without a way back.
-                .toolbar(removing: .sidebarToggle)
-                .navigationSplitViewColumnWidth(min: 320, ideal: 400, max: 480)
-                .environment(
-                    \.readerSplitOpenThread,
-                    ReaderSplitOpenThreadAction(open: resolvedOpenThread)
+            GeometryReader { geometry in
+                let leadingColumnWidth = ReaderSplitColumnWidthPolicy.preferredWidth(
+                    containerWidth: geometry.size.width
                 )
-            } detail: {
-                NavigationStack(path: $detailPath) {
-                    detailRoot(ReaderSplitDetailPlaceholder())
-                        .navigationDestination(for: ReaderSplitThreadRoute.self) { route in
-                            ThreadDetailView(
-                                account: account,
-                                threadID: route.threadID,
-                                forumID: route.forumID,
-                                initialPostID: route.initialPostID,
-                                ownThreadDeletionTarget: route.ownThreadDeletionTarget
-                            )
-                            // Replacing the selection must never reuse the
-                            // previous thread's loaded state.
-                            .id(route)
-                        }
-                }
+
+                splitNavigation(leadingColumnWidth: leadingColumnWidth)
             }
-            .navigationSplitViewStyle(.balanced)
         } else {
+            compactNavigation
+        }
+    }
+
+    private func splitNavigation(leadingColumnWidth: CGFloat) -> some View {
+        NavigationSplitView(columnVisibility: .constant(.doubleColumn)) {
             NavigationStack(path: $navigationPath) {
                 listColumn()
             }
-            // A compact handler lets the parent keep ownership of a thread
-            // opened by a nested list (for example ForumThreadsView). This is
-            // what makes the same selection transferable when an iPad window
-            // crosses the compact/regular size-class boundary.
-            .environment(\.readerSplitOpenThread, compactOpenThreadAction)
+            // A sidebar toggle could hide the list and strand the detail
+            // thread without a way back.
+            .toolbar(removing: .sidebarToggle)
+            .navigationSplitViewColumnWidth(leadingColumnWidth)
+            .environment(\.isReaderSplitListColumn, true)
+            .environment(
+                \.readerSplitOpenThread,
+                ReaderSplitOpenThreadAction(open: resolvedOpenThread)
+            )
+        } detail: {
+            NavigationStack(path: $detailPath) {
+                detailRoot(ReaderSplitDetailPlaceholder())
+                    .navigationDestination(for: ReaderSplitThreadRoute.self) { route in
+                        ThreadDetailView(
+                            account: account,
+                            threadID: route.threadID,
+                            forumID: route.forumID,
+                            initialPostID: route.initialPostID,
+                            ownThreadDeletionTarget: route.ownThreadDeletionTarget
+                        )
+                        // Replacing the selection must never reuse the
+                        // previous thread's loaded state.
+                        .id(route)
+                    }
+            }
         }
+        .navigationSplitViewStyle(.balanced)
+    }
+
+    private var compactNavigation: some View {
+        NavigationStack(path: $navigationPath) {
+            listColumn()
+        }
+        // A compact handler lets the parent keep ownership of a thread opened
+        // by a nested list. The same selection remains transferable when the
+        // horizontal size class changes between compact and regular.
+        .environment(\.readerSplitOpenThread, compactOpenThreadAction)
     }
 
     private var resolvedOpenThread: (ReaderSplitThreadRoute) -> Void {

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -984,6 +984,8 @@ enum ForumSearchLaunchPolicy {
 }
 
 struct ForumThreadRow: View {
+    @Environment(\.isReaderSplitListColumn) private var isReaderSplitListColumn
+
     enum Presentation {
         case list
         case homeFeed
@@ -1160,13 +1162,13 @@ struct ForumThreadRow: View {
                         text: thread.title,
                         keyword: highlightKeyword,
                         font: .body.weight(.semibold),
-                        lineLimit: ThreadContentDisplayPolicy.summaryLineLimit
+                        lineLimit: primaryTextLineLimit
                     )
                 } else if inlinePreviewBlocks.isEmpty == false {
                     InlineContentText(
                         blocks: inlinePreviewBlocks,
                         style: .body,
-                        lineLimit: ThreadContentDisplayPolicy.summaryLineLimit,
+                        lineLimit: primaryTextLineLimit,
                         highlightKeyword: highlightKeyword,
                         allowsLinkInteraction: false
                     )
@@ -1276,6 +1278,12 @@ struct ForumThreadRow: View {
         }
     }
 
+    private var primaryTextLineLimit: Int {
+        ForumThreadRowTextPolicy.primaryLineLimit(
+            isReaderSplitListColumn: isReaderSplitListColumn
+        )
+    }
+
     private func mediaPreviewItems(from mediaItems: [ReaderMediaItem]) -> [ReaderMediaItem] {
         guard let limit = presentation.mediaLimit(totalCount: mediaItems.count) else {
             return mediaItems
@@ -1289,6 +1297,12 @@ struct ForumThreadRow: View {
 
     private var forumBlockDisplayName: String {
         thread.forumDisplayNameResolved ?? "该吧"
+    }
+}
+
+enum ForumThreadRowTextPolicy {
+    static func primaryLineLimit(isReaderSplitListColumn: Bool) -> Int {
+        isReaderSplitListColumn ? 3 : ThreadContentDisplayPolicy.summaryLineLimit
     }
 }
 

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -4,6 +4,68 @@ import XCTest
 @testable import TiebaPure
 
 final class TiebaPureSmokeTests: XCTestCase {
+    func testReaderSplitColumnWidthUsesLandscapeSpaceWithoutStarvingDetail() {
+        XCTAssertEqual(
+            ReaderSplitColumnWidthPolicy.preferredWidth(
+                containerWidth: 1_366
+            ),
+            546.4,
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            ReaderSplitColumnWidthPolicy.preferredWidth(
+                containerWidth: 1_194
+            ),
+            477.6,
+            accuracy: 0.01
+        )
+        XCTAssertGreaterThanOrEqual(
+            1_194 - ReaderSplitColumnWidthPolicy.preferredWidth(
+                containerWidth: 1_194
+            ),
+            440
+        )
+    }
+
+    func testReaderSplitColumnWidthChangesContinuouslyAndPreservesNarrowDetail() {
+        XCTAssertEqual(
+            ReaderSplitColumnWidthPolicy.preferredWidth(
+                containerWidth: 1_024
+            ),
+            409.6,
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            ReaderSplitColumnWidthPolicy.preferredWidth(containerWidth: 700),
+            260,
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            ReaderSplitColumnWidthPolicy.preferredWidth(containerWidth: 940)
+                - ReaderSplitColumnWidthPolicy.preferredWidth(containerWidth: 939),
+            0.4,
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            ReaderSplitColumnWidthPolicy.preferredWidth(
+                containerWidth: 0
+            ),
+            400,
+            accuracy: 0.01
+        )
+    }
+
+    func testForumThreadRowShowsMoreTitleLinesOnlyInSplitList() {
+        XCTAssertEqual(
+            ForumThreadRowTextPolicy.primaryLineLimit(isReaderSplitListColumn: true),
+            3
+        )
+        XCTAssertEqual(
+            ForumThreadRowTextPolicy.primaryLineLimit(isReaderSplitListColumn: false),
+            ThreadContentDisplayPolicy.summaryLineLimit
+        )
+    }
+
     func testInteractionCountUsesRequestedSingleLineKAndWFormat() {
         XCTAssertEqual(CompactInteractionCountText.string(for: -1), "0")
         XCTAssertEqual(CompactInteractionCountText.string(for: 0), "0")

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -4985,6 +4985,39 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
     }
 
+    func testIPadLandscapeReaderListUsesAvailableWidth() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            throw XCTSkip("仅在 iPad 设备矩阵中运行。")
+        }
+        let app = launchApp()
+        XCUIDevice.shared.orientation = .landscapeLeft
+        addTeardownBlock {
+            XCUIDevice.shared.orientation = .portrait
+        }
+
+        let landscape = XCTNSPredicateExpectation(
+            predicate: NSPredicate { object, _ in
+                guard let application = object as? XCUIApplication else { return false }
+                return application.frame.width > application.frame.height
+            },
+            object: app
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [landscape], timeout: 8), .completed)
+
+        let firstThreadRow = threadRows(in: app).firstMatch
+        XCTAssertTrue(firstThreadRow.waitForExistence(timeout: 8))
+        XCTAssertGreaterThanOrEqual(
+            firstThreadRow.frame.width,
+            app.frame.width * 0.35,
+            "iPad 横屏帖子行应使用足够的横向空间展示标题"
+        )
+        XCTAssertLessThan(
+            firstThreadRow.frame.maxX,
+            app.frame.midX,
+            "左侧帖子列表不能挤占右侧详情栏"
+        )
+    }
+
     func testIPadForumThreadOpensSharedDetailInsteadOfLeadingLocalStack() throws {
         guard UIDevice.current.userInterfaceIdiom == .pad else {
             throw XCTSkip("仅在 iPad 设备矩阵中运行。")

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.4
-        CURRENT_PROJECT_VERSION: 48
+        MARKETING_VERSION: 1.4.5
+        CURRENT_PROJECT_VERSION: 49
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.4
-        CURRENT_PROJECT_VERSION: 48
+        MARKETING_VERSION: 1.4.5
+        CURRENT_PROJECT_VERSION: 49
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改

- iPad 分栏列表按可用宽度连续分配，横屏展示更多帖子信息并保留详情阅读空间
- 分栏列表中的帖子标题最多显示三行，iPhone 与非分栏页面仍保持原有摘要策略
- 将 iPad 横屏分栏用例加入 `ci-ok`，并更新版本为 1.4.5 (49)

## 验证

- 3 项分栏宽度与标题策略单元测试
- iPad 26.5 横屏宽度与共享详情路由 UI 测试
- iPhone 26.5 首页紧凑布局 UI 冒烟测试
- XcodeGen 重建与差异检查

Fixes #32