### PR TITLE
Add secure persistence backends for iOS 16

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -10,17 +10,21 @@
 		03BFC1CB27519F2A9851619C /* ContentDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1C1C285AED2131947564A /* ContentDraft.swift */; };
 		043AF9BB1E2EF30D61B1DC63 /* SwiftDataOrderedCollectionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67285F50B29BA765B74B5271 /* SwiftDataOrderedCollectionPersistence.swift */; };
 		06132F36C724DF5F6A7409D5 /* ThreadDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1626D4B0DD88E88576EBC2EB /* ThreadDetailView.swift */; };
+		073B7C872F57FED9EEA649D2 /* ContentDraftPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D675F69938E6B1281FC28A54 /* ContentDraftPersistence.swift */; };
 		07DE68396A13E2AD45D1B77F /* VoicePlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273C5E55B0D298678C72F894 /* VoicePlaybackTests.swift */; };
 		088782C68D3B3B22A6BF8320 /* BrowsingHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C549F603F6A8B5988B0B31 /* BrowsingHistory.swift */; };
 		09C2C3D3FC8AA2D05ACBF2F0 /* PbPage_PbPageResponse.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E50CC9DC6A0FEE9D095B963 /* PbPage_PbPageResponse.pb.swift */; };
 		0E9AD304E9D62F985EBE1408 /* FrsPage_FrsPage.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80CE02414B9F8BD668C519D /* FrsPage_FrsPage.pb.swift */; };
 		0F308182AFB5A18BA8EBAC46 /* AccountThreadFavoritesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFD6B34343B4446671A80AA /* AccountThreadFavoritesLoader.swift */; };
+		10FEEBCE86FD4048957AD02B /* ContentDraftPersistenceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C06BE869912F233C314E5A /* ContentDraftPersistenceFactory.swift */; };
 		116B9F91820A3F111B4D0150 /* ContentDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE52F261111609A3D8E1D30 /* ContentDraftTests.swift */; };
+		1173DB2C53FF026697D5DEB8 /* OrderedCollectionPersistenceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2856CD40A8BF8EC9A8007C76 /* OrderedCollectionPersistenceFactory.swift */; };
 		143BCEEE525C98950A8466D8 /* ReaderSplitLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9349EF851351C624AE35FF31 /* ReaderSplitLayout.swift */; };
 		15DF8B955B68CF4317A10AE7 /* ForumSignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF457C95754D5EAA87ECEFD /* ForumSignTests.swift */; };
 		15E4532BC1DF75316CA8D95A /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07566334FE43A9F9BF360D89 /* Account.swift */; };
 		1765CC21F9E90D5C7D85EFF2 /* TiebaAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC5695CD74141BB65787AB6 /* TiebaAPIService.swift */; };
 		1B38ECEBD8AB77434B402F8A /* ForumThreadsRequestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1242A6C7E6C6F3740D3E6 /* ForumThreadsRequestKey.swift */; };
+		1C53CA119B8A4874452D2F6B /* ContentDraftFilePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE6592A34B15BF182198BFA /* ContentDraftFilePersistenceTests.swift */; };
 		1D73C1F9246A5740B5D63601 /* LogoutCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6B235101269A6DE9BEB53A /* LogoutCoordinator.swift */; };
 		215E174D28331CD22F134EE6 /* TiebaAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BFF7EDD31716056CE12B69 /* TiebaAPI.swift */; };
 		22C326EADD75278D51629E56 /* ReaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431A697F330BBEC18E2252D0 /* ReaderCard.swift */; };
@@ -42,6 +46,7 @@
 		3E83765E473D5A072792B006 /* TiebaPureProfile_UserProfile.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094A7B97C027D43346675B29 /* TiebaPureProfile_UserProfile.pb.swift */; };
 		3E9872C838729BB48E4DD67A /* VideoPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */; };
 		3F0E94381375C8E91ECFC5F4 /* ThreadMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946B2D7B6BCE7C2C716A3EB2 /* ThreadMapper.swift */; };
+		3FB07858552D194FD0AE222C /* SecureFilePersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBA032F531024778CFC5C0A /* SecureFilePersistence.swift */; };
 		4121F3AF9F06FDC97D3C39C1 /* Media.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD087D4F0E7FA8246D26D8CB /* Media.pb.swift */; };
 		41274F99F33CBB936296671F /* SafariActionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872607E2663432D3116C5BB6 /* SafariActionPayload.swift */; };
 		41A327F3241D4342AE1D1D45 /* SubpostPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF76DC72E50AAADA883B8D85 /* SubpostPreviewView.swift */; };
@@ -57,6 +62,7 @@
 		4C637302510F02D057F7F18D /* AuthSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D258A9BF97B365AE98B663F /* AuthSessionTests.swift */; };
 		4CC783BD1274CE79745DE038 /* LoginWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159C859125D33A23786365A /* LoginWebView.swift */; };
 		4D7D3D4E33E7C375230D2F29 /* Post.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50FDF3AC3742333D5202EC /* Post.pb.swift */; };
+		4E2A3DFCCFD09D57BC62A04F /* FileOrderedCollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A20C49C14881A792297DFF2 /* FileOrderedCollectionPersistenceTests.swift */; };
 		4ED79FF1DB72B276E756EBF2 /* FixtureTiebaAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36421D36A7372F3886F8A1FA /* FixtureTiebaAPI.swift */; };
 		4F13CBE2C0840271AC3AB6B0 /* ThreadSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C9E000B6A70DAE855C1F80 /* ThreadSummary.swift */; };
 		50638626574849A4E23F01EA /* SimpleForum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F167B1D47EFED83CEE70F2D /* SimpleForum.pb.swift */; };
@@ -95,9 +101,11 @@
 		85EFBF3494B6DBAE4707E464 /* TiebaPostingBootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2792F6DFB423B6000542ADFB /* TiebaPostingBootstrapTests.swift */; };
 		884DB9F5E1CF43887524D6EC /* ForumMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED135C7D7263C882A3B2FF09 /* ForumMapper.swift */; };
 		89331B1C9CEFD4999D01A906 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D652931311ACE40A9A096D /* AppEnvironment.swift */; };
+		89CFC3B17B93F48527220A39 /* PersistencePrimitives.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511250E8EAC9A3A1E00A990B /* PersistencePrimitives.swift */; };
 		8CF348082F0201BCE9ED6E27 /* ForumThreadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0060EA54C03E209E46FB2C40 /* ForumThreadsView.swift */; };
 		8D25383D8C4B4FEFBBDCB658 /* OpenInTiebaPure.js in Resources */ = {isa = PBXBuildFile; fileRef = 3C4F59298557DEA63197CAA5 /* OpenInTiebaPure.js */; };
 		90A1EF7B8679DC1058702486 /* ForumListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944D4064677A9BAB7CD156BC /* ForumListView.swift */; };
+		94463A90FFDE1A58359C61B0 /* ContentDraftMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB122673DB1880647B37AE8 /* ContentDraftMigrationTests.swift */; };
 		96E558670B2758520F748005 /* ContentComposerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C0F8A37BD6F0E4EA09BFCD /* ContentComposerPolicyTests.swift */; };
 		9B869CC8E0EE590D0B003B40 /* FollowedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBDB720D1FCC2A3138B0CC /* FollowedUsersView.swift */; };
 		9C4E81261CE11986A7FC94CA /* PersistenceBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */; };
@@ -114,6 +122,7 @@
 		AA3AF8E9A9956DD4FAEA8638 /* VideoInfo.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D4BFCB0FC486AF2592D85 /* VideoInfo.pb.swift */; };
 		AC68D0057C4A48786599AB69 /* ContentFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B7B87BD4A9EB32A9F340FC /* ContentFilterTests.swift */; };
 		AC73C05F2AE82D15E3B429EB /* AlaLiveInfo.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E3067B91DE94BBC410176 /* AlaLiveInfo.pb.swift */; };
+		AC8C9EFD5E2B710919306D8B /* FileContentDraftPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77980DB0EC284A4F53AA4028 /* FileContentDraftPersistence.swift */; };
 		B0A89B13400DEB2576E1A025 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674313EBDA3BABF79049EF20 /* AvatarView.swift */; };
 		B152F8A68F8CB2ACBCD895AD /* ImageDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CD0BAA4D26A1DBC8367F53 /* ImageDownloadService.swift */; };
 		B1EC4ECCDB577E77B8026BE6 /* TiebaEmoticon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF25E73F880C6AD77740631 /* TiebaEmoticon.swift */; };
@@ -125,6 +134,7 @@
 		BC0174E4104B48F4D4A8B291 /* SwiftDataOrderedCollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBDD5BC8E767866E1874011 /* SwiftDataOrderedCollectionPersistenceTests.swift */; };
 		BE171315B6CB8B7FCA968A65 /* PbFloor_PbFloorResponse.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A967D18B7F1F21562A66FCA /* PbFloor_PbFloorResponse.pb.swift */; };
 		BE4F2342007F0803F98D82B7 /* SubPost.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB42F9B13D5397C990ED17F /* SubPost.pb.swift */; };
+		BED7DAF338555164F980FDE9 /* FileOrderedCollectionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A92826CC55F5EE91B72934 /* FileOrderedCollectionPersistence.swift */; };
 		BF200F41FA7A88C525623215 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E425761E05D459199869361A /* AboutView.swift */; };
 		BF3E65570A0501F384F8C0BA /* ReaderStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475452DA26606C9EEF2982D2 /* ReaderStateView.swift */; };
 		C02D20CEC3FEDED464983D96 /* SafariActionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872607E2663432D3116C5BB6 /* SafariActionPayload.swift */; };
@@ -247,6 +257,7 @@
 		13D33824C028F1604024BA69 /* OpenInTiebaPureRequestHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInTiebaPureRequestHandler.swift; sourceTree = "<group>"; };
 		1626D4B0DD88E88576EBC2EB /* ThreadDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadDetailView.swift; sourceTree = "<group>"; };
 		16DDB351392A69BC42810B9E /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
+		1CB122673DB1880647B37AE8 /* ContentDraftMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftMigrationTests.swift; sourceTree = "<group>"; };
 		1D6B235101269A6DE9BEB53A /* LogoutCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutCoordinator.swift; sourceTree = "<group>"; };
 		1E3321457BFA9611243ABF93 /* TiebaURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaURL.swift; sourceTree = "<group>"; };
 		1E53AE6B81F63DC0CDEC38B8 /* ShortPullRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortPullRefresh.swift; sourceTree = "<group>"; };
@@ -256,10 +267,12 @@
 		2345ABFFDDC5D3B04B88A017 /* ThreadInfo.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadInfo.pb.swift; sourceTree = "<group>"; };
 		24D4BAC59CD64A3B8F236258 /* SearchHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHistory.swift; sourceTree = "<group>"; };
 		25BD3F2D04164FFE41606F0C /* AccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountStore.swift; sourceTree = "<group>"; };
+		25C06BE869912F233C314E5A /* ContentDraftPersistenceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftPersistenceFactory.swift; sourceTree = "<group>"; };
 		273C5E55B0D298678C72F894 /* VoicePlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlaybackTests.swift; sourceTree = "<group>"; };
 		2758D17C77814946EB5560DA /* MultipartFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataTests.swift; sourceTree = "<group>"; };
 		277C554E042BEC92DDCC065C /* MediaGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaGridView.swift; sourceTree = "<group>"; };
 		2792F6DFB423B6000542ADFB /* TiebaPostingBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPostingBootstrapTests.swift; sourceTree = "<group>"; };
+		2856CD40A8BF8EC9A8007C76 /* OrderedCollectionPersistenceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedCollectionPersistenceFactory.swift; sourceTree = "<group>"; };
 		28FE6EA296C633FE6B2A0AD3 /* VideoAudioSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionTests.swift; sourceTree = "<group>"; };
 		2C32C727ADE31C67A3B02736 /* BrowsingHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingHistoryView.swift; sourceTree = "<group>"; };
 		2E36ED28464DB4F8E2D7BD1D /* TiebaPureUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TiebaPureUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -278,6 +291,7 @@
 		3797B6083214EC5E9FF58648 /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		37E6671F9A9A069EADCFAFB9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		398BABD44302879D665A9AC3 /* VoicePlaybackControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlaybackControl.swift; sourceTree = "<group>"; };
+		3A20C49C14881A792297DFF2 /* FileOrderedCollectionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOrderedCollectionPersistenceTests.swift; sourceTree = "<group>"; };
 		3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileTests.swift; sourceTree = "<group>"; };
 		3ABAA8240FEE5D60D5C61349 /* VoicePlaybackControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlaybackControlTests.swift; sourceTree = "<group>"; };
 		3BEB3F78F38EA8D24DAA64A4 /* Anti.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Anti.pb.swift; sourceTree = "<group>"; };
@@ -292,6 +306,7 @@
 		47A8570B3E26BDD92BF4524C /* TiebaMessageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaMessageAPI.swift; sourceTree = "<group>"; };
 		481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceBoundaryTests.swift; sourceTree = "<group>"; };
 		4EF25E73F880C6AD77740631 /* TiebaEmoticon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaEmoticon.swift; sourceTree = "<group>"; };
+		511250E8EAC9A3A1E00A990B /* PersistencePrimitives.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistencePrimitives.swift; sourceTree = "<group>"; };
 		522AA51FA729818AC890CD19 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		532EEE9965373A3008560F53 /* PbFloor_PbFloorRequest.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PbFloor_PbFloorRequest.pb.swift; sourceTree = "<group>"; };
 		53A22DDA746D43724E44B7D2 /* TiebaPureSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPureSmokeTests.swift; sourceTree = "<group>"; };
@@ -318,11 +333,13 @@
 		6A68DE1DD356B7AC4AB669F8 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		6AD842C2F8EBE015B4F98443 /* Abstract.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Abstract.pb.swift; sourceTree = "<group>"; };
 		6B9769DFBF55471E036C585C /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		6BBA032F531024778CFC5C0A /* SecureFilePersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureFilePersistence.swift; sourceTree = "<group>"; };
 		6E308EC64EE7E7737CA03AE5 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		703A3E007139EC93BECB057F /* OwnThreadMutationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnThreadMutationState.swift; sourceTree = "<group>"; };
 		722158AB6808A4470B0BDE41 /* TiebaForumSignAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaForumSignAPI.swift; sourceTree = "<group>"; };
 		7294F83ED412C768AFA77BCB /* LICENSE */ = {isa = PBXFileReference; path = LICENSE; sourceTree = "<group>"; };
 		72A829A6D2ABD0F1D55D90E6 /* SocialRelationshipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialRelationshipStateTests.swift; sourceTree = "<group>"; };
+		77980DB0EC284A4F53AA4028 /* FileContentDraftPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileContentDraftPersistence.swift; sourceTree = "<group>"; };
 		78FABF04E476AC1533EBDFA2 /* InteractiveNavigationPop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveNavigationPop.swift; sourceTree = "<group>"; };
 		7C6EE1B24CFBA1308B81FD41 /* MessagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesView.swift; sourceTree = "<group>"; };
 		7D258A9BF97B365AE98B663F /* AuthSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSessionTests.swift; sourceTree = "<group>"; };
@@ -369,6 +386,7 @@
 		B8606C99A4A56953BB1FA0ED /* TiebaSearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaSearchAPI.swift; sourceTree = "<group>"; };
 		B9718D80CC5DA7EC934BCFEB /* SocialRelationshipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialRelationshipState.swift; sourceTree = "<group>"; };
 		B99D4BFCB0FC486AF2592D85 /* VideoInfo.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoInfo.pb.swift; sourceTree = "<group>"; };
+		B9A92826CC55F5EE91B72934 /* FileOrderedCollectionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOrderedCollectionPersistence.swift; sourceTree = "<group>"; };
 		BA50FDF3AC3742333D5202EC /* Post.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.pb.swift; sourceTree = "<group>"; };
 		BC9BED7F7A1BE8C617FE2F15 /* TiebaEmoticonRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaEmoticonRepository.swift; sourceTree = "<group>"; };
 		C017341C9C78B3832CB8A72F /* PbContent.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PbContent.pb.swift; sourceTree = "<group>"; };
@@ -383,6 +401,7 @@
 		D31CA90EA6BEF04EEA9AD1C3 /* TiebaContentFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaContentFilter.swift; sourceTree = "<group>"; };
 		D6711EB46FB5BE95EF86ACB6 /* Personalized.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Personalized.pb.swift; sourceTree = "<group>"; };
 		D671D758CEF85777E7C7D8E4 /* MeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeView.swift; sourceTree = "<group>"; };
+		D675F69938E6B1281FC28A54 /* ContentDraftPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftPersistence.swift; sourceTree = "<group>"; };
 		D9DDCEE2EB7CAB5604D83C90 /* SubPostList.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubPostList.pb.swift; sourceTree = "<group>"; };
 		DB22109F3B9CFD8850C4BEE0 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		DBA0A4653556BD11ACA8C0A3 /* AnonymousLiveSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLiveSmokeTests.swift; sourceTree = "<group>"; };
@@ -400,6 +419,7 @@
 		EF6740440D181E8F5AA32033 /* Blocklist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blocklist.swift; sourceTree = "<group>"; };
 		EF7D805CD76F1E84BC119F98 /* Page.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.pb.swift; sourceTree = "<group>"; };
 		EFC583D811BB2682A40FF679 /* OrderedCollectionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedCollectionPersistence.swift; sourceTree = "<group>"; };
+		EFE6592A34B15BF182198BFA /* ContentDraftFilePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftFilePersistenceTests.swift; sourceTree = "<group>"; };
 		F159C859125D33A23786365A /* LoginWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWebView.swift; sourceTree = "<group>"; };
 		F2419465F1782FB4E2EF7638 /* TiebaPureTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TiebaPureTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB433765723C53B6E8A6CA9B /* TiebaPureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPureUITests.swift; sourceTree = "<group>"; };
@@ -554,18 +574,25 @@
 				44C549F603F6A8B5988B0B31 /* BrowsingHistory.swift */,
 				EDD67FF51E0529813111A68A /* ContentBlock.swift */,
 				B5A1C1C285AED2131947564A /* ContentDraft.swift */,
+				D675F69938E6B1281FC28A54 /* ContentDraftPersistence.swift */,
+				25C06BE869912F233C314E5A /* ContentDraftPersistenceFactory.swift */,
 				E6FB0DE22872019BC145C2AF /* ContentSubmission.swift */,
 				E7A4C581F09C568D7DFC25D8 /* ContentSubmissionSettings.swift */,
+				77980DB0EC284A4F53AA4028 /* FileContentDraftPersistence.swift */,
+				B9A92826CC55F5EE91B72934 /* FileOrderedCollectionPersistence.swift */,
 				5E92E90BB801373B85685DDD /* Forum.swift */,
 				7E4CFA3390403419B8C3E890 /* ForumSignSettings.swift */,
 				93E0B943190782C7374C3690 /* ForumThreadCategory.swift */,
 				8B097E875FE8B825D77AD05F /* LocalThreadLibrary.swift */,
 				EFC583D811BB2682A40FF679 /* OrderedCollectionPersistence.swift */,
+				2856CD40A8BF8EC9A8007C76 /* OrderedCollectionPersistenceFactory.swift */,
+				511250E8EAC9A3A1E00A990B /* PersistencePrimitives.swift */,
 				CD2C30123EFF90A5F9BEE7C2 /* Post.swift */,
 				638DEF254549D0D4DE625487 /* ReadingPreferences.swift */,
 				FDE02417BF13C2E0A1D7824E /* RecentForum.swift */,
 				24D4BAC59CD64A3B8F236258 /* SearchHistory.swift */,
 				16DDB351392A69BC42810B9E /* SearchResult.swift */,
+				6BBA032F531024778CFC5C0A /* SecureFilePersistence.swift */,
 				67285F50B29BA765B74B5271 /* SwiftDataOrderedCollectionPersistence.swift */,
 				81C9E000B6A70DAE855C1F80 /* ThreadSummary.swift */,
 				4EF25E73F880C6AD77740631 /* TiebaEmoticon.swift */,
@@ -663,6 +690,8 @@
 				DBA0A4653556BD11ACA8C0A3 /* AnonymousLiveSmokeTests.swift */,
 				7D258A9BF97B365AE98B663F /* AuthSessionTests.swift */,
 				08C0F8A37BD6F0E4EA09BFCD /* ContentComposerPolicyTests.swift */,
+				EFE6592A34B15BF182198BFA /* ContentDraftFilePersistenceTests.swift */,
+				1CB122673DB1880647B37AE8 /* ContentDraftMigrationTests.swift */,
 				0CE52F261111609A3D8E1D30 /* ContentDraftTests.swift */,
 				36B7B87BD4A9EB32A9F340FC /* ContentFilterTests.swift */,
 				EA31C128D796A3D90D001643 /* ContentMappingTests.swift */,
@@ -670,6 +699,7 @@
 				C3B9F1DB7C284253E1A90DCA /* ContentSubmissionCoordinatorTests.swift */,
 				83A586DD3DD949672854FF9E /* ContentSubmissionNetworkTests.swift */,
 				5E2FAEA095A18F41BED60B8D /* EmoticonResourceTests.swift */,
+				3A20C49C14881A792297DFF2 /* FileOrderedCollectionPersistenceTests.swift */,
 				7F4A700D0BB079E5CEC104C1 /* FixtureDecodingTests.swift */,
 				CBF457C95754D5EAA87ECEFD /* ForumSignTests.swift */,
 				99D55E6E9D9C9BE0630B5C89 /* InlineTextReuseTests.swift */,
@@ -1054,12 +1084,16 @@
 				FA8DDBB0C4B9772070886AEB /* ContentComposerPresentation.swift in Sources */,
 				F08D2CC153F9FB90D40524ED /* ContentComposerView.swift in Sources */,
 				03BFC1CB27519F2A9851619C /* ContentDraft.swift in Sources */,
+				073B7C872F57FED9EEA649D2 /* ContentDraftPersistence.swift in Sources */,
+				10FEEBCE86FD4048957AD02B /* ContentDraftPersistenceFactory.swift in Sources */,
 				50AA54B8BA6EAAD96FE7E609 /* ContentSubmission.pb.swift in Sources */,
 				76335BCC2EF12774CA12ACC1 /* ContentSubmission.swift in Sources */,
 				FA74FB79B01F1BE9C5A98873 /* ContentSubmissionCoordinator.swift in Sources */,
 				9FCC42B360A1683D6696808F /* ContentSubmissionSettings.swift in Sources */,
 				5A56CE0B756E52E025521190 /* Error.pb.swift in Sources */,
 				ECDE960EDA7E9E0E186B2D3C /* ExternalRoute.swift in Sources */,
+				AC8C9EFD5E2B710919306D8B /* FileContentDraftPersistence.swift in Sources */,
+				BED7DAF338555164F980FDE9 /* FileOrderedCollectionPersistence.swift in Sources */,
 				4ED79FF1DB72B276E756EBF2 /* FixtureTiebaAPI.swift in Sources */,
 				9B869CC8E0EE590D0B003B40 /* FollowedUsersView.swift in Sources */,
 				F81A17ADFC8827935D28CB43 /* Forum.swift in Sources */,
@@ -1090,6 +1124,7 @@
 				D3F2C72D1BAA5E6241C68B52 /* MetadataLine.swift in Sources */,
 				4A8E23945EF79EAEFE3019DC /* MultipartFormData.swift in Sources */,
 				7189EC19091324F1EF6886C5 /* OrderedCollectionPersistence.swift in Sources */,
+				1173DB2C53FF026697D5DEB8 /* OrderedCollectionPersistenceFactory.swift in Sources */,
 				FB6002A8AEF7E1213AC7EA87 /* OwnThreadMutationState.swift in Sources */,
 				5C55104E13B0C728DDDAD257 /* Page.pb.swift in Sources */,
 				2382AFD769C00913BCF7C713 /* PbContent.pb.swift in Sources */,
@@ -1097,6 +1132,7 @@
 				BE171315B6CB8B7FCA968A65 /* PbFloor_PbFloorResponse.pb.swift in Sources */,
 				2F67094C8E53EA02DFBE5C80 /* PbPage_PbPageRequest.pb.swift in Sources */,
 				09C2C3D3FC8AA2D05ACBF2F0 /* PbPage_PbPageResponse.pb.swift in Sources */,
+				89CFC3B17B93F48527220A39 /* PersistencePrimitives.swift in Sources */,
 				A5757E03976CA021ADE696FB /* Personalized.pb.swift in Sources */,
 				4D7D3D4E33E7C375230D2F29 /* Post.pb.swift in Sources */,
 				DB3881EB1B055DE5583FBE65 /* Post.swift in Sources */,
@@ -1114,6 +1150,7 @@
 				8028A9708BDE36C7BB815CEF /* SearchResult.swift in Sources */,
 				30D4D4D35FD01A12F8D58EAC /* SearchResultsView.swift in Sources */,
 				DEA70B990FBB4F0B3A27998B /* SearchRoute.swift in Sources */,
+				3FB07858552D194FD0AE222C /* SecureFilePersistence.swift in Sources */,
 				E4BC7D1B10FF88D762725986 /* SettingsView.swift in Sources */,
 				CDEA6D379FC8528CC2581C94 /* ShortPullRefresh.swift in Sources */,
 				50638626574849A4E23F01EA /* SimpleForum.pb.swift in Sources */,
@@ -1174,6 +1211,8 @@
 				D0B17827BAA31E0CF4AD29ED /* AnonymousLiveSmokeTests.swift in Sources */,
 				4C637302510F02D057F7F18D /* AuthSessionTests.swift in Sources */,
 				96E558670B2758520F748005 /* ContentComposerPolicyTests.swift in Sources */,
+				1C53CA119B8A4874452D2F6B /* ContentDraftFilePersistenceTests.swift in Sources */,
+				94463A90FFDE1A58359C61B0 /* ContentDraftMigrationTests.swift in Sources */,
 				116B9F91820A3F111B4D0150 /* ContentDraftTests.swift in Sources */,
 				AC68D0057C4A48786599AB69 /* ContentFilterTests.swift in Sources */,
 				CF454E1295D97B7FE03A3DDA /* ContentMappingTests.swift in Sources */,
@@ -1181,6 +1220,7 @@
 				B744513E4012208DC9BA3056 /* ContentSubmissionCoordinatorTests.swift in Sources */,
 				2E614B406807B5BAFBCA4918 /* ContentSubmissionNetworkTests.swift in Sources */,
 				7670D2DD682E7DA328CABB62 /* EmoticonResourceTests.swift in Sources */,
+				4E2A3DFCCFD09D57BC62A04F /* FileOrderedCollectionPersistenceTests.swift in Sources */,
 				34511F43DA6B267EB2816388 /* FixtureDecodingTests.swift in Sources */,
 				15DF8B955B68CF4317A10AE7 /* ForumSignTests.swift in Sources */,
 				E209C76E1A8310E8F94F6A32 /* InlineTextReuseTests.swift in Sources */,
@@ -1307,13 +1347,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.6;
+				MARKETING_VERSION = 1.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1324,14 +1364,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.6;
+				MARKETING_VERSION = 1.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1377,14 +1417,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.6;
+				MARKETING_VERSION = 1.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1397,13 +1437,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.6;
+				MARKETING_VERSION = 1.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Domain/Models/AppPersistence.swift
+++ b/TiebaPure/Domain/Models/AppPersistence.swift
@@ -1,43 +1,9 @@
 import Foundation
-import OSLog
 import SwiftData
-
-enum PersistenceAvailability: Equatable, Sendable {
-    case available
-    case unavailable
-
-    var canPersist: Bool {
-        self == .available
-    }
-}
-
-enum PersistenceFaultPoint: Equatable {
-    case legacyMigration
-    case repair
-    case clearAll
-}
-
-struct PersistenceFaultInjector {
-    static let none = PersistenceFaultInjector { _ in }
-
-    private let handler: (PersistenceFaultPoint) throws -> Void
-
-    init(_ handler: @escaping (PersistenceFaultPoint) throws -> Void) {
-        self.handler = handler
-    }
-
-    func check(_ point: PersistenceFaultPoint) throws {
-        try handler(point)
-    }
-}
-
-struct PersistenceLoadResult<Value> {
-    let value: Value
-    let repairError: Error?
-}
 
 // Single app-wide SwiftData container shared by every persisted store. Tests
 // build their own container from `models` with an in-memory configuration.
+@available(iOS 17.0, *)
 enum AppModelContainer {
     struct Resolution {
         let container: ModelContainer
@@ -51,10 +17,13 @@ enum AppModelContainer {
     static let models: [any PersistentModel.Type] = [
         ThreadFavoriteRecord.self,
         ThreadReadingPositionRecord.self,
+        ThreadReadingPositionBackendMarkerRecord.self,
         BrowsingHistoryRecord.self,
         RecentForumRecord.self,
         SearchHistoryRecord.self,
-        ContentDraftRecord.self
+        OrderedCollectionBackendMarkerRecord.self,
+        ContentDraftRecord.self,
+        ContentDraftBackendMarkerRecord.self
     ]
 
     private static let sharedResolution: Resolution = {
@@ -135,42 +104,12 @@ enum AppModelContainer {
 // Each store persists a full snapshot of its in-memory array; sortIndex
 // preserves the array order across relaunches exactly as the legacy JSON
 // encoding did.
+@available(iOS 17.0, *)
 protocol OrderedPersistentRecord: PersistentModel {
     var sortIndex: Int { get }
 }
 
-enum PersistenceDiagnostics {
-    private static let logger = Logger(
-        subsystem: "dev.infinityf4p.tiebapure",
-        category: "Persistence"
-    )
-
-    static func report(_ error: Error, operation: String) {
-        logger.error("\(operation, privacy: .public) failed: \(String(describing: error), privacy: .public)")
-    }
-}
-
-enum LegacyStorageMigration {
-    enum DecodeError: Error {
-        case invalidTopLevelArray
-    }
-
-    /// The legacy value is removed only after the SwiftData save completes and
-    /// only when the destination is durable. A successful write to the
-    /// in-memory fallback is useful for the current session but is not a
-    /// migration because it cannot survive relaunch.
-    static func persistThenRemoveLegacyValue(
-        defaults: UserDefaults,
-        key: String,
-        destinationIsDurable: Bool,
-        persist: () throws -> Void
-    ) throws {
-        try persist()
-        guard destinationIsDurable else { return }
-        defaults.removeObject(forKey: key)
-    }
-}
-
+@available(iOS 17.0, *)
 @MainActor
 enum PersistedRecordStore {
     static func fetchOrdered<Record: OrderedPersistentRecord>(
@@ -312,6 +251,7 @@ enum PersistedRecordStore {
 /// Retired: thread collections live on the Baidu account now. The model stays
 /// in the schema so stores written by older versions still open, and its rows
 /// are deleted on first launch.
+@available(iOS 17.0, *)
 @Model
 final class ThreadFavoriteRecord {
     var threadID: Int64
@@ -341,8 +281,10 @@ final class ThreadFavoriteRecord {
     }
 }
 
+@available(iOS 17.0, *)
 extension ThreadFavoriteRecord: OrderedPersistentRecord {}
 
+@available(iOS 17.0, *)
 @Model
 final class ThreadReadingPositionRecord {
     var threadID: Int64
@@ -370,8 +312,24 @@ final class ThreadReadingPositionRecord {
     }
 }
 
+@available(iOS 17.0, *)
 extension ThreadReadingPositionRecord: OrderedPersistentRecord {}
 
+@available(iOS 17.0, *)
+@Model
+final class ThreadReadingPositionBackendMarkerRecord {
+    var key: String
+    var formatVersion: Int
+    var generationID: String
+
+    init(key: String, formatVersion: Int, generationID: String) {
+        self.key = key
+        self.formatVersion = formatVersion
+        self.generationID = generationID
+    }
+}
+
+@available(iOS 17.0, *)
 @Model
 final class BrowsingHistoryRecord {
     var threadID: Int64
@@ -404,8 +362,10 @@ final class BrowsingHistoryRecord {
     }
 }
 
+@available(iOS 17.0, *)
 extension BrowsingHistoryRecord: OrderedPersistentRecord {}
 
+@available(iOS 17.0, *)
 @Model
 final class RecentForumRecord {
     var name: String
@@ -432,8 +392,10 @@ final class RecentForumRecord {
     }
 }
 
+@available(iOS 17.0, *)
 extension RecentForumRecord: OrderedPersistentRecord {}
 
+@available(iOS 17.0, *)
 @Model
 final class SearchHistoryRecord {
     var keyword: String
@@ -445,8 +407,10 @@ final class SearchHistoryRecord {
     }
 }
 
+@available(iOS 17.0, *)
 extension SearchHistoryRecord: OrderedPersistentRecord {}
 
+@available(iOS 17.0, *)
 @Model
 final class ContentDraftRecord {
     var accountID: String
@@ -478,5 +442,19 @@ final class ContentDraftRecord {
         self.imagesBlob = imagesBlob
         self.imagesByteCount = imagesByteCount ?? imagesBlob.count
         self.updatedAt = updatedAt
+    }
+}
+
+@available(iOS 17.0, *)
+@Model
+final class ContentDraftBackendMarkerRecord {
+    var key: String
+    var formatVersion: Int
+    var generationID: String
+
+    init(key: String, formatVersion: Int, generationID: String) {
+        self.key = key
+        self.formatVersion = formatVersion
+        self.generationID = generationID
     }
 }

--- a/TiebaPure/Domain/Models/ContentDraft.swift
+++ b/TiebaPure/Domain/Models/ContentDraft.swift
@@ -45,7 +45,7 @@ enum ContentDraftImageBlobDecodeOutcome: Equatable, Sendable {
 
 struct ContentDraftPruneCandidate: Sendable {
     let sourceIndex: Int
-    let persistentID: PersistentIdentifier?
+    let persistentID: String?
     let accountID: String
     let targetKey: String
     let updatedAt: Date
@@ -328,11 +328,13 @@ enum ContentDraftImageBlobCodec {
     }
 }
 
+@available(iOS 17.0, *)
 private struct ContentDraftByteCountUpdate: Sendable {
     let persistentID: PersistentIdentifier
     let byteCount: Int
 }
 
+@available(iOS 17.0, *)
 private struct ContentDraftBackgroundLoadResult: Sendable {
     let outcome: ContentDraftLoadOutcome
     let byteCountUpdate: ContentDraftByteCountUpdate?
@@ -342,7 +344,24 @@ private struct ContentDraftBackgroundLoadResult: Sendable {
 /// context receives scalar byte-count updates and can enforce capacity without
 /// touching every attachment blob.
 @ModelActor
+@available(iOS 17.0, *)
 private actor ContentDraftDatabaseActor {
+    func backendGenerationID() throws -> String? {
+        try Task.checkCancellation()
+        let markers = try modelContext.fetch(
+            FetchDescriptor<ContentDraftBackendMarkerRecord>()
+        )
+        guard markers.isEmpty == false else { return nil }
+        guard markers.count == 1,
+              let marker = markers.first,
+              marker.key == SwiftDataContentDraftPersistenceBackend.markerKey,
+              marker.formatVersion == SwiftDataContentDraftPersistenceBackend.markerFormatVersion,
+              UUID(uuidString: marker.generationID) != nil else {
+            throw ContentDraftPersistenceError.destinationMarkerMismatch
+        }
+        return marker.generationID
+    }
+
     func load(
         accountID: String,
         target: ContentSubmissionTarget
@@ -420,6 +439,130 @@ private actor ContentDraftDatabaseActor {
         return updates
     }
 
+    func migrationIdentities() throws -> [String] {
+        try Task.checkCancellation()
+        let records = try modelContext.fetch(FetchDescriptor<ContentDraftRecord>())
+        var preferredByIdentity: [String: ContentDraftRecord] = [:]
+        for record in records {
+            try Task.checkCancellation()
+            let identity = "\(record.accountID)\u{1f}\(record.targetKey)"
+            if let existing = preferredByIdentity[identity] {
+                if record.updatedAt > existing.updatedAt
+                    || (record.updatedAt == existing.updatedAt
+                        && existing.persistentModelID < record.persistentModelID) {
+                    preferredByIdentity[identity] = record
+                }
+            } else {
+                preferredByIdentity[identity] = record
+            }
+        }
+        return preferredByIdentity.keys.sorted()
+    }
+
+    func migrationRecord(identity: String) throws -> ContentDraftPersistenceRecord {
+        try Task.checkCancellation()
+        guard let separator = identity.firstIndex(of: "\u{1f}") else {
+            throw ContentDraftPersistenceError.missingMigrationRecord
+        }
+        let requestedAccountID = String(identity[..<separator])
+        let requestedTargetKey = String(identity[identity.index(after: separator)...])
+        let records = try modelContext.fetch(FetchDescriptor<ContentDraftRecord>(
+            predicate: #Predicate { record in
+                record.accountID == requestedAccountID
+                    && record.targetKey == requestedTargetKey
+            }
+        ))
+        guard let record = preferredRecord(in: records) else {
+            throw ContentDraftPersistenceError.missingMigrationRecord
+        }
+        let imagesBlob = record.imagesBlob
+        try Task.checkCancellation()
+        return try ContentDraftPersistenceRecord(
+            accountID: record.accountID,
+            targetKey: record.targetKey,
+            targetData: record.targetData,
+            title: record.title,
+            body: record.body,
+            imagesBlob: imagesBlob,
+            imagesByteCount: imagesBlob.count,
+            updatedAt: record.updatedAt
+        ).validated()
+    }
+
+    func beginMigration() throws {
+        try Task.checkCancellation()
+        do {
+            for record in try modelContext.fetch(FetchDescriptor<ContentDraftRecord>()) {
+                modelContext.delete(record)
+            }
+            try Task.checkCancellation()
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    func beginMigration(generationID: String) throws {
+        guard UUID(uuidString: generationID) != nil else {
+            throw ContentDraftPersistenceError.destinationMarkerMismatch
+        }
+        try Task.checkCancellation()
+        do {
+            for record in try modelContext.fetch(FetchDescriptor<ContentDraftRecord>()) {
+                modelContext.delete(record)
+            }
+            for marker in try modelContext.fetch(
+                FetchDescriptor<ContentDraftBackendMarkerRecord>()
+            ) {
+                modelContext.delete(marker)
+            }
+            modelContext.insert(ContentDraftBackendMarkerRecord(
+                key: SwiftDataContentDraftPersistenceBackend.markerKey,
+                formatVersion: SwiftDataContentDraftPersistenceBackend.markerFormatVersion,
+                generationID: generationID
+            ))
+            try Task.checkCancellation()
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) throws {
+        let record = try record.validated()
+        try Task.checkCancellation()
+        do {
+            let requestedAccountID = record.accountID
+            let requestedTargetKey = record.targetKey
+            let matches = try modelContext.fetch(FetchDescriptor<ContentDraftRecord>(
+                predicate: #Predicate { stored in
+                    stored.accountID == requestedAccountID
+                        && stored.targetKey == requestedTargetKey
+                }
+            ))
+            for match in matches {
+                modelContext.delete(match)
+            }
+            modelContext.insert(ContentDraftRecord(
+                accountID: record.accountID,
+                targetKey: record.targetKey,
+                targetData: record.targetData,
+                title: record.title,
+                body: record.body,
+                imagesBlob: record.imagesBlob,
+                imagesByteCount: record.imagesByteCount,
+                updatedAt: record.updatedAt
+            ))
+            try Task.checkCancellation()
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
     private func preferredRecord(in records: [ContentDraftRecord]) -> ContentDraftRecord? {
         records.max {
             if $0.updatedAt != $1.updatedAt {
@@ -431,7 +574,11 @@ private actor ContentDraftDatabaseActor {
 }
 
 @MainActor
-final class ContentDraftStore {
+@available(iOS 17.0, *)
+final class SwiftDataContentDraftPersistenceBackend: ContentDraftMigrationDestination {
+    nonisolated static let markerKey = "content-draft-backend"
+    nonisolated static let markerFormatVersion = 1
+
     private let modelContainer: ModelContainer
     private let modelContext: ModelContext
     private let databaseActorTask: Task<ContentDraftDatabaseActor, Never>
@@ -452,6 +599,57 @@ final class ContentDraftStore {
             ?? AppModelContainer.persistenceAvailability(for: modelContainer)
         persistentBackendIsAvailable = availability.canPersist
         self.persistenceAvailability = availability
+    }
+
+    func backendGenerationID() throws -> String? {
+        guard requirePersistence(operation: "read content draft backend marker") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        let markers = try modelContext.fetch(FetchDescriptor<ContentDraftBackendMarkerRecord>())
+        guard markers.isEmpty == false else { return nil }
+        guard markers.count == 1,
+              let marker = markers.first,
+              marker.key == Self.markerKey,
+              marker.formatVersion == Self.markerFormatVersion,
+              UUID(uuidString: marker.generationID) != nil else {
+            throw ContentDraftPersistenceError.destinationMarkerMismatch
+        }
+        return marker.generationID
+    }
+
+    func backendGenerationIDAsync() async throws -> String? {
+        guard requirePersistence(operation: "read content draft backend marker") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        try Task.checkCancellation()
+        let actor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+        return try await actor.backendGenerationID()
+    }
+
+    func installNativeBackendMarker(generationID: String) throws {
+        guard UUID(uuidString: generationID) != nil else {
+            throw ContentDraftPersistenceError.destinationMarkerMismatch
+        }
+        if let existing = try backendGenerationID() {
+            guard existing == generationID else {
+                throw ContentDraftPersistenceError.destinationMarkerMismatch
+            }
+            return
+        }
+        do {
+            modelContext.insert(ContentDraftBackendMarkerRecord(
+                key: Self.markerKey,
+                formatVersion: Self.markerFormatVersion,
+                generationID: generationID
+            ))
+            try modelContext.save()
+            guard try backendGenerationID() == generationID else {
+                throw ContentDraftPersistenceError.destinationMarkerMismatch
+            }
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
     }
 
     /// Returns `true` when the store was read successfully. `draft` is `nil`
@@ -805,6 +1003,113 @@ final class ContentDraftStore {
         }
     }
 
+    func migrationManifest() async throws -> ContentDraftMigrationManifest {
+        guard requirePersistence(operation: "export content draft migration manifest") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        do {
+            try Task.checkCancellation()
+            let identityActor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+            let identities = try await identityActor.migrationIdentities()
+            var entries: [ContentDraftMigrationManifestEntry] = []
+            entries.reserveCapacity(identities.count)
+            for identity in identities {
+                try Task.checkCancellation()
+                let recordActor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+                let record = try await recordActor.migrationRecord(identity: identity)
+                entries.append(try ContentDraftMigrationManifestEntry(record: record))
+            }
+            let manifest = try ContentDraftMigrationManifest(entries: entries)
+            markPersistenceSucceeded()
+            return manifest
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "export content draft migration manifest")
+            throw error
+        }
+    }
+
+    func migrationRecord(identity: String) async throws -> ContentDraftPersistenceRecord {
+        guard requirePersistence(operation: "read content draft migration record") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        do {
+            try Task.checkCancellation()
+            let actor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+            let record = try await actor.migrationRecord(identity: identity)
+            markPersistenceSucceeded()
+            return record
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "read content draft migration record")
+            throw error
+        }
+    }
+
+    func beginMigration(to manifest: ContentDraftMigrationManifest) async throws {
+        guard requirePersistence(operation: "begin content draft migration") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        do {
+            _ = try ContentDraftMigrationManifest(entries: manifest.entries)
+            try Task.checkCancellation()
+            let actor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+            try await actor.beginMigration()
+            markPersistenceSucceeded()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "begin content draft migration")
+            throw error
+        }
+    }
+
+    func beginMigration(
+        to manifest: ContentDraftMigrationManifest,
+        generationID: String
+    ) async throws {
+        guard requirePersistence(operation: "begin marked content draft migration") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        do {
+            _ = try ContentDraftMigrationManifest(entries: manifest.entries)
+            guard UUID(uuidString: generationID) != nil else {
+                throw ContentDraftPersistenceError.destinationMarkerMismatch
+            }
+            try Task.checkCancellation()
+            let actor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+            try await actor.beginMigration(generationID: generationID)
+            guard try await backendGenerationIDAsync() == generationID else {
+                throw ContentDraftPersistenceError.destinationMarkerMismatch
+            }
+            markPersistenceSucceeded()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "begin marked content draft migration")
+            throw error
+        }
+    }
+
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) async throws {
+        guard requirePersistence(operation: "write content draft migration record") else {
+            throw ContentDraftPersistenceError.unavailable
+        }
+        do {
+            try Task.checkCancellation()
+            let actor = ContentDraftDatabaseActor(modelContainer: modelContainer)
+            try await actor.writeMigrationRecord(record)
+            markPersistenceSucceeded()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "write content draft migration record")
+            throw error
+        }
+    }
+
     private func hasUnknownByteCounts() throws -> Bool {
         try modelContext.fetch(FetchDescriptor<ContentDraftRecord>()).contains { record in
             guard let byteCount = record.imagesByteCount else { return true }
@@ -830,7 +1135,7 @@ final class ContentDraftStore {
         let candidates = records.enumerated().map { index, record in
             ContentDraftPruneCandidate(
                 sourceIndex: index,
-                persistentID: record.persistentModelID,
+                persistentID: String(describing: record.persistentModelID),
                 accountID: record.accountID,
                 targetKey: record.targetKey,
                 updatedAt: record.updatedAt,
@@ -872,5 +1177,114 @@ final class ContentDraftStore {
     private func markPersistenceSucceeded() {
         guard persistentBackendIsAvailable else { return }
         persistenceAvailability = .available
+    }
+}
+
+@MainActor
+final class ContentDraftStore {
+    private let persistence: any ContentDraftPersistenceBackend
+
+    var persistenceAvailability: PersistenceAvailability {
+        persistence.persistenceAvailability
+    }
+
+    init(persistence: any ContentDraftPersistenceBackend) {
+        self.persistence = persistence
+    }
+
+    convenience init() {
+        self.init(persistence: ContentDraftPersistenceFactory.makeApplicationBackend())
+    }
+
+    @available(iOS 17.0, *)
+    convenience init(
+        modelContainer: ModelContainer,
+        persistenceAvailability: PersistenceAvailability? = nil
+    ) {
+        self.init(persistence: SwiftDataContentDraftPersistenceBackend(
+            modelContainer: modelContainer,
+            persistenceAvailability: persistenceAvailability
+        ))
+    }
+
+    @discardableResult
+    func load(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        into draft: inout ContentDraft?
+    ) -> Bool {
+        persistence.load(accountID: accountID, target: target, into: &draft)
+    }
+
+    func draft(accountID: String, target: ContentSubmissionTarget) -> ContentDraft? {
+        persistence.draft(accountID: accountID, target: target)
+    }
+
+    func loadAsync(
+        accountID: String,
+        target: ContentSubmissionTarget
+    ) async -> ContentDraftLoadOutcome {
+        await persistence.loadAsync(accountID: accountID, target: target)
+    }
+
+    @discardableResult
+    func save(_ draft: ContentDraft) -> Bool {
+        persistence.save(draft)
+    }
+
+    func saveAsync(_ draft: ContentDraft) async throws {
+        try await persistence.saveAsync(draft)
+    }
+
+    @discardableResult
+    func save(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        title: String,
+        body: String,
+        images: [ContentSubmissionImage],
+        updatedAt: Date = Date()
+    ) -> Bool {
+        save(ContentDraft(
+            accountID: accountID,
+            target: target,
+            title: title,
+            body: body,
+            images: images,
+            updatedAt: updatedAt
+        ))
+    }
+
+    func saveAsync(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        title: String,
+        body: String,
+        images: [ContentSubmissionImage],
+        updatedAt: Date = Date()
+    ) async throws {
+        try await saveAsync(ContentDraft(
+            accountID: accountID,
+            target: target,
+            title: title,
+            body: body,
+            images: images,
+            updatedAt: updatedAt
+        ))
+    }
+
+    @discardableResult
+    func delete(accountID: String, target: ContentSubmissionTarget) -> Bool {
+        persistence.delete(accountID: accountID, target: target)
+    }
+
+    @discardableResult
+    func clear(accountID: String) -> Bool {
+        persistence.clear(accountID: accountID)
+    }
+
+    @discardableResult
+    func repairLegacyMetadataAndPruneAsync() async -> Bool {
+        await persistence.repairLegacyMetadataAndPruneAsync()
     }
 }

--- a/TiebaPure/Domain/Models/ContentDraftPersistence.swift
+++ b/TiebaPure/Domain/Models/ContentDraftPersistence.swift
@@ -1,0 +1,292 @@
+import CryptoKit
+import Foundation
+
+struct ContentDraftPersistenceRecord: Equatable, Sendable {
+    let accountID: String
+    let targetKey: String
+    let targetData: Data
+    let title: String
+    let body: String
+    let imagesBlob: Data
+    let imagesByteCount: Int
+    let updatedAt: Date
+
+    var identity: String {
+        "\(accountID)\u{1f}\(targetKey)"
+    }
+
+    func validated() throws -> ContentDraftPersistenceRecord {
+        let normalizedAccountID = accountID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedAccountID.isEmpty == false,
+              normalizedAccountID == accountID,
+              accountID.contains("\u{1f}") == false,
+              targetKey.isEmpty == false,
+              targetKey.contains("\u{1f}") == false,
+              updatedAt.timeIntervalSinceReferenceDate.isFinite,
+              imagesByteCount == imagesBlob.count,
+              imagesByteCount <= ContentDraftPolicy.maximumAttachmentBytesPerDraft,
+              let target = try? JSONDecoder().decode(
+                ContentSubmissionTarget.self,
+                from: targetData
+              ),
+              target.draftKey == targetKey else {
+            throw ContentDraftPersistenceError.invalidRecord
+        }
+        switch ContentDraftImageBlobCodec.decodeWithIntegrity(imagesBlob) {
+        case .decoded:
+            return self
+        case .cancelled:
+            throw CancellationError()
+        case .damagedContainer:
+            throw ContentDraftPersistenceError.invalidRecord
+        }
+    }
+}
+
+struct ContentDraftMigrationManifestEntry: Codable, Equatable, Sendable {
+    let identity: String
+    let accountID: String
+    let targetKey: String
+    let updatedAt: Date
+    let imagesByteCount: Int
+    let metadataDigest: String
+    let blobDigest: String
+
+    init(
+        identity: String,
+        accountID: String,
+        targetKey: String,
+        updatedAt: Date,
+        imagesByteCount: Int,
+        metadataDigest: String,
+        blobDigest: String
+    ) {
+        self.identity = identity
+        self.accountID = accountID
+        self.targetKey = targetKey
+        self.updatedAt = updatedAt
+        self.imagesByteCount = imagesByteCount
+        self.metadataDigest = metadataDigest
+        self.blobDigest = blobDigest
+    }
+
+    init(record: ContentDraftPersistenceRecord) throws {
+        let record = try record.validated()
+        identity = record.identity
+        accountID = record.accountID
+        targetKey = record.targetKey
+        updatedAt = record.updatedAt
+        imagesByteCount = record.imagesByteCount
+        metadataDigest = Self.metadataDigest(record)
+        blobDigest = SecurePersistenceDigest.sha256(record.imagesBlob)
+    }
+
+    static func metadataDigest(_ record: ContentDraftPersistenceRecord) -> String {
+        metadataDigest(
+            accountID: record.accountID,
+            targetKey: record.targetKey,
+            targetData: record.targetData,
+            title: record.title,
+            body: record.body,
+            updatedAt: record.updatedAt
+        )
+    }
+
+    static func metadataDigest(
+        accountID: String,
+        targetKey: String,
+        targetData: Data,
+        title: String,
+        body: String,
+        updatedAt: Date
+    ) -> String {
+        var hasher = SHA256()
+        ContentDraftMigrationManifest.update(&hasher, with: Data(accountID.utf8))
+        ContentDraftMigrationManifest.update(&hasher, with: Data(targetKey.utf8))
+        ContentDraftMigrationManifest.update(&hasher, with: targetData)
+        ContentDraftMigrationManifest.update(&hasher, with: Data(title.utf8))
+        ContentDraftMigrationManifest.update(&hasher, with: Data(body.utf8))
+        ContentDraftMigrationManifest.update(
+            &hasher,
+            with: updatedAt.timeIntervalSinceReferenceDate.bitPattern
+        )
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+struct ContentDraftMigrationManifest: Codable, Equatable, Sendable {
+    static let currentFormatVersion = 1
+
+    let formatVersion: Int
+    let entries: [ContentDraftMigrationManifestEntry]
+
+    init(entries: [ContentDraftMigrationManifestEntry]) throws {
+        var identities = Set<String>()
+        var candidates: [ContentDraftPruneCandidate] = []
+        candidates.reserveCapacity(entries.count)
+        for (index, entry) in entries.enumerated() {
+            let normalizedAccountID = entry.accountID.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            guard normalizedAccountID.isEmpty == false,
+                  normalizedAccountID == entry.accountID,
+                  entry.accountID.contains("\u{1f}") == false,
+                  entry.targetKey.isEmpty == false,
+                  entry.targetKey.contains("\u{1f}") == false,
+                  entry.updatedAt.timeIntervalSinceReferenceDate.isFinite,
+                  entry.identity == "\(entry.accountID)\u{1f}\(entry.targetKey)",
+                  identities.insert(entry.identity).inserted,
+                  entry.imagesByteCount >= 0,
+                  entry.imagesByteCount <= ContentDraftPolicy.maximumAttachmentBytesPerDraft,
+                  Self.isSHA256Hex(entry.metadataDigest),
+                  Self.isSHA256Hex(entry.blobDigest) else {
+                throw ContentDraftPersistenceError.invalidManifest
+            }
+            candidates.append(ContentDraftPruneCandidate(
+                sourceIndex: index,
+                persistentID: entry.identity,
+                accountID: entry.accountID,
+                targetKey: entry.targetKey,
+                updatedAt: entry.updatedAt,
+                imagesByteCount: entry.imagesByteCount
+            ))
+        }
+        guard ContentDraftPruner.deletionIndices(for: candidates).isEmpty else {
+            throw ContentDraftPersistenceError.invalidManifest
+        }
+        formatVersion = Self.currentFormatVersion
+        self.entries = entries.sorted { $0.identity < $1.identity }
+    }
+
+    func fingerprint() -> String {
+        var hasher = SHA256()
+        Self.update(&hasher, with: UInt64(formatVersion))
+        Self.update(&hasher, with: UInt64(entries.count))
+        for entry in entries {
+            Self.update(&hasher, with: Data(entry.identity.utf8))
+            Self.update(&hasher, with: Data(entry.metadataDigest.utf8))
+            Self.update(&hasher, with: Data(entry.blobDigest.utf8))
+            Self.update(&hasher, with: UInt64(entry.imagesByteCount))
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func update(_ hasher: inout SHA256, with data: Data) {
+        update(&hasher, with: UInt64(data.count))
+        hasher.update(data: data)
+    }
+
+    static func update(_ hasher: inout SHA256, with value: UInt64) {
+        var bigEndian = value.bigEndian
+        withUnsafeBytes(of: &bigEndian) { hasher.update(bufferPointer: $0) }
+    }
+
+    private static func isSHA256Hex(_ value: String) -> Bool {
+        value.count == 64 && value.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (97...102).contains(byte)
+        }
+    }
+}
+
+enum ContentDraftPersistenceError: Error, Equatable {
+    case unavailable
+    case invalidRecord
+    case invalidManifest
+    case missingMigrationRecord
+    case migrationVerificationFailed
+    case sourceChangedDuringMigration
+    case destinationMarkerMismatch
+}
+
+@MainActor
+protocol ContentDraftPersistenceBackend: AnyObject {
+    var persistenceAvailability: PersistenceAvailability { get }
+
+    func load(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        into draft: inout ContentDraft?
+    ) -> Bool
+    func loadAsync(
+        accountID: String,
+        target: ContentSubmissionTarget
+    ) async -> ContentDraftLoadOutcome
+    func save(_ draft: ContentDraft) -> Bool
+    func saveAsync(_ draft: ContentDraft) async throws
+    func delete(accountID: String, target: ContentSubmissionTarget) -> Bool
+    func clear(accountID: String) -> Bool
+    func repairLegacyMetadataAndPruneAsync() async -> Bool
+
+    /// Migration is intentionally manifest + one-record-at-a-time. No call may
+    /// aggregate attachment blobs across drafts in memory.
+    func migrationManifest() async throws -> ContentDraftMigrationManifest
+    func migrationRecord(identity: String) async throws -> ContentDraftPersistenceRecord
+    func beginMigration(to manifest: ContentDraftMigrationManifest) async throws
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) async throws
+}
+
+@MainActor
+protocol ContentDraftMigrationDestination: ContentDraftPersistenceBackend {
+    func backendGenerationID() throws -> String?
+    func backendGenerationIDAsync() async throws -> String?
+    func installNativeBackendMarker(generationID: String) throws
+    func beginMigration(
+        to manifest: ContentDraftMigrationManifest,
+        generationID: String
+    ) async throws
+}
+
+extension ContentDraftPersistenceBackend {
+    func draft(accountID: String, target: ContentSubmissionTarget) -> ContentDraft? {
+        var loaded: ContentDraft?
+        guard load(accountID: accountID, target: target, into: &loaded) else { return nil }
+        return loaded
+    }
+}
+
+@MainActor
+final class UnavailableContentDraftPersistenceBackend: ContentDraftPersistenceBackend {
+    let persistenceAvailability: PersistenceAvailability = .unavailable
+
+    func load(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        into draft: inout ContentDraft?
+    ) -> Bool {
+        draft = nil
+        return false
+    }
+
+    func loadAsync(
+        accountID: String,
+        target: ContentSubmissionTarget
+    ) async -> ContentDraftLoadOutcome {
+        .unavailable
+    }
+
+    func save(_ draft: ContentDraft) -> Bool { false }
+
+    func saveAsync(_ draft: ContentDraft) async throws {
+        throw ContentDraftPersistenceError.unavailable
+    }
+
+    func delete(accountID: String, target: ContentSubmissionTarget) -> Bool { false }
+    func clear(accountID: String) -> Bool { false }
+    func repairLegacyMetadataAndPruneAsync() async -> Bool { false }
+
+    func migrationManifest() async throws -> ContentDraftMigrationManifest {
+        throw ContentDraftPersistenceError.unavailable
+    }
+
+    func migrationRecord(identity: String) async throws -> ContentDraftPersistenceRecord {
+        throw ContentDraftPersistenceError.unavailable
+    }
+
+    func beginMigration(to manifest: ContentDraftMigrationManifest) async throws {
+        throw ContentDraftPersistenceError.unavailable
+    }
+
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) async throws {
+        throw ContentDraftPersistenceError.unavailable
+    }
+}

--- a/TiebaPure/Domain/Models/ContentDraftPersistenceFactory.swift
+++ b/TiebaPure/Domain/Models/ContentDraftPersistenceFactory.swift
@@ -1,0 +1,518 @@
+import Foundation
+
+struct ContentDraftMigrationReceipt: Codable, Equatable, Sendable {
+    static let currentMigrationVersion = 1
+
+    let migrationVersion: Int
+    let sourceFingerprint: String
+    let completedAt: Date
+
+    func validated() throws -> ContentDraftMigrationReceipt {
+        guard migrationVersion == Self.currentMigrationVersion,
+              Self.isSHA256Hex(sourceFingerprint) else {
+            throw ContentDraftPersistenceStateError.invalidState
+        }
+        return self
+    }
+
+    private static func isSHA256Hex(_ value: String) -> Bool {
+        value.count == 64 && value.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (97...102).contains(byte)
+        }
+    }
+}
+
+enum ContentDraftAuthoritativeBackend: String, Codable, Sendable {
+    case secureFiles
+    case swiftData
+    case pendingActivation
+}
+
+enum ContentDraftMigrationStatus: String, Codable, Sendable {
+    case fileMigrationEligible
+    case nativeActivationPending
+    case notRequired
+    case completed
+}
+
+struct ContentDraftPersistenceState: Codable, Equatable, Sendable {
+    static let currentFormatVersion = 1
+
+    let formatVersion: Int
+    let activeBackend: ContentDraftAuthoritativeBackend
+    let migrationStatus: ContentDraftMigrationStatus
+    let destinationGenerationID: String?
+    let receipt: ContentDraftMigrationReceipt?
+
+    static var activeFiles: ContentDraftPersistenceState {
+        ContentDraftPersistenceState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .secureFiles,
+            migrationStatus: .fileMigrationEligible,
+            destinationGenerationID: nil,
+            receipt: nil
+        )
+    }
+
+    static func initialSwiftData(
+        generationID: String
+    ) -> ContentDraftPersistenceState {
+        ContentDraftPersistenceState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationStatus: .notRequired,
+            destinationGenerationID: generationID,
+            receipt: nil
+        )
+    }
+
+    static func nativeActivationPending(
+        generationID: String
+    ) -> ContentDraftPersistenceState {
+        ContentDraftPersistenceState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .pendingActivation,
+            migrationStatus: .nativeActivationPending,
+            destinationGenerationID: generationID,
+            receipt: nil
+        )
+    }
+
+    static func migrated(
+        sourceFingerprint: String,
+        generationID: String,
+        completedAt: Date
+    ) -> ContentDraftPersistenceState {
+        ContentDraftPersistenceState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationStatus: .completed,
+            destinationGenerationID: generationID,
+            receipt: ContentDraftMigrationReceipt(
+                migrationVersion: ContentDraftMigrationReceipt.currentMigrationVersion,
+                sourceFingerprint: sourceFingerprint,
+                completedAt: completedAt
+            )
+        )
+    }
+
+    func validated() throws -> ContentDraftPersistenceState {
+        guard formatVersion == Self.currentFormatVersion else {
+            throw ContentDraftPersistenceStateError.unsupportedStateVersion(formatVersion)
+        }
+        switch (activeBackend, migrationStatus, destinationGenerationID, receipt) {
+        case (.secureFiles, .fileMigrationEligible, nil, nil):
+            return self
+        case let (.pendingActivation, .nativeActivationPending, generationID?, nil):
+            guard UUID(uuidString: generationID) != nil else {
+                throw ContentDraftPersistenceStateError.invalidState
+            }
+            return self
+        case let (.swiftData, .notRequired, generationID?, nil):
+            guard UUID(uuidString: generationID) != nil else {
+                throw ContentDraftPersistenceStateError.invalidState
+            }
+            return self
+        case let (.swiftData, .completed, generationID?, receipt?):
+            guard UUID(uuidString: generationID) != nil else {
+                throw ContentDraftPersistenceStateError.invalidState
+            }
+            _ = try receipt.validated()
+            return self
+        default:
+            throw ContentDraftPersistenceStateError.invalidState
+        }
+    }
+}
+
+enum ContentDraftPersistenceStateError: Error, Equatable {
+    case unsupportedStateVersion(Int)
+    case invalidState
+    case ambiguousBackends
+}
+
+private actor ContentDraftMigrationCoordinator {
+    static let shared = ContentDraftMigrationCoordinator()
+
+    private var activeKeys = Set<String>()
+    private var waiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    func acquire(_ key: String) async {
+        if activeKeys.insert(key).inserted { return }
+        await withCheckedContinuation { continuation in
+            waiters[key, default: []].append(continuation)
+        }
+    }
+
+    func release(_ key: String) {
+        if var queued = waiters[key], queued.isEmpty == false {
+            let continuation = queued.removeFirst()
+            waiters[key] = queued.isEmpty ? nil : queued
+            continuation.resume()
+        } else {
+            activeKeys.remove(key)
+        }
+    }
+}
+
+@MainActor
+enum ContentDraftPersistenceFactory {
+    static let stateFileName = "content-drafts-backend-state.json"
+
+    static func makeApplicationBackend(
+        fileManager: FileManager = .default
+    ) -> any ContentDraftPersistenceBackend {
+        do {
+            let location = try SecurePersistenceLocation.applicationSupport(fileManager: fileManager)
+            if #available(iOS 17.0, *) {
+                return try resolveIOS17Backend(
+                    directoryURL: location.directoryURL,
+                    fileManager: fileManager,
+                    swiftDataBackend: SwiftDataContentDraftPersistenceBackend(
+                        modelContainer: AppModelContainer.shared
+                    )
+                )
+            }
+            return try resolveIOS16Backend(
+                directoryURL: location.directoryURL,
+                fileManager: fileManager
+            )
+        } catch {
+            PersistenceDiagnostics.report(error, operation: "resolve content draft persistence backend")
+            return UnavailableContentDraftPersistenceBackend()
+        }
+    }
+
+    static func makeStateFile(
+        directoryURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> SecureCodableFile<ContentDraftPersistenceState> {
+        try SecureCodableFile(
+            directoryURL: directoryURL,
+            fileName: stateFileName,
+            fileManager: fileManager,
+            maximumByteCount: 64 * 1_024
+        )
+    }
+
+    static func resolveIOS16Backend(
+        directoryURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> any ContentDraftPersistenceBackend {
+        let stateFile = try makeStateFile(directoryURL: directoryURL, fileManager: fileManager)
+        if let state = try stateFile.load() {
+            let state = try state.validated()
+            guard state.activeBackend == .secureFiles else {
+                throw ContentDraftPersistenceStateError.invalidState
+            }
+            let backend = try FileContentDraftPersistenceBackend(
+                directoryURL: directoryURL,
+                fileManager: fileManager
+            )
+            _ = try backend.catalogPresence()
+            return backend
+        }
+
+        let backend = try FileContentDraftPersistenceBackend(
+            directoryURL: directoryURL,
+            fileManager: fileManager
+        )
+        _ = try backend.catalogPresence()
+        try stateFile.replace(.activeFiles)
+        return backend
+    }
+
+    @available(iOS 17.0, *)
+    static func resolveIOS17Backend(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        swiftDataBackend: SwiftDataContentDraftPersistenceBackend
+    ) throws -> any ContentDraftPersistenceBackend {
+        let stateFile = try makeStateFile(directoryURL: directoryURL, fileManager: fileManager)
+        if let state = try stateFile.load() {
+            let state = try state.validated()
+            switch state.activeBackend {
+            case .pendingActivation:
+                guard swiftDataBackend.persistenceAvailability.canPersist,
+                      state.migrationStatus == .nativeActivationPending,
+                      let generationID = state.destinationGenerationID else {
+                    throw ContentDraftPersistenceError.unavailable
+                }
+                if let existingGeneration = try swiftDataBackend.backendGenerationID() {
+                    guard existingGeneration == generationID else {
+                        throw ContentDraftPersistenceError.destinationMarkerMismatch
+                    }
+                } else {
+                    try swiftDataBackend.installNativeBackendMarker(
+                        generationID: generationID
+                    )
+                }
+                guard try swiftDataBackend.backendGenerationID() == generationID else {
+                    throw ContentDraftPersistenceError.destinationMarkerMismatch
+                }
+                let activeState = ContentDraftPersistenceState.initialSwiftData(
+                    generationID: generationID
+                )
+                _ = try activeState.validated()
+                try stateFile.replace(activeState)
+                return swiftDataBackend
+            case .swiftData:
+                guard swiftDataBackend.persistenceAvailability.canPersist else {
+                    throw ContentDraftPersistenceError.unavailable
+                }
+                guard let generationID = state.destinationGenerationID,
+                      try swiftDataBackend.backendGenerationID() == generationID else {
+                    throw ContentDraftPersistenceError.destinationMarkerMismatch
+                }
+                // Once the state commits SwiftData as active, it remains the
+                // sole authority. The retained source is deliberately not read.
+                return swiftDataBackend
+            case .secureFiles:
+                let source = try FileContentDraftPersistenceBackend(
+                    directoryURL: directoryURL,
+                    fileManager: fileManager
+                )
+                _ = try source.catalogPresence()
+                guard swiftDataBackend.persistenceAvailability.canPersist else {
+                    return source
+                }
+                return MigratingContentDraftPersistenceBackend(
+                    source: source,
+                    destination: swiftDataBackend,
+                    stateFile: stateFile
+                )
+            }
+        }
+
+        let source = try FileContentDraftPersistenceBackend(
+            directoryURL: directoryURL,
+            fileManager: fileManager
+        )
+        let sourcePresence = try source.catalogPresence()
+        guard sourcePresence == .absent else {
+            // An iOS 16 file store always commits activeFiles before accepting
+            // mutations. Missing state beside a catalog can therefore be a
+            // lost migration commit; choosing either side could resurrect data.
+            throw ContentDraftPersistenceStateError.ambiguousBackends
+        }
+
+        guard swiftDataBackend.persistenceAvailability.canPersist else {
+            // On iOS 17 an unavailable SwiftData store may only be a transient
+            // fallback. Electing an empty file backend here could later erase
+            // durable SwiftData records when availability recovers.
+            throw ContentDraftPersistenceError.unavailable
+        }
+        // A pre-existing marker without state can be a lost activation commit.
+        // Never auto-adopt it or reconstruct state from the destination alone.
+        guard try swiftDataBackend.backendGenerationID() == nil else {
+            throw ContentDraftPersistenceStateError.ambiguousBackends
+        }
+        let generationID = UUID().uuidString.lowercased()
+        let pendingState = ContentDraftPersistenceState.nativeActivationPending(
+            generationID: generationID
+        )
+        _ = try pendingState.validated()
+        try stateFile.replace(pendingState)
+        try swiftDataBackend.installNativeBackendMarker(generationID: generationID)
+        guard try swiftDataBackend.backendGenerationID() == generationID else {
+            throw ContentDraftPersistenceError.destinationMarkerMismatch
+        }
+        let initialState = ContentDraftPersistenceState.initialSwiftData(
+            generationID: generationID
+        )
+        _ = try initialState.validated()
+        try stateFile.replace(initialState)
+        return swiftDataBackend
+    }
+}
+
+@MainActor
+final class MigratingContentDraftPersistenceBackend: ContentDraftPersistenceBackend {
+    private let source: any ContentDraftPersistenceBackend
+    private let destination: any ContentDraftMigrationDestination
+    private let stateFile: SecureCodableFile<ContentDraftPersistenceState>
+    private let now: () -> Date
+    private let beforeStateCommit: () throws -> Void
+    private let beforeRecordRead: (String) async throws -> Void
+    private var active: any ContentDraftPersistenceBackend
+    private var migrationTask: Task<Void, Never>?
+    private var migrationResolved = false
+
+    init(
+        source: any ContentDraftPersistenceBackend,
+        destination: any ContentDraftMigrationDestination,
+        stateFile: SecureCodableFile<ContentDraftPersistenceState>,
+        now: @escaping () -> Date = Date.init,
+        beforeStateCommit: @escaping () throws -> Void = {},
+        beforeRecordRead: @escaping (String) async throws -> Void = { _ in }
+    ) {
+        self.source = source
+        self.destination = destination
+        self.stateFile = stateFile
+        self.now = now
+        self.beforeStateCommit = beforeStateCommit
+        self.beforeRecordRead = beforeRecordRead
+        active = source
+    }
+
+    var persistenceAvailability: PersistenceAvailability {
+        active.persistenceAvailability
+    }
+
+    func load(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        into draft: inout ContentDraft?
+    ) -> Bool {
+        active.load(accountID: accountID, target: target, into: &draft)
+    }
+
+    func loadAsync(
+        accountID: String,
+        target: ContentSubmissionTarget
+    ) async -> ContentDraftLoadOutcome {
+        await ensureMigrationResolved()
+        guard Task.isCancelled == false else { return .unavailable }
+        return await active.loadAsync(accountID: accountID, target: target)
+    }
+
+    func save(_ draft: ContentDraft) -> Bool {
+        active.save(draft)
+    }
+
+    func saveAsync(_ draft: ContentDraft) async throws {
+        await ensureMigrationResolved()
+        try Task.checkCancellation()
+        try await active.saveAsync(draft)
+    }
+
+    func delete(accountID: String, target: ContentSubmissionTarget) -> Bool {
+        active.delete(accountID: accountID, target: target)
+    }
+
+    func clear(accountID: String) -> Bool {
+        active.clear(accountID: accountID)
+    }
+
+    func repairLegacyMetadataAndPruneAsync() async -> Bool {
+        await ensureMigrationResolved()
+        guard Task.isCancelled == false else { return false }
+        return await active.repairLegacyMetadataAndPruneAsync()
+    }
+
+    func migrationManifest() async throws -> ContentDraftMigrationManifest {
+        await ensureMigrationResolved()
+        try Task.checkCancellation()
+        return try await active.migrationManifest()
+    }
+
+    func migrationRecord(identity: String) async throws -> ContentDraftPersistenceRecord {
+        await ensureMigrationResolved()
+        try Task.checkCancellation()
+        return try await active.migrationRecord(identity: identity)
+    }
+
+    func beginMigration(to manifest: ContentDraftMigrationManifest) async throws {
+        await ensureMigrationResolved()
+        try Task.checkCancellation()
+        try await active.beginMigration(to: manifest)
+    }
+
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) async throws {
+        await ensureMigrationResolved()
+        try Task.checkCancellation()
+        try await active.writeMigrationRecord(record)
+    }
+
+    private func ensureMigrationResolved() async {
+        guard migrationResolved == false else { return }
+        if migrationTask == nil {
+            migrationTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await performMigration()
+            }
+        }
+        // Migration is backend-scoped work shared by every caller. A view task
+        // disappearing must not cancel it for the rest of the process.
+        await migrationTask?.value
+    }
+
+    private func performMigration() async {
+        defer {
+            migrationResolved = true
+            migrationTask = nil
+        }
+        let coordinationKey = stateFile.fileURL.standardizedFileURL.path
+        await ContentDraftMigrationCoordinator.shared.acquire(coordinationKey)
+        do {
+            try Task.checkCancellation()
+            guard let state = try stateFile.load() else {
+                throw ContentDraftPersistenceStateError.invalidState
+            }
+            let validatedState = try state.validated()
+            switch validatedState.activeBackend {
+            case .pendingActivation:
+                throw ContentDraftPersistenceStateError.invalidState
+            case .swiftData:
+                guard let generationID = validatedState.destinationGenerationID,
+                      try await destination.backendGenerationIDAsync() == generationID else {
+                    throw ContentDraftPersistenceError.destinationMarkerMismatch
+                }
+                active = destination
+                await ContentDraftMigrationCoordinator.shared.release(coordinationKey)
+                return
+            case .secureFiles:
+                break
+            }
+            let sourceManifest = try await source.migrationManifest()
+            let generationID = UUID().uuidString.lowercased()
+            try await destination.beginMigration(
+                to: sourceManifest,
+                generationID: generationID
+            )
+            for expectedEntry in sourceManifest.entries {
+                try Task.checkCancellation()
+                try await beforeRecordRead(expectedEntry.identity)
+                try Task.checkCancellation()
+                let record = try await source.migrationRecord(identity: expectedEntry.identity)
+                guard try ContentDraftMigrationManifestEntry(record: record) == expectedEntry else {
+                    throw ContentDraftPersistenceError.sourceChangedDuringMigration
+                }
+                try await destination.writeMigrationRecord(record)
+            }
+
+            let destinationManifest = try await destination.migrationManifest()
+            guard destinationManifest == sourceManifest else {
+                throw ContentDraftPersistenceError.migrationVerificationFailed
+            }
+            guard try await destination.backendGenerationIDAsync() == generationID else {
+                throw ContentDraftPersistenceError.destinationMarkerMismatch
+            }
+            let finalSourceManifest = try await source.migrationManifest()
+            guard finalSourceManifest == sourceManifest else {
+                throw ContentDraftPersistenceError.sourceChangedDuringMigration
+            }
+            try Task.checkCancellation()
+            let completedState = ContentDraftPersistenceState.migrated(
+                sourceFingerprint: sourceManifest.fingerprint(),
+                generationID: generationID,
+                completedAt: now()
+            )
+            _ = try completedState.validated()
+            try stateFile.replace(completedState) {
+                try Task.checkCancellation()
+                try beforeStateCommit()
+            }
+
+            // The state file is the backend-selection commit point. Do not add
+            // any throwing work between this assignment and method return.
+            active = destination
+        } catch is CancellationError {
+            active = source
+        } catch {
+            PersistenceDiagnostics.report(error, operation: "migrate content drafts to SwiftData")
+            active = source
+        }
+        await ContentDraftMigrationCoordinator.shared.release(coordinationKey)
+    }
+}

--- a/TiebaPure/Domain/Models/FileContentDraftPersistence.swift
+++ b/TiebaPure/Domain/Models/FileContentDraftPersistence.swift
@@ -1,0 +1,842 @@
+import Foundation
+
+enum FileContentDraftPersistenceError: Error, Equatable {
+    case unsupportedCatalogVersion(Int)
+    case invalidCatalog
+    case invalidAccountID
+    case pathIsSymbolicLink
+    case pathIsNotRegularFile
+    case pathIsNotDirectory
+    case attachmentTooLarge
+}
+
+struct ContentDraftFilePersistenceFaultInjector: Sendable {
+    enum Point: Sendable {
+        case beforeBlobCommit
+        case beforeCatalogCommit
+        case beforeBlobCleanup
+    }
+
+    static let none = ContentDraftFilePersistenceFaultInjector { _ in }
+
+    let check: @Sendable (Point) throws -> Void
+}
+
+private struct ContentDraftFileCatalog: Codable, Sendable {
+    static let currentFormatVersion = 1
+
+    var formatVersion: Int
+    var entries: [ContentDraftFileCatalogEntry]
+
+    static var empty: ContentDraftFileCatalog {
+        ContentDraftFileCatalog(formatVersion: currentFormatVersion, entries: [])
+    }
+}
+
+private struct ContentDraftFileCatalogEntry: Codable, Sendable {
+    let recordID: String
+    let accountID: String
+    let targetKey: String
+    let targetData: Data
+    let title: String
+    let body: String
+    let blobFileName: String
+    let imagesByteCount: Int
+    let updatedAt: Date
+    let metadataDigest: String
+    let blobDigest: String
+
+    var identity: String {
+        "\(accountID)\u{1f}\(targetKey)"
+    }
+
+    var migrationManifestEntry: ContentDraftMigrationManifestEntry {
+        ContentDraftMigrationManifestEntry(
+            identity: identity,
+            accountID: accountID,
+            targetKey: targetKey,
+            updatedAt: updatedAt,
+            imagesByteCount: imagesByteCount,
+            metadataDigest: metadataDigest,
+            blobDigest: blobDigest
+        )
+    }
+}
+
+enum ContentDraftFileCatalogPresence: Equatable, Sendable {
+    case absent
+    case empty
+    case containsDrafts
+}
+
+private final class ContentDraftFileSharedState: @unchecked Sendable {
+    let lock = NSRecursiveLock()
+}
+
+private final class ContentDraftFileStateRegistry: @unchecked Sendable {
+    static let shared = ContentDraftFileStateRegistry()
+
+    private let lock = NSLock()
+    private var states: [String: ContentDraftFileSharedState] = [:]
+
+    func state(for standardizedPath: String) -> ContentDraftFileSharedState {
+        lock.lock()
+        defer { lock.unlock() }
+        if let state = states[standardizedPath] { return state }
+        let state = ContentDraftFileSharedState()
+        states[standardizedPath] = state
+        return state
+    }
+}
+
+private final class ContentDraftFileStorage: @unchecked Sendable {
+    static let catalogFileName = "content-drafts-catalog.json"
+    static let blobDirectoryName = "content-draft-blobs"
+
+    private let directoryURL: URL
+    private let blobDirectoryURL: URL
+    private let fileManager: FileManager
+    private let catalogFile: SecureCodableFile<ContentDraftFileCatalog>
+    private let sharedState: ContentDraftFileSharedState
+    private let faultInjector: ContentDraftFilePersistenceFaultInjector
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager,
+        faultInjector: ContentDraftFilePersistenceFaultInjector
+    ) throws {
+        self.directoryURL = directoryURL
+        self.fileManager = fileManager
+        self.faultInjector = faultInjector
+        blobDirectoryURL = directoryURL.appendingPathComponent(
+            Self.blobDirectoryName,
+            isDirectory: true
+        )
+        catalogFile = try SecureCodableFile(
+            directoryURL: directoryURL,
+            fileName: Self.catalogFileName,
+            fileManager: fileManager,
+            maximumByteCount: 32 * 1_024 * 1_024
+        )
+        sharedState = ContentDraftFileStateRegistry.shared.state(
+            for: catalogFile.fileURL.standardizedFileURL.path
+        )
+        try Self.prepareDirectory(blobDirectoryURL, fileManager: fileManager)
+    }
+
+    func catalogPresence() throws -> ContentDraftFileCatalogPresence {
+        try withLock {
+            let hasCatalogArtifact = fileManager.fileExists(atPath: catalogFile.fileURL.path)
+                || fileManager.fileExists(atPath: catalogFile.backupURL.path)
+            guard hasCatalogArtifact else { return .absent }
+            return try loadCatalog().entries.isEmpty ? .empty : .containsDrafts
+        }
+    }
+
+    func load(accountID: String, target: ContentSubmissionTarget) throws -> ContentDraftLoadOutcome {
+        try withLock {
+            let normalizedAccountID = try Self.normalizedAccountID(accountID)
+            let catalog = try loadCatalog()
+            let matches = catalog.entries.filter {
+                $0.accountID == normalizedAccountID && $0.targetKey == target.draftKey
+            }
+            guard let entry = preferredEntry(in: matches) else { return .loaded(nil) }
+            guard let storedTarget = try? JSONDecoder().decode(
+                ContentSubmissionTarget.self,
+                from: entry.targetData
+            ), storedTarget.draftKey == entry.targetKey else {
+                return .damaged(.targetMetadata)
+            }
+            guard let blob = try readBlobIfValid(entry.blobFileName) else {
+                return .damaged(.attachmentContainer)
+            }
+            guard blob.count == entry.imagesByteCount,
+                  SecurePersistenceDigest.sha256(blob) == entry.blobDigest else {
+                return .damaged(.attachmentContainer)
+            }
+            let images: [ContentSubmissionImage]
+            switch ContentDraftImageBlobCodec.decodeWithIntegrity(blob) {
+            case let .decoded(decoded):
+                images = decoded
+            case .damagedContainer:
+                return .damaged(.attachmentContainer)
+            case .cancelled:
+                throw CancellationError()
+            }
+            return .loaded(ContentDraft(
+                accountID: normalizedAccountID,
+                target: storedTarget,
+                title: entry.title,
+                body: entry.body,
+                images: images,
+                updatedAt: entry.updatedAt
+            ))
+        }
+    }
+
+    func save(_ draft: ContentDraft) throws {
+        let accountID = try Self.normalizedAccountID(draft.accountID)
+        let targetData = try JSONEncoder().encode(draft.target)
+        let imagesBlob = try ContentDraftImageBlobCodec.encode(draft.images)
+        guard imagesBlob.count <= ContentDraftPolicy.maximumAttachmentBytesPerDraft else {
+            throw FileContentDraftPersistenceError.attachmentTooLarge
+        }
+
+        try withLock {
+            try Task.checkCancellation()
+            let oldCatalog = try loadCatalog()
+            let record = try ContentDraftPersistenceRecord(
+                accountID: accountID,
+                targetKey: draft.target.draftKey,
+                targetData: targetData,
+                title: draft.title,
+                body: draft.body,
+                imagesBlob: imagesBlob,
+                imagesByteCount: imagesBlob.count,
+                updatedAt: draft.updatedAt
+            ).validated()
+            let manifestEntry = try ContentDraftMigrationManifestEntry(record: record)
+            let recordID = UUID().uuidString.lowercased()
+            let blobFileName = Self.blobFileName(recordID: recordID)
+            var blobWasCommitted = false
+            var catalogWasCommitted = false
+            do {
+                try writeBlob(imagesBlob, fileName: blobFileName)
+                blobWasCommitted = true
+                var updatedEntries = oldCatalog.entries.filter {
+                    $0.accountID != accountID || $0.targetKey != draft.target.draftKey
+                }
+                updatedEntries.append(ContentDraftFileCatalogEntry(
+                    recordID: recordID,
+                    accountID: accountID,
+                    targetKey: draft.target.draftKey,
+                    targetData: targetData,
+                    title: draft.title,
+                    body: draft.body,
+                    blobFileName: blobFileName,
+                    imagesByteCount: imagesBlob.count,
+                    updatedAt: draft.updatedAt,
+                    metadataDigest: manifestEntry.metadataDigest,
+                    blobDigest: manifestEntry.blobDigest
+                ))
+                updatedEntries = pruned(updatedEntries)
+                let updatedCatalog = ContentDraftFileCatalog(
+                    formatVersion: ContentDraftFileCatalog.currentFormatVersion,
+                    entries: updatedEntries
+                )
+                try catalogFile.replace(updatedCatalog) {
+                    try Task.checkCancellation()
+                    try faultInjector.check(.beforeCatalogCommit)
+                }
+                catalogWasCommitted = true
+                cleanupBestEffort(referencedBy: updatedCatalog)
+            } catch {
+                if blobWasCommitted, catalogWasCommitted == false {
+                    try? removeRegularFileIfPresent(blobURL(fileName: blobFileName))
+                }
+                throw error
+            }
+        }
+    }
+
+    func delete(accountID: String, target: ContentSubmissionTarget) throws {
+        try withLock {
+            let normalizedAccountID = try Self.normalizedAccountID(accountID)
+            let oldCatalog = try loadCatalog()
+            let retained = oldCatalog.entries.filter {
+                $0.accountID != normalizedAccountID || $0.targetKey != target.draftKey
+            }
+            guard retained.count != oldCatalog.entries.count else { return }
+            let updated = ContentDraftFileCatalog(
+                formatVersion: ContentDraftFileCatalog.currentFormatVersion,
+                entries: retained
+            )
+            try catalogFile.replace(updated) {
+                try Task.checkCancellation()
+                try faultInjector.check(.beforeCatalogCommit)
+            }
+            cleanupBestEffort(referencedBy: updated)
+        }
+    }
+
+    func clear(accountID: String) throws {
+        try withLock {
+            let normalizedAccountID = try Self.normalizedAccountID(accountID)
+            let oldCatalog = try loadCatalog()
+            let retained = oldCatalog.entries.filter { $0.accountID != normalizedAccountID }
+            let updated = ContentDraftFileCatalog(
+                formatVersion: ContentDraftFileCatalog.currentFormatVersion,
+                entries: retained
+            )
+            // Commit an empty catalog even on a first clear. It is a durable
+            // source generation that must migrate as an intentional deletion.
+            try catalogFile.replace(updated) {
+                try Task.checkCancellation()
+                try faultInjector.check(.beforeCatalogCommit)
+            }
+            cleanupBestEffort(referencedBy: updated)
+        }
+    }
+
+    func repairAndPrune() throws {
+        try withLock {
+            let catalog = try loadCatalog()
+            let retained = pruned(catalog.entries)
+            let updated = ContentDraftFileCatalog(
+                formatVersion: ContentDraftFileCatalog.currentFormatVersion,
+                entries: retained
+            )
+            if retained.count != catalog.entries.count {
+                try catalogFile.replace(updated) {
+                    try Task.checkCancellation()
+                    try faultInjector.check(.beforeCatalogCommit)
+                }
+            }
+            cleanupBestEffort(referencedBy: updated)
+        }
+    }
+
+    func migrationManifest() throws -> ContentDraftMigrationManifest {
+        try withLock {
+            let catalog = try loadCatalog()
+            try Task.checkCancellation()
+            return try ContentDraftMigrationManifest(
+                entries: catalog.entries.map(\.migrationManifestEntry)
+            )
+        }
+    }
+
+    func migrationRecord(identity: String) throws -> ContentDraftPersistenceRecord {
+        try withLock {
+            let catalog = try loadCatalog()
+            guard let entry = preferredEntry(in: catalog.entries.filter { $0.identity == identity }),
+                  let blob = try readBlobIfValid(entry.blobFileName) else {
+                throw ContentDraftPersistenceError.missingMigrationRecord
+            }
+            let record = try ContentDraftPersistenceRecord(
+                accountID: entry.accountID,
+                targetKey: entry.targetKey,
+                targetData: entry.targetData,
+                title: entry.title,
+                body: entry.body,
+                imagesBlob: blob,
+                imagesByteCount: blob.count,
+                updatedAt: entry.updatedAt
+            ).validated()
+            guard try ContentDraftMigrationManifestEntry(record: record)
+                == entry.migrationManifestEntry else {
+                throw ContentDraftPersistenceError.invalidRecord
+            }
+            return record
+        }
+    }
+
+    func beginMigration(to manifest: ContentDraftMigrationManifest) throws {
+        try withLock {
+            _ = try ContentDraftMigrationManifest(entries: manifest.entries)
+            let empty = ContentDraftFileCatalog.empty
+            try catalogFile.replace(empty) {
+                try Task.checkCancellation()
+                try faultInjector.check(.beforeCatalogCommit)
+            }
+            cleanupBestEffort(referencedBy: empty)
+        }
+    }
+
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) throws {
+        let record = try record.validated()
+        let manifestEntry = try ContentDraftMigrationManifestEntry(record: record)
+        try withLock {
+            try Task.checkCancellation()
+            let oldCatalog = try loadCatalog()
+            let recordID = UUID().uuidString.lowercased()
+            let blobFileName = Self.blobFileName(recordID: recordID)
+            var blobWasCommitted = false
+            var catalogWasCommitted = false
+            do {
+                try writeBlob(record.imagesBlob, fileName: blobFileName)
+                blobWasCommitted = true
+                var entries = oldCatalog.entries.filter { $0.identity != record.identity }
+                entries.append(ContentDraftFileCatalogEntry(
+                    recordID: recordID,
+                    accountID: record.accountID,
+                    targetKey: record.targetKey,
+                    targetData: record.targetData,
+                    title: record.title,
+                    body: record.body,
+                    blobFileName: blobFileName,
+                    imagesByteCount: record.imagesByteCount,
+                    updatedAt: record.updatedAt,
+                    metadataDigest: manifestEntry.metadataDigest,
+                    blobDigest: manifestEntry.blobDigest
+                ))
+                let updated = ContentDraftFileCatalog(
+                    formatVersion: ContentDraftFileCatalog.currentFormatVersion,
+                    entries: pruned(entries)
+                )
+                try catalogFile.replace(updated) {
+                    try Task.checkCancellation()
+                    try faultInjector.check(.beforeCatalogCommit)
+                }
+                catalogWasCommitted = true
+                cleanupBestEffort(referencedBy: updated)
+            } catch {
+                if blobWasCommitted, catalogWasCommitted == false {
+                    try? removeRegularFileIfPresent(blobURL(fileName: blobFileName))
+                }
+                throw error
+            }
+        }
+    }
+
+    private func loadCatalog() throws -> ContentDraftFileCatalog {
+        let catalog = try catalogFile.load() ?? .empty
+        guard catalog.formatVersion == ContentDraftFileCatalog.currentFormatVersion else {
+            throw FileContentDraftPersistenceError.unsupportedCatalogVersion(catalog.formatVersion)
+        }
+        var recordIDs = Set<String>()
+        var fileNames = Set<String>()
+        var identities = Set<String>()
+        for entry in catalog.entries {
+            guard UUID(uuidString: entry.recordID) != nil,
+                  entry.blobFileName == Self.blobFileName(recordID: entry.recordID),
+                  recordIDs.insert(entry.recordID).inserted,
+                  fileNames.insert(entry.blobFileName).inserted,
+                  identities.insert(entry.identity).inserted,
+                  entry.accountID.isEmpty == false,
+                  entry.accountID == entry.accountID.trimmingCharacters(in: .whitespacesAndNewlines),
+                  entry.targetKey.isEmpty == false,
+                  entry.imagesByteCount >= 0,
+                  entry.imagesByteCount <= ContentDraftPolicy.maximumAttachmentBytesPerDraft,
+                  entry.metadataDigest == ContentDraftMigrationManifestEntry.metadataDigest(
+                    accountID: entry.accountID,
+                    targetKey: entry.targetKey,
+                    targetData: entry.targetData,
+                    title: entry.title,
+                    body: entry.body,
+                    updatedAt: entry.updatedAt
+                  ) else {
+                throw FileContentDraftPersistenceError.invalidCatalog
+            }
+        }
+        guard (try? ContentDraftMigrationManifest(
+            entries: catalog.entries.map(\.migrationManifestEntry)
+        )) != nil else {
+            throw FileContentDraftPersistenceError.invalidCatalog
+        }
+        return catalog
+    }
+
+    private func pruned(
+        _ entries: [ContentDraftFileCatalogEntry]
+    ) -> [ContentDraftFileCatalogEntry] {
+        let candidates = entries.enumerated().map { index, entry in
+            ContentDraftPruneCandidate(
+                sourceIndex: index,
+                persistentID: entry.recordID,
+                accountID: entry.accountID,
+                targetKey: entry.targetKey,
+                updatedAt: entry.updatedAt,
+                imagesByteCount: entry.imagesByteCount
+            )
+        }
+        let deletionIndices = ContentDraftPruner.deletionIndices(for: candidates)
+        return entries.enumerated().compactMap { index, entry in
+            deletionIndices.contains(index) ? nil : entry
+        }
+    }
+
+    private func preferredEntry(
+        in entries: [ContentDraftFileCatalogEntry]
+    ) -> ContentDraftFileCatalogEntry? {
+        entries.max {
+            if $0.updatedAt != $1.updatedAt { return $0.updatedAt < $1.updatedAt }
+            return $0.recordID < $1.recordID
+        }
+    }
+
+    private func writeBlob(_ data: Data, fileName: String) throws {
+        try Task.checkCancellation()
+        guard data.count <= ContentDraftPolicy.maximumAttachmentBytesPerDraft else {
+            throw FileContentDraftPersistenceError.attachmentTooLarge
+        }
+        try Self.prepareDirectory(blobDirectoryURL, fileManager: fileManager)
+        let destinationURL = blobURL(fileName: fileName)
+        guard fileManager.fileExists(atPath: destinationURL.path) == false else {
+            throw FileContentDraftPersistenceError.invalidCatalog
+        }
+        let temporaryURL = blobDirectoryURL.appendingPathComponent(
+            ".\(fileName).\(UUID().uuidString).tmp",
+            isDirectory: false
+        )
+        defer { try? fileManager.removeItem(at: temporaryURL) }
+        try data.write(to: temporaryURL, options: [.completeFileProtection])
+        try Self.secureFile(temporaryURL, fileManager: fileManager)
+        let handle = try FileHandle(forWritingTo: temporaryURL)
+        try handle.synchronize()
+        try handle.close()
+        try Task.checkCancellation()
+        try faultInjector.check(.beforeBlobCommit)
+        try fileManager.moveItem(at: temporaryURL, to: destinationURL)
+        try Self.secureFile(destinationURL, fileManager: fileManager)
+    }
+
+    private func readBlobIfValid(_ fileName: String) throws -> Data? {
+        let url = blobURL(fileName: fileName)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        try Self.rejectSymbolicLink(url, fileManager: fileManager)
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw FileContentDraftPersistenceError.pathIsNotRegularFile
+        }
+        if let size = attributes[.size] as? NSNumber,
+           size.intValue > ContentDraftPolicy.maximumAttachmentBytesPerDraft {
+            return nil
+        }
+        try Task.checkCancellation()
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        guard data.count <= ContentDraftPolicy.maximumAttachmentBytesPerDraft else { return nil }
+        return data
+    }
+
+    private func cleanupUnreferencedBlobs(
+        referencedBy catalog: ContentDraftFileCatalog
+    ) throws {
+        let referenced = Set(catalog.entries.map(\.blobFileName))
+        for url in try fileManager.contentsOfDirectory(
+            at: blobDirectoryURL,
+            includingPropertiesForKeys: nil,
+            options: []
+        ) where (url.pathExtension == "tpdi"
+            && referenced.contains(url.lastPathComponent) == false)
+            || (url.lastPathComponent.hasPrefix(".")
+                && url.lastPathComponent.hasSuffix(".tmp")) {
+            try Task.checkCancellation()
+            try removeRegularFileIfPresent(url)
+        }
+    }
+
+    private func cleanupBestEffort(referencedBy catalog: ContentDraftFileCatalog) {
+        do {
+            try faultInjector.check(.beforeBlobCleanup)
+            try cleanupUnreferencedBlobs(referencedBy: catalog)
+        } catch {
+            // The catalog is the commit point. Cleanup is maintenance and can
+            // be retried without changing the result of the committed write.
+        }
+    }
+
+    private func removeRegularFileIfPresent(_ url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try Self.rejectSymbolicLink(url, fileManager: fileManager)
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw FileContentDraftPersistenceError.pathIsNotRegularFile
+        }
+        try fileManager.removeItem(at: url)
+    }
+
+    private func blobURL(fileName: String) -> URL {
+        blobDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    private static func blobFileName(recordID: String) -> String {
+        "draft-\(recordID.lowercased()).tpdi"
+    }
+
+    private static func normalizedAccountID(_ accountID: String) throws -> String {
+        let normalized = accountID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.isEmpty == false else {
+            throw FileContentDraftPersistenceError.invalidAccountID
+        }
+        return normalized
+    }
+
+    private func withLock<Result>(_ operation: () throws -> Result) rethrows -> Result {
+        sharedState.lock.lock()
+        defer { sharedState.lock.unlock() }
+        return try operation()
+    }
+
+    private static func prepareDirectory(_ url: URL, fileManager: FileManager) throws {
+        if fileManager.fileExists(atPath: url.path) {
+            try rejectSymbolicLink(url, fileManager: fileManager)
+            let attributes = try fileManager.attributesOfItem(atPath: url.path)
+            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+                throw FileContentDraftPersistenceError.pathIsNotDirectory
+            }
+        } else {
+            try fileManager.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: secureDirectoryAttributes
+            )
+        }
+        try fileManager.setAttributes(secureDirectoryAttributes, ofItemAtPath: url.path)
+    }
+
+    private static func secureFile(_ url: URL, fileManager: FileManager) throws {
+        try fileManager.setAttributes(secureFileAttributes, ofItemAtPath: url.path)
+    }
+
+    private static func rejectSymbolicLink(_ url: URL, fileManager: FileManager) throws {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        if attributes[.type] as? FileAttributeType == .typeSymbolicLink {
+            throw FileContentDraftPersistenceError.pathIsSymbolicLink
+        }
+    }
+
+    private static var secureDirectoryAttributes: [FileAttributeKey: Any] {
+        [
+            .posixPermissions: NSNumber(value: Int16(0o700)),
+            .protectionKey: FileProtectionType.complete
+        ]
+    }
+
+    private static var secureFileAttributes: [FileAttributeKey: Any] {
+        [
+            .posixPermissions: NSNumber(value: Int16(0o600)),
+            .protectionKey: FileProtectionType.complete
+        ]
+    }
+}
+
+@MainActor
+final class FileContentDraftPersistenceBackend: ContentDraftPersistenceBackend {
+    private let storage: ContentDraftFileStorage
+    private(set) var persistenceAvailability: PersistenceAvailability = .available
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        faultInjector: ContentDraftFilePersistenceFaultInjector = .none
+    ) throws {
+        storage = try ContentDraftFileStorage(
+            directoryURL: directoryURL,
+            fileManager: fileManager,
+            faultInjector: faultInjector
+        )
+    }
+
+    func catalogPresence() throws -> ContentDraftFileCatalogPresence {
+        try storage.catalogPresence()
+    }
+
+    func load(
+        accountID: String,
+        target: ContentSubmissionTarget,
+        into draft: inout ContentDraft?
+    ) -> Bool {
+        draft = nil
+        do {
+            let outcome = try storage.load(accountID: accountID, target: target)
+            switch outcome {
+            case let .loaded(value):
+                draft = value
+                markSucceeded()
+                return true
+            case .damaged:
+                markSucceeded()
+                return false
+            case .unavailable:
+                return fail(ContentDraftPersistenceError.unavailable, operation: "load file content draft")
+            }
+        } catch is CancellationError {
+            return false
+        } catch {
+            return fail(error, operation: "load file content draft")
+        }
+    }
+
+    func loadAsync(
+        accountID: String,
+        target: ContentSubmissionTarget
+    ) async -> ContentDraftLoadOutcome {
+        let storage = storage
+        let task = Task.detached(priority: .userInitiated) {
+            try storage.load(accountID: accountID, target: target)
+        }
+        do {
+            let outcome = try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+            return outcome
+        } catch is CancellationError {
+            return .unavailable
+        } catch {
+            _ = fail(error, operation: "load file content draft")
+            return .unavailable
+        }
+    }
+
+    func save(_ draft: ContentDraft) -> Bool {
+        do {
+            try storage.save(draft)
+            markSucceeded()
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            return fail(error, operation: "save file content draft")
+        }
+    }
+
+    func saveAsync(_ draft: ContentDraft) async throws {
+        let storage = storage
+        let task = Task.detached(priority: .userInitiated) {
+            try storage.save(draft)
+        }
+        do {
+            try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "save file content draft")
+            throw error
+        }
+    }
+
+    func delete(accountID: String, target: ContentSubmissionTarget) -> Bool {
+        do {
+            try storage.delete(accountID: accountID, target: target)
+            markSucceeded()
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            return fail(error, operation: "delete file content draft")
+        }
+    }
+
+    func clear(accountID: String) -> Bool {
+        do {
+            try storage.clear(accountID: accountID)
+            markSucceeded()
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            return fail(error, operation: "clear file content drafts")
+        }
+    }
+
+    func repairLegacyMetadataAndPruneAsync() async -> Bool {
+        let storage = storage
+        let task = Task.detached(priority: .utility) {
+            try storage.repairAndPrune()
+        }
+        do {
+            try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            return fail(error, operation: "repair file content drafts")
+        }
+    }
+
+    func migrationManifest() async throws -> ContentDraftMigrationManifest {
+        let storage = storage
+        let task = Task.detached(priority: .utility) {
+            try storage.migrationManifest()
+        }
+        do {
+            let manifest = try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+            return manifest
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "export file content draft migration manifest")
+            throw error
+        }
+    }
+
+    func migrationRecord(identity: String) async throws -> ContentDraftPersistenceRecord {
+        let storage = storage
+        let task = Task.detached(priority: .utility) {
+            try storage.migrationRecord(identity: identity)
+        }
+        do {
+            let record = try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+            return record
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "read file content draft migration record")
+            throw error
+        }
+    }
+
+    func beginMigration(to manifest: ContentDraftMigrationManifest) async throws {
+        let storage = storage
+        let task = Task.detached(priority: .utility) {
+            try storage.beginMigration(to: manifest)
+        }
+        do {
+            try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "begin file content draft migration")
+            throw error
+        }
+    }
+
+    func writeMigrationRecord(_ record: ContentDraftPersistenceRecord) async throws {
+        let storage = storage
+        let task = Task.detached(priority: .utility) {
+            try storage.writeMigrationRecord(record)
+        }
+        do {
+            try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            markSucceeded()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            _ = fail(error, operation: "write file content draft migration record")
+            throw error
+        }
+    }
+
+    private func markSucceeded() {
+        persistenceAvailability = .available
+    }
+
+    private func fail(_ error: Error, operation: String) -> Bool {
+        PersistenceDiagnostics.report(error, operation: operation)
+        persistenceAvailability = .unavailable
+        return false
+    }
+}

--- a/TiebaPure/Domain/Models/FileOrderedCollectionPersistence.swift
+++ b/TiebaPure/Domain/Models/FileOrderedCollectionPersistence.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+private actor FileBrowsingHistoryMutationActor {
+    private let file: SecureCodableFile<[BrowsingHistoryEntry]>
+
+    init(file: SecureCodableFile<[BrowsingHistoryEntry]>) {
+        self.file = file
+    }
+
+    func upsert(
+        _ entry: BrowsingHistoryEntry,
+        limit: Int
+    ) throws -> [BrowsingHistoryEntry] {
+        try Task.checkCancellation()
+        return try file.update(
+            default: [],
+            beforeCommit: { try Task.checkCancellation() }
+        ) { entries in
+            try Task.checkCancellation()
+            entries = BrowsingHistoryPolicy.adding(entry, to: entries, limit: limit)
+        }
+    }
+
+    func remove(threadIDs: Set<Int64>) throws -> [BrowsingHistoryEntry] {
+        try Task.checkCancellation()
+        return try file.update(
+            default: [],
+            beforeCommit: { try Task.checkCancellation() }
+        ) { entries in
+            try Task.checkCancellation()
+            entries = BrowsingHistoryPolicy.removing(threadIDs: threadIDs, from: entries)
+        }
+    }
+
+    func removeAll() throws -> [BrowsingHistoryEntry] {
+        try Task.checkCancellation()
+        return try file.update(
+            default: [],
+            beforeCommit: { try Task.checkCancellation() }
+        ) { entries in
+            try Task.checkCancellation()
+            entries = []
+        }
+    }
+}
+
+@MainActor
+final class FileBrowsingHistoryPersistence: BrowsingHistoryPersistence {
+    let capability: PersistenceCapability = .durable
+
+    private let file: SecureCodableFile<[BrowsingHistoryEntry]>
+    private let mutationActor: FileBrowsingHistoryMutationActor
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        fileName: String = "browsing-history.json"
+    ) throws {
+        let file = try SecureCodableFile<[BrowsingHistoryEntry]>(
+            directoryURL: directoryURL,
+            fileName: fileName,
+            fileManager: fileManager
+        )
+        self.file = file
+        mutationActor = FileBrowsingHistoryMutationActor(file: file)
+    }
+
+    func load() throws -> [BrowsingHistoryEntry] {
+        try file.load() ?? []
+    }
+
+    func replaceAll(
+        _ entries: [BrowsingHistoryEntry],
+        beforeCommit: () throws -> Void
+    ) throws {
+        try file.replace(entries, beforeCommit: beforeCommit)
+    }
+
+    func upsert(
+        _ entry: BrowsingHistoryEntry,
+        limit: Int
+    ) async throws -> [BrowsingHistoryEntry] {
+        try await mutationActor.upsert(entry, limit: limit)
+    }
+
+    func remove(threadIDs: Set<Int64>) async throws -> [BrowsingHistoryEntry] {
+        try await mutationActor.remove(threadIDs: threadIDs)
+    }
+
+    func removeAll() async throws -> [BrowsingHistoryEntry] {
+        try await mutationActor.removeAll()
+    }
+
+    func recoverCorruptedStorage() throws {
+        try file.quarantineCorruptedGenerations()
+    }
+}
+
+@MainActor
+final class FileRecentForumPersistence: RecentForumPersistence {
+    let capability: PersistenceCapability = .durable
+
+    private let file: SecureCodableFile<[RecentForum]>
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        fileName: String = "recent-forums.json"
+    ) throws {
+        file = try SecureCodableFile<[RecentForum]>(
+            directoryURL: directoryURL,
+            fileName: fileName,
+            fileManager: fileManager
+        )
+    }
+
+    func load() throws -> [RecentForum] {
+        try file.load() ?? []
+    }
+
+    func replaceAll(
+        _ entries: [RecentForum],
+        beforeCommit: () throws -> Void
+    ) throws {
+        try file.replace(entries, beforeCommit: beforeCommit)
+    }
+
+    func recoverCorruptedStorage() throws {
+        try file.quarantineCorruptedGenerations()
+    }
+}
+
+@MainActor
+final class FileSearchHistoryPersistence: SearchHistoryPersistence {
+    let capability: PersistenceCapability = .durable
+
+    private let file: SecureCodableFile<[String]>
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        fileName: String = "search-history.json"
+    ) throws {
+        file = try SecureCodableFile<[String]>(
+            directoryURL: directoryURL,
+            fileName: fileName,
+            fileManager: fileManager
+        )
+    }
+
+    func load() throws -> [String] {
+        try file.load() ?? []
+    }
+
+    func replaceAll(
+        _ entries: [String],
+        beforeCommit: () throws -> Void
+    ) throws {
+        try file.replace(entries, beforeCommit: beforeCommit)
+    }
+
+    func recoverCorruptedStorage() throws {
+        try file.quarantineCorruptedGenerations()
+    }
+}
+
+@MainActor
+struct FileOrderedCollectionPersistenceBundle {
+    let browsingHistory: FileBrowsingHistoryPersistence
+    let recentForums: FileRecentForumPersistence
+    let searchHistory: FileSearchHistoryPersistence
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        browsingHistory = try FileBrowsingHistoryPersistence(
+            directoryURL: directoryURL,
+            fileManager: fileManager
+        )
+        recentForums = try FileRecentForumPersistence(
+            directoryURL: directoryURL,
+            fileManager: fileManager
+        )
+        searchHistory = try FileSearchHistoryPersistence(
+            directoryURL: directoryURL,
+            fileManager: fileManager
+        )
+    }
+
+    var erased: OrderedCollectionPersistenceBundle {
+        OrderedCollectionPersistenceBundle(
+            browsingHistory: browsingHistory,
+            recentForums: recentForums,
+            searchHistory: searchHistory
+        )
+    }
+}

--- a/TiebaPure/Domain/Models/LocalThreadLibrary.swift
+++ b/TiebaPure/Domain/Models/LocalThreadLibrary.swift
@@ -1,30 +1,6 @@
+import CryptoKit
 import Foundation
 import SwiftData
-
-// Legacy UserDefaults blobs are decoded element by element during the one-time
-// migration into SwiftData: a single corrupt entry must not drop the rest.
-struct FailableDecodable<Value: Decodable>: Decodable {
-    let value: Value?
-
-    init(from decoder: Decoder) {
-        value = try? Value(from: decoder)
-    }
-}
-
-enum PersistedArrayDecoder {
-    /// Returns `nil` only when the top-level payload cannot be decoded as an
-    /// array. A valid empty array returns `[]`, while corrupt elements inside a
-    /// valid array are still discarded individually.
-    static func decode<Element: Decodable>(_ type: Element.Type, from data: Data) -> [Element]? {
-        guard let boxes = try? JSONDecoder().decode(
-            [FailableDecodable<Element>].self,
-            from: data
-        ) else {
-            return nil
-        }
-        return boxes.compactMap(\.value)
-    }
-}
 
 enum LocalThreadListSearchPolicy {
     static func matches(query: String, fields: [String?]) -> Bool {
@@ -70,6 +46,7 @@ private enum ThreadReadingPositionDatabaseMutation: Sendable {
     case deleteAll
 }
 
+@available(iOS 17.0, *)
 @ModelActor
 private actor ThreadReadingPositionDatabaseActor {
     func apply(
@@ -276,6 +253,817 @@ enum LocalThreadLibraryPolicy {
 }
 
 @MainActor
+protocol ThreadReadingPositionPersistence: AnyObject {
+    var capability: PersistenceCapability { get }
+
+    func load() throws -> [ThreadReadingPosition]
+    func replaceAll(
+        _ positions: [ThreadReadingPosition],
+        beforeCommit: () throws -> Void
+    ) throws
+    func upsert(_ position: ThreadReadingPosition, limit: Int) throws
+    func remove(threadID: Int64) throws
+    func removeAll(beforeCommit: () throws -> Void) throws
+    func clearAll(beforeCommit: () throws -> Void) throws
+
+    func upsertInBackground(
+        _ position: ThreadReadingPosition,
+        limit: Int
+    ) async throws -> [ThreadReadingPosition]
+    func removeInBackground(threadID: Int64) async throws -> [ThreadReadingPosition]
+    func removeAllInBackground() async throws -> [ThreadReadingPosition]
+}
+
+extension ThreadReadingPositionPersistence {
+    func replaceAll(_ positions: [ThreadReadingPosition]) throws {
+        try replaceAll(positions, beforeCommit: {})
+    }
+
+    func removeAll() throws {
+        try removeAll(beforeCommit: {})
+    }
+
+    func clearAll() throws {
+        try clearAll(beforeCommit: {})
+    }
+
+    func upsertInBackground(
+        _ position: ThreadReadingPosition,
+        limit: Int
+    ) async throws -> [ThreadReadingPosition] {
+        try Task.checkCancellation()
+        try upsert(position, limit: limit)
+        return try load()
+    }
+
+    func removeInBackground(threadID: Int64) async throws -> [ThreadReadingPosition] {
+        try Task.checkCancellation()
+        try remove(threadID: threadID)
+        return try load()
+    }
+
+    func removeAllInBackground() async throws -> [ThreadReadingPosition] {
+        try Task.checkCancellation()
+        try removeAll()
+        return []
+    }
+}
+
+enum ThreadReadingPositionBackend: String, Codable, Sendable {
+    case secureFiles
+    case swiftData
+}
+
+enum ThreadReadingPositionMigrationState: String, Codable, Sendable {
+    case fileActive
+    case nativeActivationPending
+    case nativeSwiftData
+    case fileMigrationCompleted
+}
+
+struct ThreadReadingPositionBackendActivation: Codable, Equatable, Sendable {
+    static let currentMigrationVersion = 1
+
+    let migrationVersion: Int
+    let sourceFingerprint: String?
+    let destinationGenerationID: String
+    let completedAt: Date
+}
+
+struct ThreadReadingPositionBackendState: Codable, Equatable, Sendable {
+    static let currentFormatVersion = 1
+
+    let formatVersion: Int
+    let activeBackend: ThreadReadingPositionBackend
+    let migrationState: ThreadReadingPositionMigrationState
+    let retainedFilePositions: [ThreadReadingPosition]
+    let activation: ThreadReadingPositionBackendActivation?
+
+    static func initialFileBackend(
+        positions: [ThreadReadingPosition] = []
+    ) -> ThreadReadingPositionBackendState {
+        ThreadReadingPositionBackendState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .secureFiles,
+            migrationState: .fileActive,
+            retainedFilePositions: positions,
+            activation: nil
+        )
+    }
+
+    static func nativeSwiftData(
+        generationID: String,
+        now: Date
+    ) -> ThreadReadingPositionBackendState {
+        ThreadReadingPositionBackendState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationState: .nativeSwiftData,
+            retainedFilePositions: [],
+            activation: ThreadReadingPositionBackendActivation(
+                migrationVersion: ThreadReadingPositionBackendActivation.currentMigrationVersion,
+                sourceFingerprint: nil,
+                destinationGenerationID: generationID,
+                completedAt: now
+            )
+        )
+    }
+
+    static func pendingNativeSwiftData(
+        generationID: String,
+        now: Date
+    ) -> ThreadReadingPositionBackendState {
+        ThreadReadingPositionBackendState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationState: .nativeActivationPending,
+            retainedFilePositions: [],
+            activation: ThreadReadingPositionBackendActivation(
+                migrationVersion: ThreadReadingPositionBackendActivation.currentMigrationVersion,
+                sourceFingerprint: nil,
+                destinationGenerationID: generationID,
+                completedAt: now
+            )
+        )
+    }
+
+    static func migratedToSwiftData(
+        retainedFilePositions: [ThreadReadingPosition],
+        sourceFingerprint: String,
+        generationID: String,
+        now: Date
+    ) -> ThreadReadingPositionBackendState {
+        ThreadReadingPositionBackendState(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationState: .fileMigrationCompleted,
+            retainedFilePositions: retainedFilePositions,
+            activation: ThreadReadingPositionBackendActivation(
+                migrationVersion: ThreadReadingPositionBackendActivation.currentMigrationVersion,
+                sourceFingerprint: sourceFingerprint,
+                destinationGenerationID: generationID,
+                completedAt: now
+            )
+        )
+    }
+
+    func validated() throws -> ThreadReadingPositionBackendState {
+        guard formatVersion == Self.currentFormatVersion else {
+            throw ThreadReadingPositionPersistenceFactoryError.unsupportedStateVersion(
+                formatVersion
+            )
+        }
+        switch (activeBackend, migrationState, activation) {
+        case (.secureFiles, .fileActive, nil):
+            return self
+        case let (.swiftData, .nativeActivationPending, activation?):
+            guard activation.migrationVersion
+                    == ThreadReadingPositionBackendActivation.currentMigrationVersion,
+                  activation.sourceFingerprint == nil,
+                  retainedFilePositions.isEmpty,
+                  UUID(uuidString: activation.destinationGenerationID) != nil else {
+                throw ThreadReadingPositionPersistenceFactoryError.invalidState
+            }
+            return self
+        case let (.swiftData, .nativeSwiftData, activation?):
+            guard activation.migrationVersion
+                    == ThreadReadingPositionBackendActivation.currentMigrationVersion,
+                  activation.sourceFingerprint == nil,
+                  retainedFilePositions.isEmpty,
+                  UUID(uuidString: activation.destinationGenerationID) != nil else {
+                throw ThreadReadingPositionPersistenceFactoryError.invalidState
+            }
+            return self
+        case let (.swiftData, .fileMigrationCompleted, activation?):
+            guard activation.migrationVersion
+                    == ThreadReadingPositionBackendActivation.currentMigrationVersion,
+                  let sourceFingerprint = activation.sourceFingerprint,
+                  sourceFingerprint.count == 64,
+                  try ThreadReadingPositionFileMigration.fingerprint(
+                    retainedFilePositions
+                  ) == sourceFingerprint,
+                  UUID(uuidString: activation.destinationGenerationID) != nil else {
+                throw ThreadReadingPositionPersistenceFactoryError.invalidState
+            }
+            return self
+        default:
+            throw ThreadReadingPositionPersistenceFactoryError.invalidState
+        }
+    }
+}
+
+@MainActor
+protocol ThreadReadingPositionMigrationDestination: ThreadReadingPositionPersistence {
+    func backendGenerationID() throws -> String?
+    func establishNativeBackendMarker(generationID: String) throws
+    func replaceAllForMigration(
+        _ positions: [ThreadReadingPosition],
+        generationID: String
+    ) throws
+}
+
+@MainActor
+final class FileThreadReadingPositionPersistence: ThreadReadingPositionPersistence {
+    enum StorageError: Error, Equatable {
+        case backendIsNotActive
+    }
+
+    let capability: PersistenceCapability
+    let fileURL: URL
+
+    private let fileManager: FileManager
+    private let stateFile: SecureCodableFile<ThreadReadingPositionBackendState>
+
+    init(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        capability: PersistenceCapability = .durable
+    ) throws {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        self.capability = capability
+        stateFile = try SecureCodableFile<ThreadReadingPositionBackendState>(
+            directoryURL: fileURL.deletingLastPathComponent(),
+            fileName: fileURL.lastPathComponent,
+            fileManager: fileManager
+        )
+    }
+
+    var hasStateArtifacts: Bool {
+        fileManager.fileExists(atPath: stateFile.fileURL.path)
+            || fileManager.fileExists(atPath: stateFile.backupURL.path)
+    }
+
+    func loadBackendState() throws -> ThreadReadingPositionBackendState? {
+        try stateFile.load()?.validated()
+    }
+
+    func initializeFileBackendIfNeeded() throws {
+        guard try loadBackendState() == nil else { return }
+        try stateFile.replace(.initialFileBackend())
+    }
+
+    func load() throws -> [ThreadReadingPosition] {
+        guard let state = try loadBackendState() else { return [] }
+        guard state.activeBackend == .secureFiles else {
+            throw StorageError.backendIsNotActive
+        }
+        return state.retainedFilePositions
+    }
+
+    func replaceAll(
+        _ positions: [ThreadReadingPosition],
+        beforeCommit: () throws -> Void
+    ) throws {
+        let current = try loadBackendState() ?? .initialFileBackend()
+        guard current.activeBackend == .secureFiles else {
+            throw StorageError.backendIsNotActive
+        }
+        try stateFile.replace(.initialFileBackend(positions: positions)) {
+            try Task.checkCancellation()
+            try beforeCommit()
+        }
+    }
+
+    func upsert(_ position: ThreadReadingPosition, limit: Int) throws {
+        let current = LocalThreadLibraryPolicy.sanitizedReadingPositions(
+            try load(),
+            limit: limit
+        )
+        try replaceAll(LocalThreadLibraryPolicy.addingReadingPosition(
+            position,
+            to: current,
+            limit: limit
+        ))
+    }
+
+    func remove(threadID: Int64) throws {
+        let current = try load()
+        try replaceAll(current.filter { $0.threadID != threadID })
+    }
+
+    func removeAll(beforeCommit: () throws -> Void) throws {
+        try replaceAll([], beforeCommit: beforeCommit)
+    }
+
+    func clearAll(beforeCommit: () throws -> Void) throws {
+        try removeAll(beforeCommit: beforeCommit)
+    }
+
+    func prepareNativeSwiftDataActivation(
+        generationID: String,
+        now: Date
+    ) throws -> ThreadReadingPositionBackendState {
+        guard try loadBackendState() == nil else {
+            throw ThreadReadingPositionPersistenceFactoryError.invalidState
+        }
+        let pendingState = ThreadReadingPositionBackendState.pendingNativeSwiftData(
+            generationID: generationID,
+            now: now
+        )
+        _ = try pendingState.validated()
+        try stateFile.replace(pendingState)
+        return pendingState
+    }
+
+    func activateNativeSwiftData(
+        pendingState: ThreadReadingPositionBackendState,
+        now: Date
+    ) throws {
+        guard pendingState.migrationState == .nativeActivationPending,
+              let generationID = pendingState.activation?.destinationGenerationID,
+              try loadBackendState() == pendingState else {
+            throw ThreadReadingPositionPersistenceFactoryError.invalidState
+        }
+        try stateFile.replace(.nativeSwiftData(generationID: generationID, now: now))
+    }
+
+    func activateMigratedSwiftData(
+        sourceState: ThreadReadingPositionBackendState,
+        retainedFilePositions: [ThreadReadingPosition],
+        sourceFingerprint: String,
+        generationID: String,
+        now: Date
+    ) throws {
+        guard try loadBackendState() == sourceState,
+              sourceState.activeBackend == .secureFiles else {
+            throw ThreadReadingPositionPersistenceFactoryError.sourceChangedDuringMigration
+        }
+        try stateFile.replace(.migratedToSwiftData(
+            retainedFilePositions: retainedFilePositions,
+            sourceFingerprint: sourceFingerprint,
+            generationID: generationID,
+            now: now
+        ))
+    }
+}
+
+@MainActor
+private final class UnavailableThreadReadingPositionPersistence:
+    ThreadReadingPositionPersistence {
+    enum BackendError: Error {
+        case unavailable
+    }
+
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [ThreadReadingPosition] { throw BackendError.unavailable }
+
+    func replaceAll(
+        _ positions: [ThreadReadingPosition],
+        beforeCommit: () throws -> Void
+    ) throws {
+        throw BackendError.unavailable
+    }
+
+    func upsert(_ position: ThreadReadingPosition, limit: Int) throws {
+        throw BackendError.unavailable
+    }
+
+    func remove(threadID: Int64) throws { throw BackendError.unavailable }
+
+    func removeAll(beforeCommit: () throws -> Void) throws {
+        throw BackendError.unavailable
+    }
+
+    func clearAll(beforeCommit: () throws -> Void) throws {
+        throw BackendError.unavailable
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class SwiftDataThreadReadingPositionPersistence:
+    ThreadReadingPositionMigrationDestination {
+    enum MarkerError: Error, Equatable {
+        case invalidMarker
+    }
+
+    private static let markerKey = "thread-reading-position-backend"
+    private static let markerFormatVersion = 1
+
+    let capability: PersistenceCapability
+
+    private let modelContext: ModelContext
+    private let databaseActorTask: Task<ThreadReadingPositionDatabaseActor, Never>
+
+    init(
+        modelContainer: ModelContainer,
+        persistenceAvailability: PersistenceAvailability? = nil
+    ) {
+        modelContext = modelContainer.mainContext
+        let resolvedAvailability = persistenceAvailability
+            ?? AppModelContainer.persistenceAvailability(for: modelContainer)
+        if resolvedAvailability.canPersist {
+            capability = AppModelContainer.allowsLegacyCleanup(for: modelContainer)
+                ? .durable
+                : .fallback
+        } else {
+            capability = .fallback
+        }
+        databaseActorTask = Task.detached(priority: .utility) {
+            ThreadReadingPositionDatabaseActor(modelContainer: modelContainer)
+        }
+    }
+
+    func load() throws -> [ThreadReadingPosition] {
+        try PersistedRecordStore.fetchOrdered(
+            ThreadReadingPositionRecord.self,
+            in: modelContext
+        ).map(\.entry)
+    }
+
+    func replaceAll(
+        _ positions: [ThreadReadingPosition],
+        beforeCommit: () throws -> Void
+    ) throws {
+        try PersistedRecordStore.replaceAll(
+            ThreadReadingPositionRecord.self,
+            with: positions.enumerated().map {
+                ThreadReadingPositionRecord(entry: $0.element, sortIndex: $0.offset)
+            },
+            in: modelContext,
+            beforeSave: beforeCommit
+        )
+    }
+
+    func upsert(_ position: ThreadReadingPosition, limit: Int) throws {
+        try PersistedRecordStore.upsertReadingPosition(
+            position,
+            limit: limit,
+            in: modelContext
+        )
+    }
+
+    func remove(threadID: Int64) throws {
+        try PersistedRecordStore.deleteReadingPosition(
+            threadID: threadID,
+            in: modelContext
+        )
+    }
+
+    func removeAll(beforeCommit: () throws -> Void) throws {
+        try replaceAll([], beforeCommit: beforeCommit)
+    }
+
+    func backendGenerationID() throws -> String? {
+        let markers = try modelContext.fetch(
+            FetchDescriptor<ThreadReadingPositionBackendMarkerRecord>()
+        )
+        guard markers.isEmpty == false else { return nil }
+        guard markers.count == 1,
+              let marker = markers.first,
+              marker.key == Self.markerKey,
+              marker.formatVersion == Self.markerFormatVersion,
+              UUID(uuidString: marker.generationID) != nil else {
+            throw MarkerError.invalidMarker
+        }
+        return marker.generationID
+    }
+
+    func establishNativeBackendMarker(generationID: String) throws {
+        guard UUID(uuidString: generationID) != nil else {
+            throw MarkerError.invalidMarker
+        }
+        if let existing = try backendGenerationID() {
+            guard existing == generationID else { throw MarkerError.invalidMarker }
+            return
+        }
+        do {
+            modelContext.insert(ThreadReadingPositionBackendMarkerRecord(
+                key: Self.markerKey,
+                formatVersion: Self.markerFormatVersion,
+                generationID: generationID
+            ))
+            try modelContext.save()
+            guard try backendGenerationID() == generationID else {
+                throw MarkerError.invalidMarker
+            }
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    func replaceAllForMigration(
+        _ positions: [ThreadReadingPosition],
+        generationID: String
+    ) throws {
+        guard UUID(uuidString: generationID) != nil else {
+            throw MarkerError.invalidMarker
+        }
+        do {
+            try Task.checkCancellation()
+            for record in try modelContext.fetch(
+                FetchDescriptor<ThreadReadingPositionRecord>()
+            ) {
+                modelContext.delete(record)
+            }
+            for marker in try modelContext.fetch(
+                FetchDescriptor<ThreadReadingPositionBackendMarkerRecord>()
+            ) {
+                modelContext.delete(marker)
+            }
+            for (index, position) in positions.enumerated() {
+                modelContext.insert(ThreadReadingPositionRecord(
+                    entry: position,
+                    sortIndex: index
+                ))
+            }
+            modelContext.insert(ThreadReadingPositionBackendMarkerRecord(
+                key: Self.markerKey,
+                formatVersion: Self.markerFormatVersion,
+                generationID: generationID
+            ))
+            try Task.checkCancellation()
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    func clearAll(beforeCommit: () throws -> Void) throws {
+        try PersistedRecordStore.clearThreadLibrary(
+            in: modelContext,
+            beforeSave: beforeCommit
+        )
+    }
+
+    func upsertInBackground(
+        _ position: ThreadReadingPosition,
+        limit: Int
+    ) async throws -> [ThreadReadingPosition] {
+        let databaseActor = await databaseActorTask.value
+        return try await databaseActor.apply(.upsert(position, limit: limit))
+    }
+
+    func removeInBackground(threadID: Int64) async throws -> [ThreadReadingPosition] {
+        let databaseActor = await databaseActorTask.value
+        return try await databaseActor.apply(.delete(threadID: threadID))
+    }
+
+    func removeAllInBackground() async throws -> [ThreadReadingPosition] {
+        let databaseActor = await databaseActorTask.value
+        return try await databaseActor.apply(.deleteAll)
+    }
+
+    func purgeRetiredFavorites() {
+        guard capability.acceptsUserMutations else { return }
+        do {
+            try PersistedRecordStore.replaceAll(
+                ThreadFavoriteRecord.self,
+                with: [],
+                in: modelContext
+            )
+        } catch {
+            PersistenceDiagnostics.report(error, operation: "purge retired thread favorites")
+        }
+    }
+}
+
+enum ThreadReadingPositionPersistenceFactoryError: Error, Equatable {
+    case backendUnavailable
+    case unsupportedStateVersion(Int)
+    case invalidState
+    case swiftDataUnavailable
+    case destinationIsNotDurable
+    case migrationVerificationFailed
+    case sourceChangedDuringMigration
+    case markerMismatch
+}
+
+enum ThreadReadingPositionFileMigration {
+    static func fingerprint(
+        _ positions: [ThreadReadingPosition]
+    ) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(positions)
+        return SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+@MainActor
+struct ThreadReadingPositionPersistenceFactory {
+    typealias SwiftDataBuilder = @MainActor () throws ->
+        any ThreadReadingPositionMigrationDestination
+
+    private let fileURL: URL
+    private let fileManager: FileManager
+    private let supportsSwiftData: Bool
+    private let now: () -> Date
+    private let makeSwiftData: SwiftDataBuilder
+
+    init(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        supportsSwiftData: Bool,
+        now: @escaping () -> Date = Date.init,
+        makeSwiftData: @escaping SwiftDataBuilder
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        self.supportsSwiftData = supportsSwiftData
+        self.now = now
+        self.makeSwiftData = makeSwiftData
+    }
+
+    func make() -> any ThreadReadingPositionPersistence {
+        do {
+            let file = try FileThreadReadingPositionPersistence(
+                fileURL: fileURL,
+                fileManager: fileManager
+            )
+            if let state = try file.loadBackendState() {
+                return try resolve(state: state, file: file)
+            }
+            return try makeInitial(file: file)
+        } catch {
+            PersistenceDiagnostics.report(
+                error,
+                operation: "resolve reading position persistence backend"
+            )
+            return UnavailableThreadReadingPositionPersistence()
+        }
+    }
+
+    private func makeInitial(
+        file: FileThreadReadingPositionPersistence
+    ) throws -> any ThreadReadingPositionPersistence {
+        guard supportsSwiftData else {
+            try file.initializeFileBackendIfNeeded()
+            return file
+        }
+
+        let destination = try makeSwiftData()
+        guard destination.capability.isDurable else {
+            throw ThreadReadingPositionPersistenceFactoryError.destinationIsNotDurable
+        }
+        guard try destination.backendGenerationID() == nil else {
+            throw ThreadReadingPositionPersistenceFactoryError.markerMismatch
+        }
+        let generationID = UUID().uuidString.lowercased()
+        let pendingState = try file.prepareNativeSwiftDataActivation(
+            generationID: generationID,
+            now: now()
+        )
+        try destination.establishNativeBackendMarker(generationID: generationID)
+        guard try destination.backendGenerationID() == generationID else {
+            throw ThreadReadingPositionPersistenceFactoryError.markerMismatch
+        }
+        try file.activateNativeSwiftData(pendingState: pendingState, now: now())
+        return destination
+    }
+
+    private func resolve(
+        state: ThreadReadingPositionBackendState,
+        file: FileThreadReadingPositionPersistence
+    ) throws -> any ThreadReadingPositionPersistence {
+        switch state.migrationState {
+        case .fileActive:
+            guard supportsSwiftData else { return file }
+            do {
+                return try migrateToSwiftData(sourceState: state, file: file)
+            } catch {
+                PersistenceDiagnostics.report(
+                    error,
+                    operation: "migrate file reading positions to SwiftData"
+                )
+                return file
+            }
+
+        case .nativeActivationPending:
+            guard supportsSwiftData else {
+                throw ThreadReadingPositionPersistenceFactoryError.swiftDataUnavailable
+            }
+            let destination = try makeSwiftData()
+            guard destination.capability.isDurable else {
+                throw ThreadReadingPositionPersistenceFactoryError.destinationIsNotDurable
+            }
+            guard let expectedGeneration = state.activation?.destinationGenerationID else {
+                throw ThreadReadingPositionPersistenceFactoryError.invalidState
+            }
+            if let existingGeneration = try destination.backendGenerationID() {
+                guard existingGeneration == expectedGeneration else {
+                    throw ThreadReadingPositionPersistenceFactoryError.markerMismatch
+                }
+            } else {
+                try destination.establishNativeBackendMarker(
+                    generationID: expectedGeneration
+                )
+            }
+            guard try destination.backendGenerationID() == expectedGeneration else {
+                throw ThreadReadingPositionPersistenceFactoryError.markerMismatch
+            }
+            try file.activateNativeSwiftData(pendingState: state, now: now())
+            return destination
+
+        case .nativeSwiftData, .fileMigrationCompleted:
+            guard supportsSwiftData else {
+                throw ThreadReadingPositionPersistenceFactoryError.swiftDataUnavailable
+            }
+            let destination = try makeSwiftData()
+            guard destination.capability.isDurable else {
+                throw ThreadReadingPositionPersistenceFactoryError.destinationIsNotDurable
+            }
+            guard let expectedGeneration = state.activation?.destinationGenerationID,
+                  try destination.backendGenerationID() == expectedGeneration else {
+                throw ThreadReadingPositionPersistenceFactoryError.markerMismatch
+            }
+            return destination
+        }
+    }
+
+    private func migrateToSwiftData(
+        sourceState: ThreadReadingPositionBackendState,
+        file: FileThreadReadingPositionPersistence
+    ) throws -> any ThreadReadingPositionPersistence {
+        guard sourceState.activeBackend == .secureFiles,
+              sourceState.migrationState == .fileActive else {
+            throw ThreadReadingPositionPersistenceFactoryError.invalidState
+        }
+        let destination = try makeSwiftData()
+        guard destination.capability.isDurable else {
+            throw ThreadReadingPositionPersistenceFactoryError.destinationIsNotDurable
+        }
+        let sourcePositions = LocalThreadLibraryPolicy.sanitizedReadingPositions(
+            sourceState.retainedFilePositions,
+            limit: LocalThreadLibraryPolicy.maximumReadingPositions
+        )
+        let sourceFingerprint = try ThreadReadingPositionFileMigration.fingerprint(
+            sourcePositions
+        )
+        let generationID = UUID().uuidString.lowercased()
+        try destination.replaceAllForMigration(sourcePositions, generationID: generationID)
+        guard try destination.load() == sourcePositions,
+              try destination.backendGenerationID() == generationID else {
+            throw ThreadReadingPositionPersistenceFactoryError.migrationVerificationFailed
+        }
+        guard try file.loadBackendState() == sourceState else {
+            throw ThreadReadingPositionPersistenceFactoryError.sourceChangedDuringMigration
+        }
+        try file.activateMigratedSwiftData(
+            sourceState: sourceState,
+            retainedFilePositions: sourcePositions,
+            sourceFingerprint: sourceFingerprint,
+            generationID: generationID,
+            now: now()
+        )
+        return destination
+    }
+}
+
+@MainActor
+enum AppThreadReadingPositionPersistence {
+    static let shared: any ThreadReadingPositionPersistence = makeDefault()
+
+    private static func makeDefault(
+        fileManager: FileManager = .default
+    ) -> any ThreadReadingPositionPersistence {
+        do {
+            let location = try SecurePersistenceLocation.applicationSupport(
+                fileManager: fileManager
+            )
+            let fileURL = location.directoryURL.appendingPathComponent(
+                "thread-reading-position-backend.json",
+                isDirectory: false
+            )
+            if #available(iOS 17.0, *) {
+                let persistence = ThreadReadingPositionPersistenceFactory(
+                    fileURL: fileURL,
+                    fileManager: fileManager,
+                    supportsSwiftData: true
+                ) {
+                    SwiftDataThreadReadingPositionPersistence(
+                        modelContainer: AppModelContainer.shared
+                    )
+                }.make()
+                if let swiftData = persistence as? SwiftDataThreadReadingPositionPersistence {
+                    swiftData.purgeRetiredFavorites()
+                }
+                return persistence
+            }
+            return ThreadReadingPositionPersistenceFactory(
+                fileURL: fileURL,
+                fileManager: fileManager,
+                supportsSwiftData: false
+            ) {
+                throw ThreadReadingPositionPersistenceFactoryError.swiftDataUnavailable
+            }.make()
+        } catch {
+            PersistenceDiagnostics.report(
+                error,
+                operation: "open reading position persistence directory"
+            )
+            return UnavailableThreadReadingPositionPersistence()
+        }
+    }
+}
+
+@MainActor
 final class LocalThreadLibraryStore: ObservableObject {
     static let shared = LocalThreadLibraryStore()
 
@@ -284,8 +1072,7 @@ final class LocalThreadLibraryStore: ObservableObject {
     private let readingPositionsKey: String
     private let readingPositionLimit: Int
     private let now: () -> Date
-    private let modelContext: ModelContext
-    private let readingPositionDatabaseActorTask: Task<ThreadReadingPositionDatabaseActor, Never>
+    private let persistence: any ThreadReadingPositionPersistence
     private let persistentBackendIsAvailable: Bool
     private let faultInjector: PersistenceFaultInjector
     private var readingPositionMutationTail: Task<Bool, Never>?
@@ -300,8 +1087,7 @@ final class LocalThreadLibraryStore: ObservableObject {
         favoritesKey: String = "dev.infinityf4p.tiebapure.threadFavorites",
         readingPositionsKey: String = "dev.infinityf4p.tiebapure.threadReadingPositions",
         readingPositionLimit: Int = LocalThreadLibraryPolicy.maximumReadingPositions,
-        modelContainer: ModelContainer = AppModelContainer.shared,
-        persistenceAvailability: PersistenceAvailability? = nil,
+        persistence: any ThreadReadingPositionPersistence,
         faultInjector: PersistenceFaultInjector = .none,
         now: @escaping () -> Date = Date.init
     ) {
@@ -313,27 +1099,18 @@ final class LocalThreadLibraryStore: ObservableObject {
             LocalThreadLibraryPolicy.maximumReadingPositions
         )
         self.now = now
+        self.persistence = persistence
         self.faultInjector = faultInjector
-        let context = modelContainer.mainContext
-        modelContext = context
-        readingPositionDatabaseActorTask = Task.detached(priority: .utility) {
-            ThreadReadingPositionDatabaseActor(modelContainer: modelContainer)
-        }
-        let initialAvailability = persistenceAvailability
-            ?? AppModelContainer.persistenceAvailability(for: modelContainer)
-        persistentBackendIsAvailable = initialAvailability.canPersist
-        self.persistenceAvailability = initialAvailability
-        let destinationIsDurable = initialAvailability.canPersist
-            && AppModelContainer.allowsLegacyCleanup(for: modelContainer)
+        persistentBackendIsAvailable = persistence.capability.acceptsUserMutations
+        persistenceAvailability = persistence.capability.availability
         var legacyPositionsFallback: [ThreadReadingPosition]?
         var legacyPositionsMigrationFailed = false
         do {
             try Self.migrateLegacyReadingPositions(
                 defaults: defaults,
                 key: readingPositionsKey,
-                context: context,
+                persistence: persistence,
                 limit: self.readingPositionLimit,
-                destinationIsDurable: destinationIsDurable,
                 legacyFallback: &legacyPositionsFallback,
                 faultInjector: faultInjector
             )
@@ -345,7 +1122,7 @@ final class LocalThreadLibraryStore: ObservableObject {
         var loadedReadingPositions: [ThreadReadingPosition]
         do {
             let result = try Self.loadAndRepairReadingPositions(
-                context: context,
+                persistence: persistence,
                 limit: self.readingPositionLimit,
                 canRepair: persistentBackendIsAvailable,
                 faultInjector: faultInjector
@@ -365,14 +1142,9 @@ final class LocalThreadLibraryStore: ObservableObject {
             loadedReadingPositions = legacyPositionsFallback
         }
         readingPositions = loadedReadingPositions
-        // Collections live on the Baidu account now; the rows this app used to
-        // keep are dropped once so they stop taking up space.
-        Self.purgeRetiredFavorites(
-            defaults: defaults,
-            key: favoritesKey,
-            context: context,
-            canWrite: persistentBackendIsAvailable
-        )
+        // Collections live on the Baidu account now. Keep only the historical
+        // SwiftData schema compatibility; no local-favorite API is restored.
+        defaults.removeObject(forKey: favoritesKey)
     }
 
     @discardableResult
@@ -381,7 +1153,7 @@ final class LocalThreadLibraryStore: ObservableObject {
         var succeeded = true
         do {
             let result = try Self.loadAndRepairReadingPositions(
-                context: modelContext,
+                persistence: persistence,
                 limit: readingPositionLimit,
                 canRepair: persistentBackendIsAvailable,
                 faultInjector: faultInjector
@@ -502,11 +1274,7 @@ final class LocalThreadLibraryStore: ObservableObject {
             limit: readingPositionLimit
         )
         do {
-            try PersistedRecordStore.upsertReadingPosition(
-                position,
-                limit: readingPositionLimit,
-                in: modelContext
-            )
+            try persistence.upsert(position, limit: readingPositionLimit)
             readingPositions = updated
             markPersistenceSucceeded()
             return true
@@ -526,10 +1294,7 @@ final class LocalThreadLibraryStore: ObservableObject {
             return false
         }
         do {
-            try PersistedRecordStore.deleteReadingPosition(
-                threadID: threadID,
-                in: modelContext
-            )
+            try persistence.remove(threadID: threadID)
             readingPositions.removeAll { $0.threadID == threadID }
             markPersistenceSucceeded()
             return true
@@ -548,11 +1313,7 @@ final class LocalThreadLibraryStore: ObservableObject {
             return false
         }
         do {
-            try PersistedRecordStore.replaceAll(
-                ThreadReadingPositionRecord.self,
-                with: [],
-                in: modelContext
-            )
+            try persistence.removeAll()
             defaults.removeObject(forKey: readingPositionsKey)
             readingPositions = []
             markPersistenceSucceeded()
@@ -572,7 +1333,7 @@ final class LocalThreadLibraryStore: ObservableObject {
             return false
         }
         do {
-            try PersistedRecordStore.clearThreadLibrary(in: modelContext) {
+            try persistence.clearAll {
                 try faultInjector.check(.clearAll)
             }
             defaults.removeObject(forKey: readingPositionsKey)
@@ -597,7 +1358,6 @@ final class LocalThreadLibraryStore: ObservableObject {
         }
 
         let previousMutation = readingPositionMutationTail
-        let databaseActorTask = readingPositionDatabaseActorTask
         let mutationID = UUID()
         pendingReadingPositionMutationCount += 1
         readingPositionMutationTailID = mutationID
@@ -619,8 +1379,20 @@ final class LocalThreadLibraryStore: ObservableObject {
             }
 
             do {
-                let databaseActor = await databaseActorTask.value
-                let persisted = try await databaseActor.apply(mutation)
+                let persisted: [ThreadReadingPosition]
+                switch mutation {
+                case let .upsert(position, limit):
+                    persisted = try await self.persistence.upsertInBackground(
+                        position,
+                        limit: limit
+                    )
+                case let .delete(threadID):
+                    persisted = try await self.persistence.removeInBackground(
+                        threadID: threadID
+                    )
+                case .deleteAll:
+                    persisted = try await self.persistence.removeAllInBackground()
+                }
                 self.readingPositions = persisted
                 if removesLegacyValueOnSuccess {
                     self.defaults.removeObject(forKey: self.readingPositionsKey)
@@ -647,28 +1419,19 @@ final class LocalThreadLibraryStore: ObservableObject {
     }
 
     private static func loadAndRepairReadingPositions(
-        context: ModelContext,
+        persistence: any ThreadReadingPositionPersistence,
         limit: Int,
         canRepair: Bool,
         faultInjector: PersistenceFaultInjector = .none
     ) throws -> PersistenceLoadResult<[ThreadReadingPosition]> {
-        let raw = try PersistedRecordStore.fetchOrdered(
-            ThreadReadingPositionRecord.self,
-            in: context
-        ).map(\.entry)
+        let raw = try persistence.load()
         let sanitized = LocalThreadLibraryPolicy.sanitizedReadingPositions(
             raw,
             limit: limit
         )
         if canRepair, raw != sanitized {
             do {
-                try PersistedRecordStore.replaceAll(
-                    ThreadReadingPositionRecord.self,
-                    with: sanitized.enumerated().map {
-                        ThreadReadingPositionRecord(entry: $0.element, sortIndex: $0.offset)
-                    },
-                    in: context
-                ) {
+                try persistence.replaceAll(sanitized) {
                     try faultInjector.check(.repair)
                 }
             } catch {
@@ -678,44 +1441,31 @@ final class LocalThreadLibraryStore: ObservableObject {
         return PersistenceLoadResult(value: sanitized, repairError: nil)
     }
 
-    /// Thread collections moved to the Baidu account, so the rows and the
-    /// pre-SwiftData blob this app used to keep are deleted on the next launch.
-    /// A failure here costs nothing but the space, so it never marks the store
-    /// unavailable.
-    private static func purgeRetiredFavorites(
-        defaults: UserDefaults,
-        key: String,
-        context: ModelContext,
-        canWrite: Bool
-    ) {
-        defaults.removeObject(forKey: key)
-        guard canWrite else { return }
-        do {
-            try PersistedRecordStore.replaceAll(
-                ThreadFavoriteRecord.self,
-                with: [],
-                in: context
-            )
-        } catch {
-            PersistenceDiagnostics.report(error, operation: "purge retired thread favorites")
-        }
-    }
-
     // One-time import of the pre-SwiftData UserDefaults JSON blob.
     private static func migrateLegacyReadingPositions(
         defaults: UserDefaults,
         key: String,
-        context: ModelContext,
+        persistence: any ThreadReadingPositionPersistence,
         limit: Int,
-        destinationIsDurable: Bool,
         legacyFallback: inout [ThreadReadingPosition]?,
         faultInjector: PersistenceFaultInjector
     ) throws {
         guard let data = defaults.data(forKey: key) else { return }
-        let existing = try PersistedRecordStore.fetchOrdered(
-            ThreadReadingPositionRecord.self,
-            in: context
-        ).map(\.entry)
+        let existing: [ThreadReadingPosition]
+        do {
+            existing = try persistence.load()
+        } catch {
+            if let decoded = PersistedArrayDecoder.decode(
+                ThreadReadingPosition.self,
+                from: data
+            ) {
+                legacyFallback = LocalThreadLibraryPolicy.sanitizedReadingPositions(
+                    decoded,
+                    limit: limit
+                )
+            }
+            throw error
+        }
         let source: [ThreadReadingPosition]
         if existing.isEmpty {
             guard let decoded = PersistedArrayDecoder.decode(
@@ -733,17 +1483,61 @@ final class LocalThreadLibraryStore: ObservableObject {
         try LegacyStorageMigration.persistThenRemoveLegacyValue(
             defaults: defaults,
             key: key,
-            destinationIsDurable: destinationIsDurable
+            destinationIsDurable: persistence.capability.isDurable
         ) {
-            try PersistedRecordStore.replaceAll(
-                ThreadReadingPositionRecord.self,
-                with: sanitized.enumerated().map {
-                    ThreadReadingPositionRecord(entry: $0.element, sortIndex: $0.offset)
-                },
-                in: context
-            ) {
+            try persistence.replaceAll(sanitized) {
                 try faultInjector.check(.legacyMigration)
             }
         }
+    }
+}
+
+extension LocalThreadLibraryStore {
+    convenience init(
+        defaults: UserDefaults = .standard,
+        favoritesKey: String = "dev.infinityf4p.tiebapure.threadFavorites",
+        readingPositionsKey: String = "dev.infinityf4p.tiebapure.threadReadingPositions",
+        readingPositionLimit: Int = LocalThreadLibraryPolicy.maximumReadingPositions,
+        faultInjector: PersistenceFaultInjector = .none,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.init(
+            defaults: defaults,
+            favoritesKey: favoritesKey,
+            readingPositionsKey: readingPositionsKey,
+            readingPositionLimit: readingPositionLimit,
+            persistence: AppThreadReadingPositionPersistence.shared,
+            faultInjector: faultInjector,
+            now: now
+        )
+    }
+}
+
+@available(iOS 17.0, *)
+extension LocalThreadLibraryStore {
+    convenience init(
+        defaults: UserDefaults = .standard,
+        favoritesKey: String = "dev.infinityf4p.tiebapure.threadFavorites",
+        readingPositionsKey: String = "dev.infinityf4p.tiebapure.threadReadingPositions",
+        readingPositionLimit: Int = LocalThreadLibraryPolicy.maximumReadingPositions,
+        modelContainer: ModelContainer,
+        persistenceAvailability: PersistenceAvailability? = nil,
+        faultInjector: PersistenceFaultInjector = .none,
+        now: @escaping () -> Date = Date.init
+    ) {
+        let persistence = SwiftDataThreadReadingPositionPersistence(
+            modelContainer: modelContainer,
+            persistenceAvailability: persistenceAvailability
+        )
+        self.init(
+            defaults: defaults,
+            favoritesKey: favoritesKey,
+            readingPositionsKey: readingPositionsKey,
+            readingPositionLimit: readingPositionLimit,
+            persistence: persistence,
+            faultInjector: faultInjector,
+            now: now
+        )
+        persistence.purgeRetiredFavorites()
     }
 }

--- a/TiebaPure/Domain/Models/OrderedCollectionPersistenceFactory.swift
+++ b/TiebaPure/Domain/Models/OrderedCollectionPersistenceFactory.swift
@@ -1,0 +1,617 @@
+import Foundation
+
+enum OrderedCollectionPersistenceBackend: String, Codable, Sendable {
+    case secureFiles
+    case swiftData
+}
+
+enum OrderedCollectionMigrationState: String, Codable, Sendable {
+    case notRequired
+    case swiftDataActivationPending
+    case fileToSwiftDataEligible
+    case fileToSwiftDataCompleted
+}
+
+struct OrderedCollectionMigrationReceipt: Codable, Equatable, Sendable {
+    let migrationVersion: Int
+    let sourceBackend: OrderedCollectionPersistenceBackend
+    let destinationBackend: OrderedCollectionPersistenceBackend
+    let sourceFingerprint: String
+    let completedAt: Date
+}
+
+struct OrderedCollectionPersistenceManifest: Codable, Equatable, Sendable {
+    static let currentFormatVersion = 1
+    static let currentMigrationVersion = 1
+
+    let formatVersion: Int
+    let activeBackend: OrderedCollectionPersistenceBackend
+    let migrationState: OrderedCollectionMigrationState
+    let migrationReceipt: OrderedCollectionMigrationReceipt?
+    let destinationGeneration: String?
+
+    static func initialFileBackend() -> OrderedCollectionPersistenceManifest {
+        OrderedCollectionPersistenceManifest(
+            formatVersion: currentFormatVersion,
+            activeBackend: .secureFiles,
+            migrationState: .fileToSwiftDataEligible,
+            migrationReceipt: nil,
+            destinationGeneration: nil
+        )
+    }
+
+    static func pendingSwiftDataActivation(
+        destinationGeneration: String
+    ) -> OrderedCollectionPersistenceManifest {
+        OrderedCollectionPersistenceManifest(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationState: .swiftDataActivationPending,
+            migrationReceipt: nil,
+            destinationGeneration: destinationGeneration
+        )
+    }
+
+    static func initialSwiftDataBackend(
+        destinationGeneration: String
+    ) -> OrderedCollectionPersistenceManifest {
+        OrderedCollectionPersistenceManifest(
+            formatVersion: currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationState: .notRequired,
+            migrationReceipt: nil,
+            destinationGeneration: destinationGeneration
+        )
+    }
+}
+
+@MainActor
+protocol OrderedCollectionBackendMarkerPersistence: AnyObject {
+    var capability: PersistenceCapability { get }
+
+    func loadGeneration() throws -> String?
+    func replaceGeneration(_ generation: String) throws
+}
+
+struct OrderedCollectionPersistenceSnapshot: Codable, Equatable, Sendable {
+    let browsingHistory: [BrowsingHistoryEntry]
+    let recentForums: [RecentForum]
+    let searchHistory: [String]
+
+    var isEmpty: Bool {
+        browsingHistory.isEmpty && recentForums.isEmpty && searchHistory.isEmpty
+    }
+
+    func fingerprint() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return SecurePersistenceDigest.sha256(try encoder.encode(self))
+    }
+}
+
+@MainActor
+struct OrderedCollectionPersistenceBundle {
+    let browsingHistory: any BrowsingHistoryPersistence
+    let recentForums: any RecentForumPersistence
+    let searchHistory: any SearchHistoryPersistence
+    let backendMarker: (any OrderedCollectionBackendMarkerPersistence)?
+
+    init(
+        browsingHistory: any BrowsingHistoryPersistence,
+        recentForums: any RecentForumPersistence,
+        searchHistory: any SearchHistoryPersistence,
+        backendMarker: (any OrderedCollectionBackendMarkerPersistence)? = nil
+    ) {
+        self.browsingHistory = browsingHistory
+        self.recentForums = recentForums
+        self.searchHistory = searchHistory
+        self.backendMarker = backendMarker
+    }
+
+    var isDurable: Bool {
+        browsingHistory.capability.isDurable
+            && recentForums.capability.isDurable
+            && searchHistory.capability.isDurable
+    }
+
+    func snapshot() throws -> OrderedCollectionPersistenceSnapshot {
+        OrderedCollectionPersistenceSnapshot(
+            browsingHistory: try browsingHistory.load(),
+            recentForums: try recentForums.load(),
+            searchHistory: try searchHistory.load()
+        )
+    }
+
+    func replaceAll(with snapshot: OrderedCollectionPersistenceSnapshot) throws {
+        // The receipt remains on the source backend until all three writes and
+        // the subsequent read-back verification succeed. A crash between these
+        // idempotent writes therefore retries from the file snapshot.
+        try browsingHistory.replaceAll(snapshot.browsingHistory)
+        try recentForums.replaceAll(snapshot.recentForums)
+        try searchHistory.replaceAll(snapshot.searchHistory)
+    }
+}
+
+enum OrderedCollectionPersistenceFactoryError: Error, Equatable {
+    case backendUnavailable
+    case unsupportedManifestVersion(Int)
+    case inconsistentManifest
+    case swiftDataUnavailable
+    case destinationIsNotDurable
+    case migrationVerificationFailed
+    case ambiguousBackendRecovery
+    case destinationMarkerUnavailable
+    case destinationMarkerMismatch
+    case sourceChangedDuringMigration
+}
+
+@MainActor
+struct OrderedCollectionPersistenceFactory {
+    typealias SwiftDataBuilder = @MainActor () throws -> OrderedCollectionPersistenceBundle
+
+    private let directoryURL: URL
+    private let fileManager: FileManager
+    private let supportsSwiftData: Bool
+    private let now: () -> Date
+    private let makeSwiftDataBundle: SwiftDataBuilder
+
+    init(
+        directoryURL: URL,
+        fileManager: FileManager = .default,
+        supportsSwiftData: Bool,
+        now: @escaping () -> Date = Date.init,
+        makeSwiftDataBundle: @escaping SwiftDataBuilder
+    ) {
+        self.directoryURL = directoryURL
+        self.fileManager = fileManager
+        self.supportsSwiftData = supportsSwiftData
+        self.now = now
+        self.makeSwiftDataBundle = makeSwiftDataBundle
+    }
+
+    func make() -> OrderedCollectionPersistenceBundle {
+        do {
+            let manifestFile = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+                directoryURL: directoryURL,
+                fileName: "ordered-collections-manifest.json",
+                fileManager: fileManager,
+                maximumByteCount: 64 * 1_024
+            )
+            if let manifest = try manifestFile.load() {
+                try Self.validate(manifest)
+                return try resolve(manifest: manifest, manifestFile: manifestFile)
+            }
+            if hasFileBackendArtifacts {
+                throw OrderedCollectionPersistenceFactoryError.ambiguousBackendRecovery
+            }
+            return try makeInitialBundle(manifestFile: manifestFile)
+        } catch {
+            PersistenceDiagnostics.report(
+                error,
+                operation: "resolve ordered collection persistence backend"
+            )
+            return Self.unavailableBundle()
+        }
+    }
+
+    static func makeApplicationBundle(
+        fileManager: FileManager = .default
+    ) -> OrderedCollectionPersistenceBundle {
+        do {
+            let location = try SecurePersistenceLocation.applicationSupport(fileManager: fileManager)
+            if #available(iOS 17.0, *) {
+                return OrderedCollectionPersistenceFactory(
+                    directoryURL: location.directoryURL,
+                    fileManager: fileManager,
+                    supportsSwiftData: true
+                ) {
+                    OrderedCollectionPersistenceBundle(
+                        browsingHistory: SwiftDataBrowsingHistoryPersistence(
+                            modelContainer: AppModelContainer.shared
+                        ),
+                        recentForums: SwiftDataRecentForumPersistence(
+                            modelContainer: AppModelContainer.shared
+                        ),
+                        searchHistory: SwiftDataSearchHistoryPersistence(
+                            modelContainer: AppModelContainer.shared
+                        ),
+                        backendMarker: SwiftDataOrderedCollectionBackendMarkerPersistence(
+                            modelContainer: AppModelContainer.shared
+                        )
+                    )
+                }.make()
+            }
+            return OrderedCollectionPersistenceFactory(
+                directoryURL: location.directoryURL,
+                fileManager: fileManager,
+                supportsSwiftData: false
+            ) {
+                throw OrderedCollectionPersistenceFactoryError.swiftDataUnavailable
+            }.make()
+        } catch {
+            PersistenceDiagnostics.report(
+                error,
+                operation: "open ordered collection persistence directory"
+            )
+            return unavailableBundle()
+        }
+    }
+
+    private func makeInitialBundle(
+        manifestFile: SecureCodableFile<OrderedCollectionPersistenceManifest>
+    ) throws -> OrderedCollectionPersistenceBundle {
+        if supportsSwiftData {
+            let bundle = try makeSwiftDataBundle()
+            guard bundle.isDurable else {
+                // Do not turn a transient in-memory SwiftData fallback into a
+                // permanent backend choice. Legacy data remains available for
+                // this session and backend selection retries on the next launch.
+                return bundle
+            }
+            let marker = try Self.requireDurableMarker(from: bundle)
+            guard try marker.loadGeneration() == nil else {
+                throw OrderedCollectionPersistenceFactoryError.ambiguousBackendRecovery
+            }
+            let generation = UUID().uuidString
+            try manifestFile.replace(.pendingSwiftDataActivation(
+                destinationGeneration: generation
+            ))
+            return try completePendingSwiftDataActivation(
+                bundle: bundle,
+                marker: marker,
+                generation: generation,
+                manifestFile: manifestFile
+            )
+        }
+
+        let bundle = try makeFileBundle()
+        try manifestFile.replace(.initialFileBackend())
+        return bundle.erased
+    }
+
+    private func resolve(
+        manifest: OrderedCollectionPersistenceManifest,
+        manifestFile: SecureCodableFile<OrderedCollectionPersistenceManifest>
+    ) throws -> OrderedCollectionPersistenceBundle {
+        if manifest.migrationState == .swiftDataActivationPending {
+            guard supportsSwiftData else {
+                throw OrderedCollectionPersistenceFactoryError.swiftDataUnavailable
+            }
+            let bundle = try makeSwiftDataBundle()
+            guard bundle.isDurable else {
+                throw OrderedCollectionPersistenceFactoryError.destinationIsNotDurable
+            }
+            let marker = try Self.requireDurableMarker(from: bundle)
+            guard let generation = manifest.destinationGeneration else {
+                throw OrderedCollectionPersistenceFactoryError.inconsistentManifest
+            }
+            return try completePendingSwiftDataActivation(
+                bundle: bundle,
+                marker: marker,
+                generation: generation,
+                manifestFile: manifestFile
+            )
+        }
+
+        switch manifest.activeBackend {
+        case .swiftData:
+            guard supportsSwiftData else {
+                throw OrderedCollectionPersistenceFactoryError.swiftDataUnavailable
+            }
+            let bundle = try makeSwiftDataBundle()
+            guard bundle.isDurable else {
+                throw OrderedCollectionPersistenceFactoryError.destinationIsNotDurable
+            }
+            let marker = try Self.requireDurableMarker(from: bundle)
+            guard let expectedGeneration = manifest.destinationGeneration,
+                  try marker.loadGeneration() == expectedGeneration else {
+                throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+            }
+            return bundle
+
+        case .secureFiles:
+            let fileBundle = try makeFileBundle()
+            guard supportsSwiftData,
+                  manifest.migrationState == .fileToSwiftDataEligible else {
+                return fileBundle.erased
+            }
+            do {
+                return try migrateToSwiftData(
+                    source: fileBundle.erased,
+                    manifestFile: manifestFile
+                )
+            } catch {
+                PersistenceDiagnostics.report(
+                    error,
+                    operation: "migrate ordered collections from files to SwiftData"
+                )
+                return fileBundle.erased
+            }
+        }
+    }
+
+    private func migrateToSwiftData(
+        source: OrderedCollectionPersistenceBundle,
+        manifestFile: SecureCodableFile<OrderedCollectionPersistenceManifest>
+    ) throws -> OrderedCollectionPersistenceBundle {
+        let snapshot = try source.snapshot()
+        let destination = try makeSwiftDataBundle()
+        guard destination.isDurable else {
+            throw OrderedCollectionPersistenceFactoryError.destinationIsNotDurable
+        }
+        let marker = try Self.requireDurableMarker(from: destination)
+
+        try destination.replaceAll(with: snapshot)
+        guard try destination.snapshot() == snapshot else {
+            throw OrderedCollectionPersistenceFactoryError.migrationVerificationFailed
+        }
+        let generation = UUID().uuidString
+        try marker.replaceGeneration(generation)
+        guard try marker.loadGeneration() == generation else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+        }
+        guard try source.snapshot() == snapshot else {
+            throw OrderedCollectionPersistenceFactoryError.sourceChangedDuringMigration
+        }
+
+        try commitMigrationReceipt(
+            sourceSnapshot: snapshot,
+            destinationGeneration: generation,
+            manifestFile: manifestFile
+        )
+        return destination
+    }
+
+    private func completePendingSwiftDataActivation(
+        bundle: OrderedCollectionPersistenceBundle,
+        marker: any OrderedCollectionBackendMarkerPersistence,
+        generation: String,
+        manifestFile: SecureCodableFile<OrderedCollectionPersistenceManifest>
+    ) throws -> OrderedCollectionPersistenceBundle {
+        switch try marker.loadGeneration() {
+        case nil:
+            try marker.replaceGeneration(generation)
+        case let existing? where existing == generation:
+            break
+        case .some:
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+        }
+        guard try marker.loadGeneration() == generation else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+        }
+        try manifestFile.replace(.initialSwiftDataBackend(
+            destinationGeneration: generation
+        ))
+        return bundle
+    }
+
+    private func commitMigrationReceipt(
+        sourceSnapshot: OrderedCollectionPersistenceSnapshot,
+        destinationGeneration: String,
+        manifestFile: SecureCodableFile<OrderedCollectionPersistenceManifest>
+    ) throws {
+        let receipt = OrderedCollectionMigrationReceipt(
+            migrationVersion: OrderedCollectionPersistenceManifest.currentMigrationVersion,
+            sourceBackend: .secureFiles,
+            destinationBackend: .swiftData,
+            sourceFingerprint: try sourceSnapshot.fingerprint(),
+            completedAt: now()
+        )
+        try manifestFile.replace(OrderedCollectionPersistenceManifest(
+            formatVersion: OrderedCollectionPersistenceManifest.currentFormatVersion,
+            activeBackend: .swiftData,
+            migrationState: .fileToSwiftDataCompleted,
+            migrationReceipt: receipt,
+            destinationGeneration: destinationGeneration
+        ))
+    }
+
+    private static func requireDurableMarker(
+        from bundle: OrderedCollectionPersistenceBundle
+    ) throws -> any OrderedCollectionBackendMarkerPersistence {
+        guard let marker = bundle.backendMarker,
+              marker.capability.isDurable else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerUnavailable
+        }
+        return marker
+    }
+
+    private func makeFileBundle() throws -> FileOrderedCollectionPersistenceBundle {
+        try FileOrderedCollectionPersistenceBundle(
+            directoryURL: directoryURL,
+            fileManager: fileManager
+        )
+    }
+
+    private var hasFileBackendArtifacts: Bool {
+        [
+            "browsing-history.json",
+            "recent-forums.json",
+            "search-history.json"
+        ].contains { fileName in
+            let primary = directoryURL.appendingPathComponent(fileName, isDirectory: false)
+            let backup = directoryURL.appendingPathComponent(
+                "\(fileName).backup",
+                isDirectory: false
+            )
+            return fileManager.fileExists(atPath: primary.path)
+                || fileManager.fileExists(atPath: backup.path)
+        }
+    }
+
+    private static func validate(
+        _ manifest: OrderedCollectionPersistenceManifest
+    ) throws {
+        guard manifest.formatVersion == OrderedCollectionPersistenceManifest.currentFormatVersion else {
+            throw OrderedCollectionPersistenceFactoryError.unsupportedManifestVersion(
+                manifest.formatVersion
+            )
+        }
+        let generationIsValid = manifest.destinationGeneration.flatMap(UUID.init(uuidString:)) != nil
+        switch (
+            manifest.activeBackend,
+            manifest.migrationState,
+            manifest.migrationReceipt,
+            generationIsValid
+        ) {
+        case (.secureFiles, .fileToSwiftDataEligible, nil, false):
+            return
+        case (.swiftData, .swiftDataActivationPending, nil, true),
+             (.swiftData, .notRequired, nil, true):
+            return
+        case let (.swiftData, .fileToSwiftDataCompleted, receipt?, true):
+            guard receipt.migrationVersion
+                    == OrderedCollectionPersistenceManifest.currentMigrationVersion,
+                  receipt.sourceBackend == .secureFiles,
+                  receipt.destinationBackend == .swiftData,
+                  receipt.sourceFingerprint.isEmpty == false else {
+                throw OrderedCollectionPersistenceFactoryError.inconsistentManifest
+            }
+        default:
+            throw OrderedCollectionPersistenceFactoryError.inconsistentManifest
+        }
+    }
+
+    private static func unavailableBundle() -> OrderedCollectionPersistenceBundle {
+        OrderedCollectionPersistenceBundle(
+            browsingHistory: UnavailableBrowsingHistoryPersistence(),
+            recentForums: UnavailableRecentForumPersistence(),
+            searchHistory: UnavailableSearchHistoryPersistence()
+        )
+    }
+}
+
+@MainActor
+enum AppOrderedCollectionPersistence {
+    private static let bundle = OrderedCollectionPersistenceFactory.makeApplicationBundle()
+
+    static var browsingHistory: any BrowsingHistoryPersistence {
+        bundle.browsingHistory
+    }
+
+    static var recentForums: any RecentForumPersistence {
+        bundle.recentForums
+    }
+
+    static var searchHistory: any SearchHistoryPersistence {
+        bundle.searchHistory
+    }
+}
+
+extension BrowsingHistoryStore {
+    convenience init(
+        defaults: UserDefaults = .standard,
+        key: String = "dev.infinityf4p.tiebapure.browsingHistory",
+        limit: Int = BrowsingHistoryPolicy.maximumStoredEntries,
+        faultInjector: PersistenceFaultInjector = .none,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.init(
+            defaults: defaults,
+            key: key,
+            limit: limit,
+            persistence: AppOrderedCollectionPersistence.browsingHistory,
+            faultInjector: faultInjector,
+            now: now
+        )
+    }
+}
+
+extension RecentForumStore {
+    convenience init(
+        defaults: UserDefaults = .standard,
+        key: String = "dev.infinityf4p.tiebapure.recentForums",
+        limit: Int = RecentForumPolicy.maximumStoredEntries,
+        faultInjector: PersistenceFaultInjector = .none,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.init(
+            defaults: defaults,
+            key: key,
+            limit: limit,
+            persistence: AppOrderedCollectionPersistence.recentForums,
+            faultInjector: faultInjector,
+            now: now
+        )
+    }
+}
+
+extension SearchHistoryStore {
+    convenience init(
+        defaults: UserDefaults = .standard,
+        key: String = "dev.infinityf4p.tiebapure.searchHistory",
+        limit: Int = SearchHistoryPolicy.maximumStoredEntries,
+        faultInjector: PersistenceFaultInjector = .none
+    ) {
+        self.init(
+            defaults: defaults,
+            key: key,
+            limit: limit,
+            persistence: AppOrderedCollectionPersistence.searchHistory,
+            faultInjector: faultInjector
+        )
+    }
+}
+
+@MainActor
+private final class UnavailableBrowsingHistoryPersistence: BrowsingHistoryPersistence {
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [BrowsingHistoryEntry] {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+
+    func replaceAll(
+        _ entries: [BrowsingHistoryEntry],
+        beforeCommit: () throws -> Void
+    ) throws {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+
+    func upsert(
+        _ entry: BrowsingHistoryEntry,
+        limit: Int
+    ) async throws -> [BrowsingHistoryEntry] {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+
+    func remove(threadIDs: Set<Int64>) async throws -> [BrowsingHistoryEntry] {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+
+    func removeAll() async throws -> [BrowsingHistoryEntry] {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+}
+
+@MainActor
+private final class UnavailableRecentForumPersistence: RecentForumPersistence {
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [RecentForum] {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+
+    func replaceAll(
+        _ entries: [RecentForum],
+        beforeCommit: () throws -> Void
+    ) throws {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+}
+
+@MainActor
+private final class UnavailableSearchHistoryPersistence: SearchHistoryPersistence {
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [String] {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+
+    func replaceAll(
+        _ entries: [String],
+        beforeCommit: () throws -> Void
+    ) throws {
+        throw OrderedCollectionPersistenceFactoryError.backendUnavailable
+    }
+}

--- a/TiebaPure/Domain/Models/PersistencePrimitives.swift
+++ b/TiebaPure/Domain/Models/PersistencePrimitives.swift
@@ -1,0 +1,84 @@
+import Foundation
+import OSLog
+
+enum PersistenceAvailability: Equatable, Sendable {
+    case available
+    case unavailable
+
+    var canPersist: Bool {
+        self == .available
+    }
+}
+
+enum PersistenceFaultPoint: Equatable {
+    case legacyMigration
+    case repair
+    case clearAll
+}
+
+struct PersistenceFaultInjector {
+    static let none = PersistenceFaultInjector { _ in }
+
+    private let handler: (PersistenceFaultPoint) throws -> Void
+
+    init(_ handler: @escaping (PersistenceFaultPoint) throws -> Void) {
+        self.handler = handler
+    }
+
+    func check(_ point: PersistenceFaultPoint) throws {
+        try handler(point)
+    }
+}
+
+struct PersistenceLoadResult<Value> {
+    let value: Value
+    let repairError: Error?
+}
+
+enum PersistenceDiagnostics {
+    private static let logger = Logger(
+        subsystem: "dev.infinityf4p.tiebapure",
+        category: "Persistence"
+    )
+
+    static func report(_ error: Error, operation: String) {
+        logger.error("\(operation, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+    }
+}
+
+enum LegacyStorageMigration {
+    enum DecodeError: Error {
+        case invalidTopLevelArray
+    }
+
+    static func persistThenRemoveLegacyValue(
+        defaults: UserDefaults,
+        key: String,
+        destinationIsDurable: Bool,
+        persist: () throws -> Void
+    ) throws {
+        try persist()
+        guard destinationIsDurable else { return }
+        defaults.removeObject(forKey: key)
+    }
+}
+
+struct FailableDecodable<Value: Decodable>: Decodable {
+    let value: Value?
+
+    init(from decoder: Decoder) {
+        value = try? Value(from: decoder)
+    }
+}
+
+enum PersistedArrayDecoder {
+    static func decode<Element: Decodable>(_ type: Element.Type, from data: Data) -> [Element]? {
+        guard let boxes = try? JSONDecoder().decode(
+            [FailableDecodable<Element>].self,
+            from: data
+        ) else {
+            return nil
+        }
+        return boxes.compactMap(\.value)
+    }
+}

--- a/TiebaPure/Domain/Models/SecureFilePersistence.swift
+++ b/TiebaPure/Domain/Models/SecureFilePersistence.swift
@@ -1,0 +1,486 @@
+import CryptoKit
+import Foundation
+
+enum SecureFilePersistenceError: Error, Equatable {
+    case invalidFileName
+    case pathIsSymbolicLink
+    case pathIsNotRegularFile
+    case pathIsNotDirectory
+    case payloadTooLarge
+    case unsupportedFormatVersion(Int)
+    case checksumMismatch
+    case corruptedPrimaryAndBackup
+    case failedClosed
+}
+
+private final class SecureFileSharedState: @unchecked Sendable {
+    let lock = NSLock()
+    var isFailedClosed = false
+}
+
+private final class SecureFileStateRegistry: @unchecked Sendable {
+    static let shared = SecureFileStateRegistry()
+
+    private let registryLock = NSLock()
+    private var states: [String: SecureFileSharedState] = [:]
+
+    func state(for standardizedPath: String) -> SecureFileSharedState {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+        if let existing = states[standardizedPath] {
+            return existing
+        }
+        let created = SecureFileSharedState()
+        states[standardizedPath] = created
+        return created
+    }
+}
+
+struct SecurePersistenceLocation: Sendable {
+    static let currentDirectoryName = "v1"
+
+    let directoryURL: URL
+
+    static func applicationSupport(
+        fileManager: FileManager = .default,
+        baseDirectoryURL: URL? = nil
+    ) throws -> SecurePersistenceLocation {
+        let applicationSupport: URL
+        if let baseDirectoryURL {
+            applicationSupport = baseDirectoryURL
+        } else {
+            guard let resolved = fileManager.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            applicationSupport = resolved
+        }
+        if fileManager.fileExists(atPath: applicationSupport.path) == false {
+            try fileManager.createDirectory(
+                at: applicationSupport,
+                withIntermediateDirectories: true
+            )
+        }
+
+        var directoryURL = applicationSupport
+        for component in ["TiebaPure", "Persistence", currentDirectoryName] {
+            directoryURL.appendPathComponent(component, isDirectory: true)
+            try prepareProtectedDirectory(directoryURL, fileManager: fileManager)
+        }
+        return SecurePersistenceLocation(directoryURL: directoryURL)
+    }
+
+    private static func prepareProtectedDirectory(
+        _ directoryURL: URL,
+        fileManager: FileManager
+    ) throws {
+        if fileManager.fileExists(atPath: directoryURL.path) {
+            let attributes = try fileManager.attributesOfItem(atPath: directoryURL.path)
+            if attributes[.type] as? FileAttributeType == .typeSymbolicLink {
+                throw SecureFilePersistenceError.pathIsSymbolicLink
+            }
+            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+                throw SecureFilePersistenceError.pathIsNotDirectory
+            }
+        } else {
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: false,
+                attributes: protectedDirectoryAttributes
+            )
+        }
+        try fileManager.setAttributes(
+            protectedDirectoryAttributes,
+            ofItemAtPath: directoryURL.path
+        )
+    }
+
+    private static var protectedDirectoryAttributes: [FileAttributeKey: Any] {
+        var attributes: [FileAttributeKey: Any] = [
+            .posixPermissions: NSNumber(value: Int16(0o700))
+        ]
+#if os(iOS)
+        attributes[.protectionKey] = FileProtectionType.complete
+#endif
+        return attributes
+    }
+}
+
+enum SecurePersistenceDigest {
+    static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// A small, versioned file store used by the iOS 16 persistence adapters.
+///
+/// Every operation is serialized by the lock, including a read-modify-write
+/// performed from the browsing-history actor. The latest committed generation
+/// is mirrored as a backup. A corrupt primary is restored from that backup; when
+/// neither generation is valid, writes remain blocked until explicit recovery
+/// quarantines the damaged files.
+final class SecureCodableFile<Payload: Codable & Sendable>: @unchecked Sendable {
+    private struct Envelope: Codable {
+        let formatVersion: Int
+        let payload: Payload
+        let checksum: String
+    }
+
+    private enum ReadResult {
+        case missing
+        case value(Payload, encodedEnvelope: Data)
+        case corrupt
+    }
+
+    static var currentFormatVersion: Int { 1 }
+    static var defaultMaximumByteCount: Int { 8 * 1_024 * 1_024 }
+
+    let fileURL: URL
+    let backupURL: URL
+
+    private let fileManager: FileManager
+    private let maximumByteCount: Int
+    private let sharedState: SecureFileSharedState
+
+    init(
+        directoryURL: URL,
+        fileName: String,
+        fileManager: FileManager = .default,
+        maximumByteCount: Int = SecureCodableFile.defaultMaximumByteCount
+    ) throws {
+        guard fileName.isEmpty == false,
+              fileName != ".",
+              fileName != "..",
+              fileName == (fileName as NSString).lastPathComponent else {
+            throw SecureFilePersistenceError.invalidFileName
+        }
+        self.fileManager = fileManager
+        self.maximumByteCount = max(maximumByteCount, 1)
+        fileURL = directoryURL.appendingPathComponent(fileName, isDirectory: false)
+        backupURL = directoryURL.appendingPathComponent("\(fileName).backup", isDirectory: false)
+        sharedState = SecureFileStateRegistry.shared.state(
+            for: fileURL.standardizedFileURL.path
+        )
+        try Self.prepareDirectory(directoryURL, fileManager: fileManager)
+    }
+
+    func load() throws -> Payload? {
+        try withLock {
+            try loadLocked()
+        }
+    }
+
+    func replace(
+        _ payload: Payload,
+        beforeCommit: () throws -> Void = {}
+    ) throws {
+        try withLock {
+            guard sharedState.isFailedClosed == false else {
+                throw SecureFilePersistenceError.failedClosed
+            }
+            _ = try loadLocked()
+            let encoded = try encode(payload)
+            try beforeCommit()
+            try invalidateBackupLocked()
+            try atomicWrite(encoded, to: fileURL)
+            refreshBackupBestEffort(encoded)
+        }
+    }
+
+    func update(
+        default defaultPayload: @autoclosure () -> Payload,
+        beforeCommit: () throws -> Void = {},
+        transform: (inout Payload) throws -> Void
+    ) throws -> Payload {
+        try withLock {
+            guard sharedState.isFailedClosed == false else {
+                throw SecureFilePersistenceError.failedClosed
+            }
+            var payload = try loadLocked() ?? defaultPayload()
+            try transform(&payload)
+            let encoded = try encode(payload)
+            try beforeCommit()
+            try invalidateBackupLocked()
+            try atomicWrite(encoded, to: fileURL)
+            refreshBackupBestEffort(encoded)
+            return payload
+        }
+    }
+
+    /// Preserves damaged generations for diagnostics and unlocks a clean store.
+    /// This is intentionally explicit so a decode failure can never silently
+    /// erase the only remaining copy.
+    func quarantineCorruptedGenerations(now: Date = Date()) throws {
+        try withLock {
+            guard sharedState.isFailedClosed else { return }
+            let suffix = String(Int(now.timeIntervalSince1970)) + "-" + UUID().uuidString
+            try quarantineIfPresent(fileURL, suffix: suffix)
+            try quarantineIfPresent(backupURL, suffix: suffix)
+            sharedState.isFailedClosed = false
+        }
+    }
+
+    private func loadLocked() throws -> Payload? {
+        guard sharedState.isFailedClosed == false else {
+            throw SecureFilePersistenceError.failedClosed
+        }
+
+        let primary = try read(fileURL)
+        switch primary {
+        case let .value(payload, encodedEnvelope):
+            refreshBackupBestEffort(encodedEnvelope)
+            return payload
+        case .missing, .corrupt:
+            let backup = try read(backupURL)
+            switch backup {
+            case let .value(payload, encodedEnvelope):
+                try atomicWrite(encodedEnvelope, to: fileURL)
+                return payload
+            case .missing:
+                if case .missing = primary {
+                    return nil
+                }
+            case .corrupt:
+                break
+            }
+        }
+
+        sharedState.isFailedClosed = true
+        throw SecureFilePersistenceError.corruptedPrimaryAndBackup
+    }
+
+    private func invalidateBackupLocked() throws {
+        guard fileManager.fileExists(atPath: backupURL.path) else { return }
+        try Self.rejectSymbolicLink(at: backupURL, fileManager: fileManager)
+        let attributes = try fileManager.attributesOfItem(atPath: backupURL.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw SecureFilePersistenceError.pathIsNotRegularFile
+        }
+        try fileManager.removeItem(at: backupURL)
+    }
+
+    private func refreshBackupBestEffort(_ encodedEnvelope: Data) {
+        do {
+            if fileManager.fileExists(atPath: backupURL.path) {
+                try Self.rejectSymbolicLink(at: backupURL, fileManager: fileManager)
+                let attributes = try fileManager.attributesOfItem(atPath: backupURL.path)
+                if attributes[.type] as? FileAttributeType == .typeRegular,
+                   try Data(contentsOf: backupURL, options: [.mappedIfSafe]) == encodedEnvelope {
+                    return
+                }
+            }
+            try invalidateBackupLocked()
+            try atomicWrite(encodedEnvelope, to: backupURL)
+        } catch {
+            // The primary is already committed and remains authoritative. Never
+            // leave an older backup that could resurrect a cleared entry.
+            try? removeRegularBackupIfPresent()
+        }
+    }
+
+    private func removeRegularBackupIfPresent() throws {
+        guard fileManager.fileExists(atPath: backupURL.path) else { return }
+        try Self.rejectSymbolicLink(at: backupURL, fileManager: fileManager)
+        let attributes = try fileManager.attributesOfItem(atPath: backupURL.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else { return }
+        try fileManager.removeItem(at: backupURL)
+    }
+
+    private func read(_ url: URL) throws -> ReadResult {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return .missing
+        }
+        try Self.rejectSymbolicLink(at: url, fileManager: fileManager)
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw SecureFilePersistenceError.pathIsNotRegularFile
+        }
+        if let byteCount = attributes[.size] as? NSNumber,
+           byteCount.intValue > maximumByteCount {
+            return .corrupt
+        }
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        guard data.count <= maximumByteCount else {
+            return .corrupt
+        }
+        do {
+            return .value(try decode(data), encodedEnvelope: data)
+        } catch let error as SecureFilePersistenceError {
+            switch error {
+            case .unsupportedFormatVersion, .checksumMismatch:
+                return .corrupt
+            default:
+                throw error
+            }
+        } catch is DecodingError {
+            return .corrupt
+        }
+    }
+
+    private func encode(_ payload: Payload) throws -> Data {
+        let payloadData = try Self.encoder().encode(payload)
+        guard payloadData.count <= maximumByteCount else {
+            throw SecureFilePersistenceError.payloadTooLarge
+        }
+        let envelope = Envelope(
+            formatVersion: Self.currentFormatVersion,
+            payload: payload,
+            checksum: SecurePersistenceDigest.sha256(payloadData)
+        )
+        let data = try Self.encoder().encode(envelope)
+        guard data.count <= maximumByteCount else {
+            throw SecureFilePersistenceError.payloadTooLarge
+        }
+        return data
+    }
+
+    private func decode(_ data: Data) throws -> Payload {
+        let envelope = try Self.decoder().decode(Envelope.self, from: data)
+        guard envelope.formatVersion == Self.currentFormatVersion else {
+            throw SecureFilePersistenceError.unsupportedFormatVersion(envelope.formatVersion)
+        }
+        let payloadData = try Self.encoder().encode(envelope.payload)
+        guard SecurePersistenceDigest.sha256(payloadData) == envelope.checksum else {
+            throw SecureFilePersistenceError.checksumMismatch
+        }
+        return envelope.payload
+    }
+
+    private func atomicWrite(_ data: Data, to destinationURL: URL) throws {
+        guard data.count <= maximumByteCount else {
+            throw SecureFilePersistenceError.payloadTooLarge
+        }
+        let directoryURL = destinationURL.deletingLastPathComponent()
+        try Self.prepareDirectory(directoryURL, fileManager: fileManager)
+        try Self.rejectSymbolicLinkIfPresent(at: destinationURL, fileManager: fileManager)
+
+        let temporaryURL = directoryURL.appendingPathComponent(
+            ".\(destinationURL.lastPathComponent).\(UUID().uuidString).tmp",
+            isDirectory: false
+        )
+        defer { try? fileManager.removeItem(at: temporaryURL) }
+
+        try data.write(to: temporaryURL, options: Self.protectedWritingOptions)
+        try Self.secureFile(at: temporaryURL, fileManager: fileManager)
+        let handle = try FileHandle(forWritingTo: temporaryURL)
+        try handle.synchronize()
+        try handle.close()
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            _ = try fileManager.replaceItemAt(
+                destinationURL,
+                withItemAt: temporaryURL,
+                backupItemName: nil,
+                options: [.usingNewMetadataOnly]
+            )
+        } else {
+            try fileManager.moveItem(at: temporaryURL, to: destinationURL)
+        }
+    }
+
+    private func quarantineIfPresent(_ url: URL, suffix: String) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try Self.rejectSymbolicLink(at: url, fileManager: fileManager)
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw SecureFilePersistenceError.pathIsNotRegularFile
+        }
+        try Self.secureFile(at: url, fileManager: fileManager)
+        let quarantineURL = url.deletingLastPathComponent().appendingPathComponent(
+            "\(url.lastPathComponent).corrupt-\(suffix)",
+            isDirectory: false
+        )
+        try fileManager.moveItem(at: url, to: quarantineURL)
+    }
+
+    private func withLock<Result>(_ operation: () throws -> Result) rethrows -> Result {
+        sharedState.lock.lock()
+        defer { sharedState.lock.unlock() }
+        return try operation()
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+
+    private static func decoder() -> JSONDecoder {
+        JSONDecoder()
+    }
+
+    private static func prepareDirectory(
+        _ directoryURL: URL,
+        fileManager: FileManager
+    ) throws {
+        if fileManager.fileExists(atPath: directoryURL.path) {
+            try rejectSymbolicLink(at: directoryURL, fileManager: fileManager)
+            let attributes = try fileManager.attributesOfItem(atPath: directoryURL.path)
+            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+                throw SecureFilePersistenceError.pathIsNotDirectory
+            }
+        } else {
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: secureDirectoryAttributes
+            )
+        }
+        try fileManager.setAttributes(
+            secureDirectoryAttributes,
+            ofItemAtPath: directoryURL.path
+        )
+    }
+
+    private static func secureFile(at url: URL, fileManager: FileManager) throws {
+        try fileManager.setAttributes(secureFileAttributes, ofItemAtPath: url.path)
+    }
+
+    private static func rejectSymbolicLinkIfPresent(
+        at url: URL,
+        fileManager: FileManager
+    ) throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try rejectSymbolicLink(at: url, fileManager: fileManager)
+    }
+
+    private static func rejectSymbolicLink(
+        at url: URL,
+        fileManager: FileManager
+    ) throws {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        if attributes[.type] as? FileAttributeType == .typeSymbolicLink {
+            throw SecureFilePersistenceError.pathIsSymbolicLink
+        }
+    }
+
+    private static var secureDirectoryAttributes: [FileAttributeKey: Any] {
+        var attributes: [FileAttributeKey: Any] = [
+            .posixPermissions: NSNumber(value: Int16(0o700))
+        ]
+#if os(iOS)
+        attributes[.protectionKey] = FileProtectionType.complete
+#endif
+        return attributes
+    }
+
+    private static var secureFileAttributes: [FileAttributeKey: Any] {
+        var attributes: [FileAttributeKey: Any] = [
+            .posixPermissions: NSNumber(value: Int16(0o600))
+        ]
+#if os(iOS)
+        attributes[.protectionKey] = FileProtectionType.complete
+#endif
+        return attributes
+    }
+
+    private static var protectedWritingOptions: Data.WritingOptions {
+#if os(iOS)
+        [.completeFileProtection]
+#else
+        []
+#endif
+    }
+}

--- a/TiebaPure/Domain/Models/SwiftDataOrderedCollectionPersistence.swift
+++ b/TiebaPure/Domain/Models/SwiftDataOrderedCollectionPersistence.swift
@@ -1,12 +1,98 @@
 import Foundation
 import SwiftData
 
+@available(iOS 17.0, *)
+@Model
+final class OrderedCollectionBackendMarkerRecord {
+    var key: String
+    var formatVersion: Int
+    var generationID: String
+
+    init(key: String, formatVersion: Int, generationID: String) {
+        self.key = key
+        self.formatVersion = formatVersion
+        self.generationID = generationID
+    }
+}
+
+@MainActor
+@available(iOS 17.0, *)
+final class SwiftDataOrderedCollectionBackendMarkerPersistence:
+    OrderedCollectionBackendMarkerPersistence
+{
+    private static let markerKey = "ordered-collections"
+    private static let markerFormatVersion = 1
+
+    let capability: PersistenceCapability
+
+    private let modelContext: ModelContext
+
+    init(
+        modelContainer: ModelContainer,
+        persistenceAvailability: PersistenceAvailability? = nil
+    ) {
+        modelContext = modelContainer.mainContext
+        let resolvedAvailability = persistenceAvailability
+            ?? AppModelContainer.persistenceAvailability(for: modelContainer)
+        guard resolvedAvailability.canPersist else {
+            capability = .fallback
+            return
+        }
+        capability = AppModelContainer.allowsLegacyCleanup(for: modelContainer)
+            ? .durable
+            : .fallback
+    }
+
+    func loadGeneration() throws -> String? {
+        let markers = try modelContext.fetch(
+            FetchDescriptor<OrderedCollectionBackendMarkerRecord>()
+        ).filter { $0.key == Self.markerKey }
+        guard markers.count <= 1 else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+        }
+        guard let marker = markers.first else { return nil }
+        guard marker.formatVersion == Self.markerFormatVersion,
+              UUID(uuidString: marker.generationID) != nil else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+        }
+        return marker.generationID
+    }
+
+    func replaceGeneration(_ generation: String) throws {
+        guard capability.isDurable else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerUnavailable
+        }
+        guard UUID(uuidString: generation) != nil else {
+            throw OrderedCollectionPersistenceFactoryError.destinationMarkerMismatch
+        }
+
+        do {
+            let markers = try modelContext.fetch(
+                FetchDescriptor<OrderedCollectionBackendMarkerRecord>()
+            ).filter { $0.key == Self.markerKey }
+            for marker in markers {
+                modelContext.delete(marker)
+            }
+            modelContext.insert(OrderedCollectionBackendMarkerRecord(
+                key: Self.markerKey,
+                formatVersion: Self.markerFormatVersion,
+                generationID: generation
+            ))
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+}
+
 private enum BrowsingHistoryDatabaseMutation: Sendable {
     case upsert(BrowsingHistoryEntry, limit: Int)
     case delete(threadIDs: Set<Int64>)
     case deleteAll
 }
 
+@available(iOS 17.0, *)
 @ModelActor
 private actor BrowsingHistoryDatabaseActor {
     func apply(_ mutation: BrowsingHistoryDatabaseMutation) throws -> [BrowsingHistoryEntry] {
@@ -121,6 +207,7 @@ private actor BrowsingHistoryDatabaseActor {
 }
 
 @MainActor
+@available(iOS 17.0, *)
 final class SwiftDataBrowsingHistoryPersistence: BrowsingHistoryPersistence {
     let capability: PersistenceCapability
 
@@ -194,6 +281,7 @@ final class SwiftDataBrowsingHistoryPersistence: BrowsingHistoryPersistence {
 }
 
 @MainActor
+@available(iOS 17.0, *)
 final class SwiftDataRecentForumPersistence: RecentForumPersistence {
     let capability: PersistenceCapability
 
@@ -238,6 +326,7 @@ final class SwiftDataRecentForumPersistence: RecentForumPersistence {
 }
 
 @MainActor
+@available(iOS 17.0, *)
 final class SwiftDataSearchHistoryPersistence: SearchHistoryPersistence {
     let capability: PersistenceCapability
 
@@ -281,34 +370,8 @@ final class SwiftDataSearchHistoryPersistence: SearchHistoryPersistence {
     }
 }
 
-@MainActor
-enum AppOrderedCollectionPersistence {
-    static let browsingHistory: any BrowsingHistoryPersistence =
-        SwiftDataBrowsingHistoryPersistence(modelContainer: AppModelContainer.shared)
-    static let recentForums: any RecentForumPersistence =
-        SwiftDataRecentForumPersistence(modelContainer: AppModelContainer.shared)
-    static let searchHistory: any SearchHistoryPersistence =
-        SwiftDataSearchHistoryPersistence(modelContainer: AppModelContainer.shared)
-}
-
 extension BrowsingHistoryStore {
-    convenience init(
-        defaults: UserDefaults = .standard,
-        key: String = "dev.infinityf4p.tiebapure.browsingHistory",
-        limit: Int = BrowsingHistoryPolicy.maximumStoredEntries,
-        faultInjector: PersistenceFaultInjector = .none,
-        now: @escaping () -> Date = Date.init
-    ) {
-        self.init(
-            defaults: defaults,
-            key: key,
-            limit: limit,
-            persistence: AppOrderedCollectionPersistence.browsingHistory,
-            faultInjector: faultInjector,
-            now: now
-        )
-    }
-
+    @available(iOS 17.0, *)
     convenience init(
         defaults: UserDefaults = .standard,
         key: String = "dev.infinityf4p.tiebapure.browsingHistory",
@@ -333,23 +396,7 @@ extension BrowsingHistoryStore {
 }
 
 extension RecentForumStore {
-    convenience init(
-        defaults: UserDefaults = .standard,
-        key: String = "dev.infinityf4p.tiebapure.recentForums",
-        limit: Int = RecentForumPolicy.maximumStoredEntries,
-        faultInjector: PersistenceFaultInjector = .none,
-        now: @escaping () -> Date = Date.init
-    ) {
-        self.init(
-            defaults: defaults,
-            key: key,
-            limit: limit,
-            persistence: AppOrderedCollectionPersistence.recentForums,
-            faultInjector: faultInjector,
-            now: now
-        )
-    }
-
+    @available(iOS 17.0, *)
     convenience init(
         defaults: UserDefaults = .standard,
         key: String = "dev.infinityf4p.tiebapure.recentForums",
@@ -374,21 +421,7 @@ extension RecentForumStore {
 }
 
 extension SearchHistoryStore {
-    convenience init(
-        defaults: UserDefaults = .standard,
-        key: String = "dev.infinityf4p.tiebapure.searchHistory",
-        limit: Int = SearchHistoryPolicy.maximumStoredEntries,
-        faultInjector: PersistenceFaultInjector = .none
-    ) {
-        self.init(
-            defaults: defaults,
-            key: key,
-            limit: limit,
-            persistence: AppOrderedCollectionPersistence.searchHistory,
-            faultInjector: faultInjector
-        )
-    }
-
+    @available(iOS 17.0, *)
     convenience init(
         defaults: UserDefaults = .standard,
         key: String = "dev.infinityf4p.tiebapure.searchHistory",

--- a/TiebaPureTests/ContentDraftFilePersistenceTests.swift
+++ b/TiebaPureTests/ContentDraftFilePersistenceTests.swift
@@ -1,0 +1,400 @@
+import XCTest
+@testable import TiebaPure
+
+final class ContentDraftFilePersistenceTests: XCTestCase {
+    private enum InjectedFailure: Error {
+        case beforeCatalogCommit
+        case blobCleanup
+    }
+
+    private final class CancellationGate: @unchecked Sendable {
+        let entered = DispatchSemaphore(value: 0)
+        let proceed = DispatchSemaphore(value: 0)
+    }
+
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "TiebaPure-ContentDraftFileTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func makeTarget(threadID: Int64) -> ContentSubmissionTarget {
+        ContentSubmissionTarget(
+            kind: .threadReply,
+            forumID: 10,
+            forumName: "fixture",
+            forumDisplayName: "测试吧",
+            threadID: threadID,
+            threadTitle: "测试帖子",
+            parentPostID: nil,
+            parentFloor: nil,
+            subpostID: nil,
+            replyUserID: nil,
+            replyUserDisplayName: nil
+        )
+    }
+
+    private func makeImage(marker: UInt8, byteCount: Int = 3) -> ContentSubmissionImage {
+        ContentSubmissionImage(
+            data: Data(repeating: marker, count: byteCount),
+            pixelWidth: 20,
+            pixelHeight: 30,
+            mimeType: "image/jpeg"
+        )
+    }
+
+    private func makeDraft(
+        accountID: String = "account",
+        threadID: Int64,
+        marker: UInt8,
+        updatedAt: TimeInterval? = nil,
+        imageByteCount: Int = 3
+    ) -> ContentDraft {
+        ContentDraft(
+            accountID: accountID,
+            target: makeTarget(threadID: threadID),
+            title: "title-\(threadID)",
+            body: "body-\(threadID)",
+            images: [makeImage(marker: marker, byteCount: imageByteCount)],
+            updatedAt: Date(timeIntervalSince1970: updatedAt ?? TimeInterval(threadID))
+        )
+    }
+
+    private func blobURLs(in directory: URL) throws -> [URL] {
+        let blobDirectory = directory.appendingPathComponent(
+            "content-draft-blobs",
+            isDirectory: true
+        )
+        return try FileManager.default.contentsOfDirectory(
+            at: blobDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "tpdi" }
+    }
+
+    @MainActor
+    func testCatalogAndRawTPDIBlobAreStoredSeparatelyWithSecureAttributes() throws {
+        let directory = try makeDirectory()
+        let backend = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let store = ContentDraftStore(persistence: backend)
+        let draft = makeDraft(
+            threadID: 1,
+            marker: 0xa5,
+            imageByteCount: 1_024 * 1_024
+        )
+
+        XCTAssertTrue(store.save(draft))
+
+        let catalogURL = directory.appendingPathComponent("content-drafts-catalog.json")
+        let blobs = try blobURLs(in: directory)
+        let blobURL = try XCTUnwrap(blobs.first)
+        XCTAssertEqual(blobs.count, 1)
+        XCTAssertLessThan(
+            try Data(contentsOf: catalogURL).count,
+            try Data(contentsOf: blobURL).count / 10
+        )
+        XCTAssertEqual(
+            Data(try Data(contentsOf: blobURL).prefix(5)),
+            Data([0x54, 0x50, 0x44, 0x49, 0x02])
+        )
+
+        for url in [catalogURL, blobURL] {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            let permissions = try XCTUnwrap(
+                (attributes[.posixPermissions] as? NSNumber)?.intValue
+            )
+            XCTAssertEqual(permissions & 0o777, 0o600)
+            // CoreSimulator does not expose NSFileProtectionKey on every host
+            // filesystem. Verify it whenever the filesystem reports support.
+            if let protection = attributes[.protectionKey] as? FileProtectionType {
+                XCTAssertEqual(protection, .complete)
+            }
+        }
+    }
+
+    @MainActor
+    func testSeparateInstancesSerializeConcurrentCatalogUpdates() async throws {
+        let directory = try makeDirectory()
+        let first = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        let second = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        let firstDraft = makeDraft(threadID: 1, marker: 1)
+        let secondDraft = makeDraft(threadID: 2, marker: 2)
+
+        async let firstSave: Void = first.saveAsync(firstDraft)
+        async let secondSave: Void = second.saveAsync(secondDraft)
+        try await firstSave
+        try await secondSave
+
+        let reloaded = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        XCTAssertEqual(reloaded.draft(accountID: "account", target: firstDraft.target), firstDraft)
+        XCTAssertEqual(reloaded.draft(accountID: "account", target: secondDraft.target), secondDraft)
+        XCTAssertEqual(try blobURLs(in: directory).count, 2)
+    }
+
+    @MainActor
+    func testCatalogCommitFailureKeepsPreviousDraftAndRemovesStagedBlob() throws {
+        let directory = try makeDirectory()
+        let stableBackend = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let stableStore = ContentDraftStore(persistence: stableBackend)
+        let original = makeDraft(threadID: 1, marker: 1, updatedAt: 1)
+        XCTAssertTrue(stableStore.save(original))
+
+        let failingBackend = try FileContentDraftPersistenceBackend(
+            directoryURL: directory,
+            faultInjector: ContentDraftFilePersistenceFaultInjector { point in
+                if case .beforeCatalogCommit = point {
+                    throw InjectedFailure.beforeCatalogCommit
+                }
+            }
+        )
+        let replacement = makeDraft(threadID: 1, marker: 9, updatedAt: 9)
+        XCTAssertFalse(ContentDraftStore(persistence: failingBackend).save(replacement))
+
+        let reloaded = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        XCTAssertEqual(reloaded.draft(accountID: "account", target: original.target), original)
+        XCTAssertEqual(try blobURLs(in: directory).count, 1)
+    }
+
+    @MainActor
+    func testCleanupFailureAfterCatalogCommitDoesNotReportCommittedSaveAsFailed() throws {
+        let directory = try makeDirectory()
+        let stableStore = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        let original = makeDraft(threadID: 1, marker: 1, updatedAt: 1)
+        XCTAssertTrue(stableStore.save(original))
+
+        let backend = try FileContentDraftPersistenceBackend(
+            directoryURL: directory,
+            faultInjector: ContentDraftFilePersistenceFaultInjector { point in
+                if case .beforeBlobCleanup = point {
+                    throw InjectedFailure.blobCleanup
+                }
+            }
+        )
+        let replacement = makeDraft(threadID: 1, marker: 9, updatedAt: 9)
+        XCTAssertTrue(ContentDraftStore(persistence: backend).save(replacement))
+
+        let reloaded = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        XCTAssertEqual(reloaded.draft(accountID: "account", target: replacement.target), replacement)
+        // The old orphan can remain until maintenance, but it must never make
+        // the already committed replacement look like a failed mutation.
+        XCTAssertEqual(try blobURLs(in: directory).count, 2)
+    }
+
+    @MainActor
+    func testCancellationAfterBlobCommitDoesNotPublishDraftOrLeakBlob() async throws {
+        let directory = try makeDirectory()
+        let gate = CancellationGate()
+        let backend = try FileContentDraftPersistenceBackend(
+            directoryURL: directory,
+            faultInjector: ContentDraftFilePersistenceFaultInjector { point in
+                if case .beforeCatalogCommit = point {
+                    gate.entered.signal()
+                    gate.proceed.wait()
+                    try Task.checkCancellation()
+                }
+            }
+        )
+        let store = ContentDraftStore(persistence: backend)
+        let draft = makeDraft(threadID: 1, marker: 1)
+        let task = Task { @MainActor in try await store.saveAsync(draft) }
+
+        let entered = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: gate.entered.wait(timeout: .now() + 5))
+            }
+        }
+        XCTAssertEqual(entered, .success)
+        task.cancel()
+        gate.proceed.signal()
+        do {
+            try await task.value
+            XCTFail("Cancellation must be preserved")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let reloaded = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        XCTAssertNil(reloaded.draft(accountID: "account", target: draft.target))
+        XCTAssertTrue(try blobURLs(in: directory).isEmpty)
+    }
+
+    @MainActor
+    func testCapacityPrunesOldestCatalogEntryAndItsBlob() throws {
+        let directory = try makeDirectory()
+        let store = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        for index in 0...ContentDraftPolicy.maximumDraftsPerAccount {
+            XCTAssertTrue(store.save(makeDraft(
+                threadID: Int64(index + 1),
+                marker: UInt8(index % 200),
+                updatedAt: TimeInterval(index)
+            )))
+        }
+
+        XCTAssertNil(store.draft(accountID: "account", target: makeTarget(threadID: 1)))
+        XCTAssertNotNil(store.draft(
+            accountID: "account",
+            target: makeTarget(threadID: Int64(ContentDraftPolicy.maximumDraftsPerAccount + 1))
+        ))
+        XCTAssertEqual(
+            try blobURLs(in: directory).count,
+            ContentDraftPolicy.maximumDraftsPerAccount
+        )
+    }
+
+    @MainActor
+    func testDamagedBlobIsReportedAndCanBeDeletedWithoutTouchingOtherDrafts() async throws {
+        let directory = try makeDirectory()
+        let store = ContentDraftStore(persistence: try FileContentDraftPersistenceBackend(
+            directoryURL: directory
+        ))
+        let damaged = makeDraft(threadID: 1, marker: 1)
+        let retained = makeDraft(threadID: 2, marker: 2)
+        XCTAssertTrue(store.save(damaged))
+        let damagedBlob = try XCTUnwrap(blobURLs(in: directory).first)
+        XCTAssertTrue(store.save(retained))
+        var bytes = try Data(contentsOf: damagedBlob)
+        bytes[bytes.index(before: bytes.endIndex)] ^= 0xff
+        try bytes.write(to: damagedBlob, options: [.atomic, .completeFileProtection])
+
+        let damagedOutcome = await store.loadAsync(
+            accountID: "account",
+            target: damaged.target
+        )
+        XCTAssertEqual(damagedOutcome, .damaged(.attachmentContainer))
+        XCTAssertTrue(store.delete(accountID: "account", target: damaged.target))
+        XCTAssertEqual(store.draft(accountID: "account", target: retained.target), retained)
+        XCTAssertEqual(try blobURLs(in: directory).count, 1)
+    }
+
+    @MainActor
+    func testMigrationManifestContainsOnlyDigestsAndRecordsStreamIndividually() async throws {
+        let directory = try makeDirectory()
+        let backend = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let store = ContentDraftStore(persistence: backend)
+        let draft = makeDraft(
+            threadID: 1,
+            marker: 0xa5,
+            imageByteCount: 2 * 1_024 * 1_024
+        )
+        XCTAssertTrue(store.save(draft))
+
+        let manifest = try await backend.migrationManifest()
+        let entry = try XCTUnwrap(manifest.entries.first)
+        XCTAssertEqual(manifest.entries.count, 1)
+        XCTAssertEqual(entry.identity, "account\u{1f}\(draft.target.draftKey)")
+        XCTAssertEqual(entry.blobDigest.count, 64)
+        XCTAssertEqual(entry.metadataDigest.count, 64)
+        XCTAssertLessThan(try JSONEncoder().encode(manifest).count, 2_048)
+
+        let record = try await backend.migrationRecord(identity: entry.identity)
+        XCTAssertEqual(record.imagesByteCount, record.imagesBlob.count)
+        XCTAssertGreaterThan(record.imagesBlob.count, 2 * 1_024 * 1_024)
+    }
+
+    @MainActor
+    func testMigrationManifestDoesNotReadAttachmentBlob() async throws {
+        let directory = try makeDirectory()
+        let backend = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(ContentDraftStore(persistence: backend).save(draft))
+        let blobURL = try XCTUnwrap(blobURLs(in: directory).first)
+        try FileManager.default.removeItem(at: blobURL)
+
+        let manifest = try await backend.migrationManifest()
+        XCTAssertEqual(manifest.entries.count, 1)
+        do {
+            _ = try await backend.migrationRecord(identity: manifest.entries[0].identity)
+            XCTFail("The missing per-record blob must fail when that record is streamed")
+        } catch {
+            // Expected. The manifest remains metadata-only; the record read is
+            // the first operation that touches the attachment container.
+        }
+    }
+
+    func testPersistenceStateRejectsInvalidBackendStatusCombinations() throws {
+        let generationID = "11111111-1111-1111-1111-111111111111"
+        XCTAssertNoThrow(try ContentDraftPersistenceState.activeFiles.validated())
+        XCTAssertNoThrow(try ContentDraftPersistenceState.initialSwiftData(
+            generationID: generationID
+        ).validated())
+        XCTAssertNoThrow(try ContentDraftPersistenceState.nativeActivationPending(
+            generationID: generationID
+        ).validated())
+        XCTAssertNoThrow(try ContentDraftPersistenceState.migrated(
+            sourceFingerprint: String(repeating: "a", count: 64),
+            generationID: generationID,
+            completedAt: Date(timeIntervalSinceReferenceDate: 1)
+        ).validated())
+        XCTAssertThrowsError(try ContentDraftPersistenceState.initialSwiftData(
+            generationID: "not-a-generation"
+        ).validated())
+
+        let invalid = ContentDraftPersistenceState(
+            formatVersion: ContentDraftPersistenceState.currentFormatVersion,
+            activeBackend: .secureFiles,
+            migrationStatus: .completed,
+            destinationGenerationID: generationID,
+            receipt: ContentDraftMigrationReceipt(
+                migrationVersion: ContentDraftMigrationReceipt.currentMigrationVersion,
+                sourceFingerprint: String(repeating: "a", count: 64),
+                completedAt: Date()
+            )
+        )
+        XCTAssertThrowsError(try invalid.validated())
+    }
+
+    @MainActor
+    func testIOS16ResolverFailsClosedForCorruptCatalogInsteadOfCreatingEmptyStore() throws {
+        let directory = try makeDirectory()
+        let catalogURL = directory.appendingPathComponent("content-drafts-catalog.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("not a catalog".utf8).write(to: catalogURL)
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS16Backend(
+            directoryURL: directory
+        ))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(
+                ContentDraftPersistenceFactory.stateFileName
+            ).path
+        ))
+    }
+
+    @MainActor
+    func testIOS16ResolverCommitsFileAuthorityBeforeReturningWritableBackend() throws {
+        let directory = try makeDirectory()
+        let backend = try ContentDraftPersistenceFactory.resolveIOS16Backend(
+            directoryURL: directory
+        )
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        XCTAssertEqual(try stateFile.load(), ContentDraftPersistenceState.activeFiles)
+
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(backend.save(draft))
+        let relaunched = try ContentDraftPersistenceFactory.resolveIOS16Backend(
+            directoryURL: directory
+        )
+        XCTAssertEqual(relaunched.draft(accountID: "account", target: draft.target), draft)
+    }
+}

--- a/TiebaPureTests/ContentDraftMigrationTests.swift
+++ b/TiebaPureTests/ContentDraftMigrationTests.swift
@@ -1,0 +1,567 @@
+import Foundation
+import SwiftData
+import XCTest
+@testable import TiebaPure
+
+@available(iOS 17.0, *)
+final class ContentDraftMigrationTests: XCTestCase {
+    private enum InjectedFailure: Error {
+        case stateCommit
+    }
+
+    private actor MigrationGate {
+        private var entered = false
+        private var released = false
+
+        func pause() async throws {
+            entered = true
+            while released == false {
+                try Task.checkCancellation()
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+        }
+
+        func waitUntilEntered() async {
+            while entered == false {
+                await Task.yield()
+            }
+        }
+
+        func release() {
+            released = true
+        }
+    }
+
+    private actor InvocationCounter {
+        private(set) var count = 0
+
+        func increment() {
+            count += 1
+        }
+    }
+
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "TiebaPure-ContentDraftMigrationTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(AppModelContainer.models)
+        return try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        )
+    }
+
+    private func makeTarget(threadID: Int64) -> ContentSubmissionTarget {
+        ContentSubmissionTarget(
+            kind: .threadReply,
+            forumID: 10,
+            forumName: "fixture",
+            forumDisplayName: "测试吧",
+            threadID: threadID,
+            threadTitle: "测试帖子",
+            parentPostID: nil,
+            parentFloor: nil,
+            subpostID: nil,
+            replyUserID: nil,
+            replyUserDisplayName: nil
+        )
+    }
+
+    private func makeDraft(
+        threadID: Int64,
+        marker: UInt8,
+        updatedAt: TimeInterval? = nil
+    ) -> ContentDraft {
+        ContentDraft(
+            accountID: "account",
+            target: makeTarget(threadID: threadID),
+            title: "title-\(threadID)",
+            body: "body-\(threadID)",
+            images: [ContentSubmissionImage(
+                data: Data(repeating: marker, count: 32),
+                pixelWidth: 20,
+                pixelHeight: 30,
+                mimeType: "image/jpeg"
+            )],
+            updatedAt: Date(timeIntervalSince1970: updatedAt ?? TimeInterval(threadID))
+        )
+    }
+
+    private func corruptGenerations(_ file: SecureCodableFile<ContentDraftPersistenceState>) throws {
+        for url in [file.fileURL, file.backupURL] {
+            try Data("corrupt".utf8).write(to: url, options: .atomic)
+        }
+    }
+
+    private func corruptCatalogGenerations(in directory: URL) throws {
+        for name in [
+            "content-drafts-catalog.json",
+            "content-drafts-catalog.json.backup"
+        ] {
+            let url = directory.appendingPathComponent(name)
+            try Data("corrupt".utf8).write(to: url, options: .atomic)
+        }
+    }
+
+    @MainActor
+    func testVerifiedMigrationCommitsAuthorityAndNeverRechecksRetainedSource() async throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.activeFiles)
+        let source = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let sourceStore = ContentDraftStore(persistence: source)
+        let first = makeDraft(threadID: 1, marker: 1)
+        let second = makeDraft(threadID: 2, marker: 2)
+        XCTAssertTrue(sourceStore.save(first))
+        XCTAssertTrue(sourceStore.save(second))
+        let sourceBlobNames = try FileManager.default.contentsOfDirectory(
+            at: directory.appendingPathComponent("content-draft-blobs", isDirectory: true),
+            includingPropertiesForKeys: nil
+        ).map(\.lastPathComponent)
+
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let migrating = MigratingContentDraftPersistenceBackend(
+            source: source,
+            destination: destination,
+            stateFile: stateFile,
+            now: { Date(timeIntervalSinceReferenceDate: 10) }
+        )
+        let migrationOutcome = await ContentDraftStore(persistence: migrating).loadAsync(
+            accountID: "account",
+            target: first.target
+        )
+        XCTAssertEqual(migrationOutcome, .loaded(first))
+
+        let state = try XCTUnwrap(stateFile.load())
+        XCTAssertEqual(state.activeBackend, .swiftData)
+        XCTAssertEqual(state.migrationStatus, .completed)
+        XCTAssertEqual(state.receipt?.completedAt, Date(timeIntervalSinceReferenceDate: 10))
+        XCTAssertEqual(destination.draft(accountID: "account", target: second.target), second)
+        for name in sourceBlobNames {
+            XCTAssertTrue(FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("content-draft-blobs", isDirectory: true)
+                    .appendingPathComponent(name).path
+            ))
+        }
+
+        let destinationOnly = makeDraft(threadID: 3, marker: 3)
+        XCTAssertTrue(destination.save(destinationOnly))
+        try corruptCatalogGenerations(in: directory)
+
+        let resolved = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )
+        XCTAssertEqual(
+            resolved.draft(accountID: "account", target: destinationOnly.target),
+            destinationOnly
+        )
+        XCTAssertEqual(
+            try stateFile.load()?.receipt?.completedAt,
+            Date(timeIntervalSinceReferenceDate: 10)
+        )
+    }
+
+    @MainActor
+    func testStateCommitFailureLeavesSourceActiveAndRetryClearsPartialDestination() async throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.activeFiles)
+        let source = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(source.save(draft))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let failing = MigratingContentDraftPersistenceBackend(
+            source: source,
+            destination: destination,
+            stateFile: stateFile,
+            beforeStateCommit: { throw InjectedFailure.stateCommit }
+        )
+
+        let failedCommitOutcome = await failing.loadAsync(
+            accountID: "account",
+            target: draft.target
+        )
+        XCTAssertEqual(failedCommitOutcome, .loaded(draft))
+        XCTAssertEqual(try stateFile.load(), ContentDraftPersistenceState.activeFiles)
+        XCTAssertEqual(destination.draft(accountID: "account", target: draft.target), draft)
+
+        let partialOnly = makeDraft(threadID: 9, marker: 9)
+        XCTAssertTrue(destination.save(partialOnly))
+        let retry = MigratingContentDraftPersistenceBackend(
+            source: source,
+            destination: destination,
+            stateFile: stateFile
+        )
+        let retryOutcome = await retry.loadAsync(
+            accountID: "account",
+            target: draft.target
+        )
+        XCTAssertEqual(retryOutcome, .loaded(draft))
+        XCTAssertNil(destination.draft(accountID: "account", target: partialOnly.target))
+        XCTAssertEqual(try stateFile.load()?.activeBackend, .swiftData)
+    }
+
+    @MainActor
+    func testCancelledWaiterDoesNotCancelSharedMigration() async throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.activeFiles)
+        let source = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(source.save(draft))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let gate = MigrationGate()
+        let migrating = MigratingContentDraftPersistenceBackend(
+            source: source,
+            destination: destination,
+            stateFile: stateFile,
+            beforeRecordRead: { _ in try await gate.pause() }
+        )
+
+        let task = Task { @MainActor in
+            await migrating.loadAsync(accountID: "account", target: draft.target)
+        }
+        await gate.waitUntilEntered()
+        task.cancel()
+        await gate.release()
+        let cancelledOutcome = await task.value
+        XCTAssertEqual(cancelledOutcome, .unavailable)
+        XCTAssertEqual(try stateFile.load()?.activeBackend, .swiftData)
+        XCTAssertEqual(destination.draft(accountID: "account", target: draft.target), draft)
+
+        let subsequentOutcome = await migrating.loadAsync(
+            accountID: "account",
+            target: draft.target
+        )
+        XCTAssertEqual(subsequentOutcome, .loaded(draft))
+    }
+
+    @MainActor
+    func testConcurrentResolversSerializeAndSecondDoesNotReplayAfterCommit() async throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.activeFiles)
+        let source = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(source.save(draft))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let firstGate = MigrationGate()
+        let secondReads = InvocationCounter()
+        let first = MigratingContentDraftPersistenceBackend(
+            source: source,
+            destination: destination,
+            stateFile: stateFile,
+            beforeRecordRead: { _ in try await firstGate.pause() }
+        )
+        let second = MigratingContentDraftPersistenceBackend(
+            source: source,
+            destination: destination,
+            stateFile: stateFile,
+            beforeRecordRead: { _ in await secondReads.increment() }
+        )
+
+        let firstTask = Task { @MainActor in
+            await first.loadAsync(accountID: "account", target: draft.target)
+        }
+        await firstGate.waitUntilEntered()
+        let secondTask = Task { @MainActor in
+            await second.loadAsync(accountID: "account", target: draft.target)
+        }
+        await firstGate.release()
+
+        let firstOutcome = await firstTask.value
+        let secondOutcome = await secondTask.value
+        let secondReadCount = await secondReads.count
+        XCTAssertEqual(firstOutcome, .loaded(draft))
+        XCTAssertEqual(secondOutcome, .loaded(draft))
+        XCTAssertEqual(secondReadCount, 0)
+        XCTAssertEqual(try stateFile.load()?.activeBackend, .swiftData)
+    }
+
+    @MainActor
+    func testMissingStateBesideFileCatalogFailsClosedInsteadOfChoosingEitherBackend() throws {
+        let directory = try makeDirectory()
+        let source = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        XCTAssertTrue(source.save(makeDraft(threadID: 1, marker: 1)))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        XCTAssertTrue(destination.save(makeDraft(threadID: 2, marker: 2)))
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )) { error in
+            XCTAssertEqual(error as? ContentDraftPersistenceStateError, .ambiguousBackends)
+        }
+    }
+
+    @MainActor
+    func testCorruptStateFailsClosedBeforeInspectingEitherBackend() throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.activeFiles)
+        try corruptGenerations(stateFile)
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        ))
+    }
+
+    @MainActor
+    func testCorruptFileCatalogWithoutStateCannotFallBackToEmptySwiftData() throws {
+        let directory = try makeDirectory()
+        let catalogURL = directory.appendingPathComponent("content-drafts-catalog.json")
+        try Data("corrupt".utf8).write(to: catalogURL, options: .atomic)
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        ))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(
+                ContentDraftPersistenceFactory.stateFileName
+            ).path
+        ))
+    }
+
+    @MainActor
+    func testCompletedStateWithUnavailableDestinationNeverFallsBackToRetainedSource() throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.migrated(
+            sourceFingerprint: String(repeating: "a", count: 64),
+            generationID: "11111111-1111-1111-1111-111111111111",
+            completedAt: Date(timeIntervalSinceReferenceDate: 1)
+        ))
+        let source = try FileContentDraftPersistenceBackend(directoryURL: directory)
+        let retainedOnly = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(source.save(retainedOnly))
+        let unavailableDestination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer(),
+            persistenceAvailability: .unavailable
+        )
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: unavailableDestination
+        ))
+        XCTAssertEqual(source.draft(accountID: "account", target: retainedOnly.target), retainedOnly)
+    }
+
+    @MainActor
+    func testFreshBootstrapAndLegitimateClearKeepDestinationMarkerAuthoritative() throws {
+        let directory = try makeDirectory()
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(destination.save(draft))
+
+        let resolved = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )
+        XCTAssertEqual(resolved.draft(accountID: "account", target: draft.target), draft)
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        let state = try XCTUnwrap(stateFile.load())
+        XCTAssertEqual(state.activeBackend, .swiftData)
+        XCTAssertEqual(state.migrationStatus, .notRequired)
+        XCTAssertEqual(try destination.backendGenerationID(), state.destinationGenerationID)
+
+        XCTAssertTrue(resolved.clear(accountID: "account"))
+        XCTAssertNil(destination.draft(accountID: "account", target: draft.target))
+        let afterLegitimateClear = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )
+        XCTAssertNil(afterLegitimateClear.draft(accountID: "account", target: draft.target))
+        XCTAssertEqual(try destination.backendGenerationID(), state.destinationGenerationID)
+    }
+
+    @MainActor
+    func testActiveSwiftDataStateFailsClosedWhenDatabaseWasRebuiltWithoutMarker() throws {
+        let directory = try makeDirectory()
+        let original = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        _ = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: original
+        )
+        let rebuilt = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+
+        XCTAssertNil(try rebuilt.backendGenerationID())
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: rebuilt
+        )) { error in
+            XCTAssertEqual(error as? ContentDraftPersistenceError, .destinationMarkerMismatch)
+        }
+    }
+
+    @MainActor
+    func testActiveSwiftDataStateFailsClosedForMarkerGenerationMismatch() throws {
+        let directory = try makeDirectory()
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.initialSwiftData(
+            generationID: "11111111-1111-1111-1111-111111111111"
+        ))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let actualGeneration = UUID().uuidString.lowercased()
+        try destination.installNativeBackendMarker(generationID: actualGeneration)
+        XCTAssertNotEqual(actualGeneration, "11111111-1111-1111-1111-111111111111")
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )) { error in
+            XCTAssertEqual(error as? ContentDraftPersistenceError, .destinationMarkerMismatch)
+        }
+    }
+
+    @MainActor
+    func testNativeActivationPendingRetriesBeforeMarkerWrite() throws {
+        let directory = try makeDirectory()
+        let generationID = "11111111-1111-1111-1111-111111111111"
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.nativeActivationPending(generationID: generationID))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        XCTAssertNil(try destination.backendGenerationID())
+
+        _ = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )
+        XCTAssertEqual(try destination.backendGenerationID(), generationID)
+        let state = try XCTUnwrap(stateFile.load())
+        XCTAssertEqual(state.activeBackend, .swiftData)
+        XCTAssertEqual(state.destinationGenerationID, generationID)
+    }
+
+    @MainActor
+    func testNativeActivationPendingRetriesAfterMarkerWrite() throws {
+        let directory = try makeDirectory()
+        let generationID = "22222222-2222-2222-2222-222222222222"
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.nativeActivationPending(generationID: generationID))
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        try destination.installNativeBackendMarker(generationID: generationID)
+
+        _ = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )
+        let state = try XCTUnwrap(stateFile.load())
+        XCTAssertEqual(state.activeBackend, .swiftData)
+        XCTAssertEqual(state.destinationGenerationID, generationID)
+    }
+
+    @MainActor
+    func testMissingStateWithExistingDestinationMarkerFailsClosed() throws {
+        let directory = try makeDirectory()
+        let destination = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: try makeContainer()
+        )
+        let generationID = "33333333-3333-3333-3333-333333333333"
+        try destination.installNativeBackendMarker(generationID: generationID)
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        try stateFile.replace(.initialSwiftData(generationID: generationID))
+        try FileManager.default.removeItem(at: stateFile.fileURL)
+        try FileManager.default.removeItem(at: stateFile.backupURL)
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: destination
+        )) { error in
+            XCTAssertEqual(error as? ContentDraftPersistenceStateError, .ambiguousBackends)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stateFile.fileURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stateFile.backupURL.path))
+    }
+
+    @MainActor
+    func testTransientSwiftDataFailureOnFirstLaunchDoesNotElectEmptyFileBackend() throws {
+        let directory = try makeDirectory()
+        let container = try makeContainer()
+        let available = SwiftDataContentDraftPersistenceBackend(modelContainer: container)
+        let draft = makeDraft(threadID: 1, marker: 1)
+        XCTAssertTrue(available.save(draft))
+        let transientFallback = SwiftDataContentDraftPersistenceBackend(
+            modelContainer: container,
+            persistenceAvailability: .unavailable
+        )
+
+        XCTAssertThrowsError(try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: transientFallback
+        ))
+        let stateFile = try ContentDraftPersistenceFactory.makeStateFile(
+            directoryURL: directory
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stateFile.fileURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stateFile.backupURL.path))
+
+        let recovered = SwiftDataContentDraftPersistenceBackend(modelContainer: container)
+        let resolved = try ContentDraftPersistenceFactory.resolveIOS17Backend(
+            directoryURL: directory,
+            swiftDataBackend: recovered
+        )
+        XCTAssertEqual(resolved.draft(accountID: "account", target: draft.target), draft)
+        XCTAssertEqual(try stateFile.load()?.activeBackend, .swiftData)
+    }
+}

--- a/TiebaPureTests/ContentDraftTests.swift
+++ b/TiebaPureTests/ContentDraftTests.swift
@@ -2,6 +2,7 @@ import SwiftData
 import XCTest
 @testable import TiebaPure
 
+@available(iOS 17.0, *)
 private enum LegacyContentDraftSchemaV1: VersionedSchema {
     static let versionIdentifier = Schema.Version(1, 0, 0)
 
@@ -46,6 +47,7 @@ private enum LegacyContentDraftSchemaV1: VersionedSchema {
     }
 }
 
+@available(iOS 17.0, *)
 final class ContentDraftTests: XCTestCase {
     private func makeInMemoryModelContainer() throws -> ModelContainer {
         let schema = Schema(AppModelContainer.models)

--- a/TiebaPureTests/FileOrderedCollectionPersistenceTests.swift
+++ b/TiebaPureTests/FileOrderedCollectionPersistenceTests.swift
@@ -1,0 +1,911 @@
+import Foundation
+import XCTest
+@testable import TiebaPure
+
+final class FileOrderedCollectionPersistenceTests: XCTestCase {
+    private enum InjectedFailure: Error {
+        case beforeCommit
+        case swiftDataUnavailable
+    }
+
+    private func makeScratchDirectory(function: String = #function) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(function)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    @MainActor
+    func testAdaptersPersistIndependentOrderedSnapshotsAcrossReopen() throws {
+        let directory = try makeScratchDirectory()
+        let browsingEntries = [
+            makeBrowsingEntry(threadID: 2, visitedAt: 2),
+            makeBrowsingEntry(threadID: 1, visitedAt: 1)
+        ]
+        let recentEntries = [
+            makeRecentForum(name: "second", updatedAt: 2),
+            makeRecentForum(name: "first", updatedAt: 1)
+        ]
+        let searchEntries = ["second", "first"]
+
+        let first = try FileOrderedCollectionPersistenceBundle(directoryURL: directory)
+        try first.browsingHistory.replaceAll(browsingEntries)
+        try first.recentForums.replaceAll(recentEntries)
+        try first.searchHistory.replaceAll(searchEntries)
+
+        let reopened = try FileOrderedCollectionPersistenceBundle(directoryURL: directory)
+        XCTAssertEqual(try reopened.browsingHistory.load(), browsingEntries)
+        XCTAssertEqual(try reopened.recentForums.load(), recentEntries)
+        XCTAssertEqual(try reopened.searchHistory.load(), searchEntries)
+        XCTAssertEqual(
+            Set(try FileManager.default.contentsOfDirectory(atPath: directory.path)),
+            Set([
+                "browsing-history.json",
+                "browsing-history.json.backup",
+                "recent-forums.json",
+                "recent-forums.json.backup",
+                "search-history.json",
+                "search-history.json.backup"
+            ])
+        )
+    }
+
+    @MainActor
+    func testBrowsingHistoryTransactionsAcrossAdaptersDoNotLoseUpdates() async throws {
+        let directory = try makeScratchDirectory()
+        let first = try FileBrowsingHistoryPersistence(directoryURL: directory)
+        let second = try FileBrowsingHistoryPersistence(directoryURL: directory)
+
+        async let firstResult = first.upsert(
+            makeBrowsingEntry(threadID: 1, visitedAt: 1),
+            limit: 10
+        )
+        async let secondResult = second.upsert(
+            makeBrowsingEntry(threadID: 2, visitedAt: 2),
+            limit: 10
+        )
+        _ = try await (firstResult, secondResult)
+
+        XCTAssertEqual(Set(try first.load().map(\.threadID)), Set([Int64(1), Int64(2)]))
+    }
+
+    @MainActor
+    func testCancelledBrowsingMutationDoesNotCommitOrPoisonNextMutation() async throws {
+        let directory = try makeScratchDirectory()
+        let persistence = try FileBrowsingHistoryPersistence(directoryURL: directory)
+        let cancelled = Task {
+            try await persistence.upsert(
+                makeBrowsingEntry(threadID: 1, visitedAt: 1),
+                limit: 10
+            )
+        }
+        cancelled.cancel()
+
+        do {
+            _ = try await cancelled.value
+            XCTFail("Expected cancellation before the atomic commit")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertEqual(try persistence.load(), [])
+
+        let committed = try await persistence.upsert(
+            makeBrowsingEntry(threadID: 2, visitedAt: 2),
+            limit: 10
+        )
+        XCTAssertEqual(committed.map(\.threadID), [2])
+        XCTAssertEqual(try persistence.load().map(\.threadID), [2])
+    }
+
+    @MainActor
+    func testBeforeCommitFailureLeavesPrimaryBytesUnchangedAndNoTemporaryFiles() throws {
+        let directory = try makeScratchDirectory()
+        let persistence = try FileSearchHistoryPersistence(directoryURL: directory)
+        try persistence.replaceAll(["original"])
+        let fileURL = directory.appendingPathComponent("search-history.json")
+        let originalBytes = try Data(contentsOf: fileURL)
+
+        XCTAssertThrowsError(
+            try persistence.replaceAll(["candidate"]) {
+                throw InjectedFailure.beforeCommit
+            }
+        )
+
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalBytes)
+        XCTAssertEqual(try persistence.load(), ["original"])
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: directory.path)
+                .contains(where: { $0.hasSuffix(".tmp") })
+        )
+    }
+
+    @MainActor
+    func testPrimaryCorruptionRecoversLatestGenerationAndClearDoesNotResurrectData() throws {
+        let directory = try makeScratchDirectory()
+        let persistence = try FileSearchHistoryPersistence(directoryURL: directory)
+        let primaryURL = directory.appendingPathComponent("search-history.json")
+
+        try persistence.replaceAll(["first"])
+        try persistence.replaceAll(["latest"])
+        try Data("truncated".utf8).write(to: primaryURL)
+        XCTAssertEqual(try persistence.load(), ["latest"])
+
+        try persistence.replaceAll([])
+        try Data("truncated-again".utf8).write(to: primaryURL)
+        XCTAssertEqual(try persistence.load(), [])
+    }
+
+    @MainActor
+    func testDoubleCorruptionFailsClosedUntilExplicitRecovery() throws {
+        let directory = try makeScratchDirectory()
+        let persistence = try FileSearchHistoryPersistence(directoryURL: directory)
+        let secondInstance = try FileSearchHistoryPersistence(directoryURL: directory)
+        try persistence.replaceAll(["protected"])
+
+        let primaryURL = directory.appendingPathComponent("search-history.json")
+        let backupURL = directory.appendingPathComponent("search-history.json.backup")
+        try Data("bad-primary".utf8).write(to: primaryURL)
+        try Data("bad-backup".utf8).write(to: backupURL)
+
+        XCTAssertThrowsError(try persistence.load())
+        XCTAssertThrowsError(try secondInstance.replaceAll(["must-not-overwrite-corruption"]))
+        XCTAssertEqual(try Data(contentsOf: primaryURL), Data("bad-primary".utf8))
+
+        try secondInstance.recoverCorruptedStorage()
+        try persistence.replaceAll(["recovered"])
+        XCTAssertEqual(try persistence.load(), ["recovered"])
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: directory.path)
+                .filter { $0.contains(".corrupt-") }.count,
+            2
+        )
+    }
+
+    @MainActor
+    func testFilesUsePrivatePermissionsAndCompleteProtection() throws {
+        let directory = try makeScratchDirectory()
+        let persistence = try FileSearchHistoryPersistence(directoryURL: directory)
+        try persistence.replaceAll(["private"])
+
+        let fileURL = directory.appendingPathComponent("search-history.json")
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let directoryAttributes = try FileManager.default.attributesOfItem(atPath: directory.path)
+        let fileMode = try XCTUnwrap(fileAttributes[.posixPermissions] as? NSNumber).intValue
+        let directoryMode = try XCTUnwrap(
+            directoryAttributes[.posixPermissions] as? NSNumber
+        ).intValue
+
+        XCTAssertEqual(fileMode & 0o777, 0o600)
+        XCTAssertEqual(directoryMode & 0o777, 0o700)
+        // CoreSimulator does not expose NSFileProtectionKey on every host
+        // filesystem. Verify it whenever the filesystem reports support.
+        if let protection = fileAttributes[.protectionKey] as? FileProtectionType {
+            XCTAssertEqual(protection, .complete)
+        }
+    }
+
+    func testApplicationPersistenceLocationHardensEveryOwnedDirectory() throws {
+        let applicationSupport = try makeScratchDirectory()
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o755))],
+            ofItemAtPath: applicationSupport.path
+        )
+        let preexisting = applicationSupport.appendingPathComponent(
+            "TiebaPure",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: preexisting, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o755))],
+            ofItemAtPath: preexisting.path
+        )
+
+        let location = try SecurePersistenceLocation.applicationSupport(
+            baseDirectoryURL: applicationSupport
+        )
+
+        let ownedDirectories = [
+            preexisting,
+            preexisting.appendingPathComponent("Persistence", isDirectory: true),
+            location.directoryURL
+        ]
+        for directory in ownedDirectories {
+            let attributes = try FileManager.default.attributesOfItem(atPath: directory.path)
+            let mode = try XCTUnwrap(
+                attributes[.posixPermissions] as? NSNumber
+            ).intValue
+            XCTAssertEqual(mode & 0o777, 0o700)
+            if let protection = attributes[.protectionKey] as? FileProtectionType {
+                XCTAssertEqual(protection, .complete)
+            }
+        }
+        let rootAttributes = try FileManager.default.attributesOfItem(
+            atPath: applicationSupport.path
+        )
+        let rootMode = try XCTUnwrap(
+            rootAttributes[.posixPermissions] as? NSNumber
+        ).intValue
+        XCTAssertEqual(rootMode & 0o777, 0o755)
+    }
+
+    func testApplicationPersistenceLocationRejectsIntermediateSymbolicLink() throws {
+        let applicationSupport = try makeScratchDirectory(function: "root")
+        let outside = try makeScratchDirectory(function: "outside")
+        let linked = applicationSupport.appendingPathComponent("TiebaPure", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: linked,
+            withDestinationURL: outside
+        )
+
+        XCTAssertThrowsError(try SecurePersistenceLocation.applicationSupport(
+            baseDirectoryURL: applicationSupport
+        )) { error in
+            XCTAssertEqual(error as? SecureFilePersistenceError, .pathIsSymbolicLink)
+        }
+        XCTAssertTrue(
+            try FileManager.default.contentsOfDirectory(atPath: outside.path).isEmpty
+        )
+    }
+
+    func testMissingFileIsEmptyButOversizedAndSymbolicLinkFilesFailClosed() throws {
+        let missingDirectory = try makeScratchDirectory(function: "missing")
+        let missing = try SecureCodableFile<[String]>(
+            directoryURL: missingDirectory,
+            fileName: "values.json"
+        )
+        XCTAssertNil(try missing.load())
+
+        let oversizedDirectory = try makeScratchDirectory(function: "oversized")
+        let oversized = try SecureCodableFile<[String]>(
+            directoryURL: oversizedDirectory,
+            fileName: "values.json",
+            maximumByteCount: 32
+        )
+        try Data(repeating: 0x41, count: 64).write(to: oversized.fileURL)
+        try Data(repeating: 0x42, count: 64).write(to: oversized.backupURL)
+        XCTAssertThrowsError(try oversized.load())
+        XCTAssertThrowsError(try oversized.replace(["must-not-overwrite"]))
+
+        let symlinkDirectory = try makeScratchDirectory(function: "symlink")
+        let outsideURL = symlinkDirectory.appendingPathComponent("outside.json")
+        try Data("outside".utf8).write(to: outsideURL)
+        let linkURL = symlinkDirectory.appendingPathComponent("values.json")
+        try FileManager.default.createSymbolicLink(
+            at: linkURL,
+            withDestinationURL: outsideURL
+        )
+        let linked = try SecureCodableFile<[String]>(
+            directoryURL: symlinkDirectory,
+            fileName: "values.json"
+        )
+        XCTAssertThrowsError(try linked.load()) { error in
+            XCTAssertEqual(error as? SecureFilePersistenceError, .pathIsSymbolicLink)
+        }
+        XCTAssertEqual(try Data(contentsOf: outsideURL), Data("outside".utf8))
+    }
+
+    @MainActor
+    func testFactoryMigratesFileBackendWithReceiptAndKeepsSourceSnapshot() throws {
+        let sourceDirectory = try makeScratchDirectory(function: "source")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let completedAt = Date(timeIntervalSinceReferenceDate: 123)
+        let marker = TestOrderedCollectionBackendMarkerPersistence()
+
+        let iOS16Bundle = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: false
+        ) {
+            throw InjectedFailure.swiftDataUnavailable
+        }.make()
+        let sourceSnapshot = makeSnapshot()
+        try iOS16Bundle.replaceAll(with: sourceSnapshot)
+
+        let migrated = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: true,
+            now: { completedAt }
+        ) {
+            try self.makeDestinationBundle(
+                directoryURL: destinationDirectory,
+                marker: marker
+            )
+        }.make()
+
+        XCTAssertEqual(try migrated.snapshot(), sourceSnapshot)
+        XCTAssertEqual(
+            try FileOrderedCollectionPersistenceBundle(
+                directoryURL: sourceDirectory
+            ).erased.snapshot(),
+            sourceSnapshot
+        )
+
+        let manifest = try loadManifest(from: sourceDirectory)
+        XCTAssertEqual(manifest.activeBackend, .swiftData)
+        XCTAssertEqual(manifest.migrationState, .fileToSwiftDataCompleted)
+        XCTAssertEqual(manifest.migrationReceipt?.completedAt, completedAt)
+        XCTAssertEqual(manifest.destinationGeneration, marker.generation)
+        XCTAssertFalse(try XCTUnwrap(marker.generation).isEmpty)
+        XCTAssertEqual(
+            manifest.migrationReceipt?.sourceFingerprint,
+            try sourceSnapshot.fingerprint()
+        )
+    }
+
+    @MainActor
+    func testMissingManifestWithFileArtifactsFailsClosedWithoutOpeningDestination() throws {
+        let sourceDirectory = try makeScratchDirectory(function: "source")
+        let sourceSnapshot = makeSnapshot()
+        let unmanifestedFiles = try FileOrderedCollectionPersistenceBundle(
+            directoryURL: sourceDirectory
+        ).erased
+        try unmanifestedFiles.replaceAll(with: sourceSnapshot)
+        var destinationBuilderCallCount = 0
+
+        let resolved = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: true
+        ) {
+            destinationBuilderCallCount += 1
+            throw InjectedFailure.swiftDataUnavailable
+        }.make()
+
+        XCTAssertEqual(resolved.browsingHistory.capability, .unavailable)
+        XCTAssertEqual(resolved.recentForums.capability, .unavailable)
+        XCTAssertEqual(resolved.searchHistory.capability, .unavailable)
+        XCTAssertEqual(destinationBuilderCallCount, 0)
+        XCTAssertEqual(try unmanifestedFiles.snapshot(), sourceSnapshot)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: sourceDirectory
+                .appendingPathComponent("ordered-collections-manifest.json")
+                .path
+        ))
+    }
+
+    @MainActor
+    func testMissingManifestWithExistingDestinationMarkerFailsClosed() throws {
+        let stateDirectory = try makeScratchDirectory(function: "state")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let marker = TestOrderedCollectionBackendMarkerPersistence()
+        let destination = try makeDestinationBundle(
+            directoryURL: destinationDirectory,
+            marker: marker
+        )
+        try destination.replaceAll(with: makeSnapshot())
+
+        _ = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) {
+            destination
+        }.make()
+        let expectedDestination = try destination.snapshot()
+
+        let manifest = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+            directoryURL: stateDirectory,
+            fileName: "ordered-collections-manifest.json"
+        )
+        try FileManager.default.removeItem(at: manifest.fileURL)
+        try FileManager.default.removeItem(at: manifest.backupURL)
+
+        let unresolved = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) {
+            destination
+        }.make()
+
+        XCTAssertEqual(unresolved.browsingHistory.capability, .unavailable)
+        XCTAssertEqual(try destination.snapshot(), expectedDestination)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: manifest.fileURL.path))
+        XCTAssertNotNil(marker.generation)
+    }
+
+    @MainActor
+    func testInitialSwiftDataFallbackDoesNotCommitBackendManifest() throws {
+        let directory = try makeScratchDirectory()
+        let fallback = OrderedCollectionPersistenceBundle(
+            browsingHistory: FallbackTestBrowsingPersistence(),
+            recentForums: FallbackTestRecentPersistence(),
+            searchHistory: FallbackTestSearchPersistence()
+        )
+
+        let resolved = OrderedCollectionPersistenceFactory(
+            directoryURL: directory,
+            supportsSwiftData: true
+        ) {
+            fallback
+        }.make()
+
+        XCTAssertEqual(resolved.browsingHistory.capability, .fallback)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: directory
+                    .appendingPathComponent("ordered-collections-manifest.json")
+                    .path
+            )
+        )
+    }
+
+    @MainActor
+    func testNativeSwiftDataActivationPreservesExistingRowsAndCommitsMarker() throws {
+        let stateDirectory = try makeScratchDirectory(function: "state")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let marker = TestOrderedCollectionBackendMarkerPersistence()
+        let destination = try makeDestinationBundle(
+            directoryURL: destinationDirectory,
+            marker: marker
+        )
+        let existing = makeSnapshot()
+        try destination.replaceAll(with: existing)
+
+        let resolved = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertEqual(try resolved.snapshot(), existing)
+        let manifest = try loadManifest(from: stateDirectory)
+        XCTAssertEqual(manifest.activeBackend, .swiftData)
+        XCTAssertEqual(manifest.migrationState, .notRequired)
+        XCTAssertEqual(manifest.destinationGeneration, marker.generation)
+        XCTAssertEqual(marker.replaceCallCount, 1)
+    }
+
+    @MainActor
+    func testPendingNativeActivationRetriesTheSpecifiedGeneration() throws {
+        let stateDirectory = try makeScratchDirectory(function: "state")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let marker = TestOrderedCollectionBackendMarkerPersistence()
+        marker.replaceError = InjectedFailure.beforeCommit
+        let destination = try makeDestinationBundle(
+            directoryURL: destinationDirectory,
+            marker: marker
+        )
+
+        let first = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { destination }.make()
+        XCTAssertEqual(first.browsingHistory.capability, .unavailable)
+        let pending = try loadManifest(from: stateDirectory)
+        XCTAssertEqual(pending.migrationState, .swiftDataActivationPending)
+        let pendingGeneration = try XCTUnwrap(pending.destinationGeneration)
+        XCTAssertNil(marker.generation)
+
+        marker.replaceError = nil
+        let retried = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertEqual(retried.browsingHistory.capability, .durable)
+        XCTAssertEqual(marker.generation, pendingGeneration)
+        let active = try loadManifest(from: stateDirectory)
+        XCTAssertEqual(active.migrationState, .notRequired)
+        XCTAssertEqual(active.destinationGeneration, pendingGeneration)
+    }
+
+    @MainActor
+    func testPendingActivationWithMatchingMarkerOnlyFinishesManifestCommit() throws {
+        let stateDirectory = try makeScratchDirectory(function: "state")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let generation = "11111111-1111-1111-1111-111111111111"
+        let marker = TestOrderedCollectionBackendMarkerPersistence(generation: generation)
+        let destination = try makeDestinationBundle(
+            directoryURL: destinationDirectory,
+            marker: marker
+        )
+        let manifest = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+            directoryURL: stateDirectory,
+            fileName: "ordered-collections-manifest.json"
+        )
+        try manifest.replace(.pendingSwiftDataActivation(
+            destinationGeneration: generation
+        ))
+
+        let resolved = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertEqual(resolved.browsingHistory.capability, .durable)
+        XCTAssertEqual(marker.replaceCallCount, 0)
+        XCTAssertEqual(try loadManifest(from: stateDirectory).migrationState, .notRequired)
+    }
+
+    @MainActor
+    func testActiveSwiftDataFailsClosedAfterDatabaseRebuildLosesMarker() throws {
+        let stateDirectory = try makeScratchDirectory(function: "state")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let expectedGeneration = "22222222-2222-2222-2222-222222222222"
+        let manifest = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+            directoryURL: stateDirectory,
+            fileName: "ordered-collections-manifest.json"
+        )
+        try manifest.replace(.initialSwiftDataBackend(
+            destinationGeneration: expectedGeneration
+        ))
+        let rebuiltMarker = TestOrderedCollectionBackendMarkerPersistence()
+        let rebuiltDestination = try makeDestinationBundle(
+            directoryURL: destinationDirectory,
+            marker: rebuiltMarker
+        )
+
+        let resolved = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { rebuiltDestination }.make()
+
+        XCTAssertEqual(resolved.browsingHistory.capability, .unavailable)
+        XCTAssertNil(rebuiltMarker.generation)
+        XCTAssertEqual(rebuiltMarker.replaceCallCount, 0)
+    }
+
+    @MainActor
+    func testActiveAndPendingSwiftDataRejectMarkerGenerationMismatch() throws {
+        for migrationState in [
+            OrderedCollectionMigrationState.notRequired,
+            .swiftDataActivationPending
+        ] {
+            let stateDirectory = try makeScratchDirectory(function: "state-\(migrationState.rawValue)")
+            let destinationDirectory = try makeScratchDirectory(
+                function: "destination-\(migrationState.rawValue)"
+            )
+            let expectedGeneration = "33333333-3333-3333-3333-333333333333"
+            let manifest = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+                directoryURL: stateDirectory,
+                fileName: "ordered-collections-manifest.json"
+            )
+            let state: OrderedCollectionPersistenceManifest = migrationState == .notRequired
+                ? .initialSwiftDataBackend(destinationGeneration: expectedGeneration)
+                : .pendingSwiftDataActivation(destinationGeneration: expectedGeneration)
+            try manifest.replace(state)
+            let marker = TestOrderedCollectionBackendMarkerPersistence(
+                generation: "44444444-4444-4444-4444-444444444444"
+            )
+            let destination = try makeDestinationBundle(
+                directoryURL: destinationDirectory,
+                marker: marker
+            )
+
+            let resolved = OrderedCollectionPersistenceFactory(
+                directoryURL: stateDirectory,
+                supportsSwiftData: true
+            ) { destination }.make()
+
+            XCTAssertEqual(resolved.browsingHistory.capability, .unavailable)
+            XCTAssertEqual(marker.generation, "44444444-4444-4444-4444-444444444444")
+            XCTAssertEqual(marker.replaceCallCount, 0)
+        }
+    }
+
+    @MainActor
+    func testLegitimateClearKeepsMarkerAndReopensEmptySwiftData() throws {
+        let stateDirectory = try makeScratchDirectory(function: "state")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let marker = TestOrderedCollectionBackendMarkerPersistence()
+        let destination = try makeDestinationBundle(
+            directoryURL: destinationDirectory,
+            marker: marker
+        )
+        try destination.replaceAll(with: makeSnapshot())
+        _ = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { destination }.make()
+        let generation = try XCTUnwrap(marker.generation)
+
+        try destination.replaceAll(with: OrderedCollectionPersistenceSnapshot(
+            browsingHistory: [],
+            recentForums: [],
+            searchHistory: []
+        ))
+        let reopened = OrderedCollectionPersistenceFactory(
+            directoryURL: stateDirectory,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertTrue(try reopened.snapshot().isEmpty)
+        XCTAssertEqual(marker.generation, generation)
+        XCTAssertEqual(marker.replaceCallCount, 1)
+    }
+
+    @MainActor
+    func testFileMigrationRechecksSourceAndRetriesPartialDestination() throws {
+        let sourceDirectory = try makeScratchDirectory(function: "source")
+        let destinationDirectory = try makeScratchDirectory(function: "destination")
+        let source = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: false
+        ) { throw InjectedFailure.swiftDataUnavailable }.make()
+        try source.replaceAll(with: makeSnapshot())
+        let marker = TestOrderedCollectionBackendMarkerPersistence()
+        marker.onReplace = { _ in
+            try source.searchHistory.replaceAll(["source-changed-during-migration"])
+        }
+
+        let first = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: true
+        ) {
+            try self.makeDestinationBundle(
+                directoryURL: destinationDirectory,
+                marker: marker
+            )
+        }.make()
+
+        XCTAssertEqual(try first.searchHistory.load(), ["source-changed-during-migration"])
+        XCTAssertEqual(try loadManifest(from: sourceDirectory).activeBackend, .secureFiles)
+        XCTAssertNotNil(marker.generation)
+
+        marker.onReplace = nil
+        let retried = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: true
+        ) {
+            try self.makeDestinationBundle(
+                directoryURL: destinationDirectory,
+                marker: marker
+            )
+        }.make()
+
+        XCTAssertEqual(try retried.searchHistory.load(), ["source-changed-during-migration"])
+        let active = try loadManifest(from: sourceDirectory)
+        XCTAssertEqual(active.activeBackend, .swiftData)
+        XCTAssertEqual(active.destinationGeneration, marker.generation)
+    }
+
+    @MainActor
+    func testCommittedSwiftDataBackendFailsClosedWhenOnlyFallbackOpens() throws {
+        let directory = try makeScratchDirectory()
+        let manifest = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+            directoryURL: directory,
+            fileName: "ordered-collections-manifest.json"
+        )
+        try manifest.replace(.initialSwiftDataBackend(
+            destinationGeneration: "55555555-5555-5555-5555-555555555555"
+        ))
+        let fallback = OrderedCollectionPersistenceBundle(
+            browsingHistory: FallbackTestBrowsingPersistence(),
+            recentForums: FallbackTestRecentPersistence(),
+            searchHistory: FallbackTestSearchPersistence()
+        )
+
+        let resolved = OrderedCollectionPersistenceFactory(
+            directoryURL: directory,
+            supportsSwiftData: true
+        ) { fallback }.make()
+
+        XCTAssertEqual(resolved.browsingHistory.capability, .unavailable)
+        XCTAssertEqual(resolved.recentForums.capability, .unavailable)
+        XCTAssertEqual(resolved.searchHistory.capability, .unavailable)
+    }
+
+    @MainActor
+    func testMigrationFailureKeepsFileBackendEligibleForRetry() throws {
+        let sourceDirectory = try makeScratchDirectory(function: "source")
+        let source = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: false
+        ) {
+            throw InjectedFailure.swiftDataUnavailable
+        }.make()
+        let sourceSnapshot = makeSnapshot()
+        try source.replaceAll(with: sourceSnapshot)
+
+        let failed = OrderedCollectionPersistenceFactory(
+            directoryURL: sourceDirectory,
+            supportsSwiftData: true
+        ) {
+            OrderedCollectionPersistenceBundle(
+                browsingHistory: UnavailableTestBrowsingPersistence(),
+                recentForums: UnavailableTestRecentPersistence(),
+                searchHistory: UnavailableTestSearchPersistence()
+            )
+        }.make()
+
+        XCTAssertEqual(try failed.snapshot(), sourceSnapshot)
+        let manifest = try loadManifest(from: sourceDirectory)
+        XCTAssertEqual(manifest.activeBackend, .secureFiles)
+        XCTAssertEqual(manifest.migrationState, .fileToSwiftDataEligible)
+        XCTAssertNil(manifest.migrationReceipt)
+    }
+
+    @MainActor
+    func testCorruptManifestReturnsUnavailableWithoutSelectingAnotherBackend() throws {
+        let directory = try makeScratchDirectory()
+        let manifestFile = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+            directoryURL: directory,
+            fileName: "ordered-collections-manifest.json"
+        )
+        try manifestFile.replace(.initialFileBackend())
+        try Data("bad-primary".utf8).write(to: manifestFile.fileURL)
+        try Data("bad-backup".utf8).write(to: manifestFile.backupURL)
+        var swiftDataBuilderCallCount = 0
+
+        let bundle = OrderedCollectionPersistenceFactory(
+            directoryURL: directory,
+            supportsSwiftData: true
+        ) {
+            swiftDataBuilderCallCount += 1
+            throw InjectedFailure.swiftDataUnavailable
+        }.make()
+
+        XCTAssertEqual(bundle.browsingHistory.capability, .unavailable)
+        XCTAssertEqual(bundle.recentForums.capability, .unavailable)
+        XCTAssertEqual(bundle.searchHistory.capability, .unavailable)
+        XCTAssertEqual(swiftDataBuilderCallCount, 0)
+    }
+
+    @MainActor
+    private func loadManifest(
+        from directory: URL
+    ) throws -> OrderedCollectionPersistenceManifest {
+        let file = try SecureCodableFile<OrderedCollectionPersistenceManifest>(
+            directoryURL: directory,
+            fileName: "ordered-collections-manifest.json"
+        )
+        return try XCTUnwrap(file.load())
+    }
+
+    @MainActor
+    private func makeDestinationBundle(
+        directoryURL: URL,
+        marker: TestOrderedCollectionBackendMarkerPersistence
+    ) throws -> OrderedCollectionPersistenceBundle {
+        let files = try FileOrderedCollectionPersistenceBundle(directoryURL: directoryURL)
+        return OrderedCollectionPersistenceBundle(
+            browsingHistory: files.browsingHistory,
+            recentForums: files.recentForums,
+            searchHistory: files.searchHistory,
+            backendMarker: marker
+        )
+    }
+
+    private func makeSnapshot() -> OrderedCollectionPersistenceSnapshot {
+        OrderedCollectionPersistenceSnapshot(
+            browsingHistory: [makeBrowsingEntry(threadID: 1, visitedAt: 1)],
+            recentForums: [makeRecentForum(name: "forum", updatedAt: 1)],
+            searchHistory: ["keyword"]
+        )
+    }
+
+    private func makeBrowsingEntry(
+        threadID: Int64,
+        visitedAt: TimeInterval
+    ) -> BrowsingHistoryEntry {
+        BrowsingHistoryEntry(
+            threadID: threadID,
+            title: "thread-\(threadID)",
+            authorDisplayName: "author-\(threadID)",
+            visitedAt: Date(timeIntervalSinceReferenceDate: visitedAt)
+        )
+    }
+
+    private func makeRecentForum(
+        name: String,
+        updatedAt: TimeInterval
+    ) -> RecentForum {
+        RecentForum(
+            name: name,
+            displayName: "\(name)吧",
+            updatedAt: Date(timeIntervalSinceReferenceDate: updatedAt)
+        )
+    }
+}
+
+@MainActor
+private final class UnavailableTestBrowsingPersistence: BrowsingHistoryPersistence {
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [BrowsingHistoryEntry] { [] }
+    func replaceAll(
+        _ entries: [BrowsingHistoryEntry],
+        beforeCommit: () throws -> Void
+    ) throws {}
+    func upsert(
+        _ entry: BrowsingHistoryEntry,
+        limit: Int
+    ) async throws -> [BrowsingHistoryEntry] { [] }
+    func remove(threadIDs: Set<Int64>) async throws -> [BrowsingHistoryEntry] { [] }
+    func removeAll() async throws -> [BrowsingHistoryEntry] { [] }
+}
+
+@MainActor
+private final class UnavailableTestRecentPersistence: RecentForumPersistence {
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [RecentForum] { [] }
+    func replaceAll(
+        _ entries: [RecentForum],
+        beforeCommit: () throws -> Void
+    ) throws {}
+}
+
+@MainActor
+private final class UnavailableTestSearchPersistence: SearchHistoryPersistence {
+    let capability: PersistenceCapability = .unavailable
+
+    func load() throws -> [String] { [] }
+    func replaceAll(
+        _ entries: [String],
+        beforeCommit: () throws -> Void
+    ) throws {}
+}
+
+@MainActor
+private final class FallbackTestBrowsingPersistence: BrowsingHistoryPersistence {
+    let capability: PersistenceCapability = .fallback
+
+    func load() throws -> [BrowsingHistoryEntry] { [] }
+    func replaceAll(
+        _ entries: [BrowsingHistoryEntry],
+        beforeCommit: () throws -> Void
+    ) throws {}
+    func upsert(
+        _ entry: BrowsingHistoryEntry,
+        limit: Int
+    ) async throws -> [BrowsingHistoryEntry] { [] }
+    func remove(threadIDs: Set<Int64>) async throws -> [BrowsingHistoryEntry] { [] }
+    func removeAll() async throws -> [BrowsingHistoryEntry] { [] }
+}
+
+@MainActor
+private final class FallbackTestRecentPersistence: RecentForumPersistence {
+    let capability: PersistenceCapability = .fallback
+
+    func load() throws -> [RecentForum] { [] }
+    func replaceAll(
+        _ entries: [RecentForum],
+        beforeCommit: () throws -> Void
+    ) throws {}
+}
+
+@MainActor
+private final class FallbackTestSearchPersistence: SearchHistoryPersistence {
+    let capability: PersistenceCapability = .fallback
+
+    func load() throws -> [String] { [] }
+    func replaceAll(
+        _ entries: [String],
+        beforeCommit: () throws -> Void
+    ) throws {}
+}
+
+@MainActor
+private final class TestOrderedCollectionBackendMarkerPersistence:
+    OrderedCollectionBackendMarkerPersistence
+{
+    let capability: PersistenceCapability
+    var generation: String?
+    var replaceError: Error?
+    var onReplace: ((String) throws -> Void)?
+    private(set) var replaceCallCount = 0
+
+    init(
+        capability: PersistenceCapability = .durable,
+        generation: String? = nil
+    ) {
+        self.capability = capability
+        self.generation = generation
+    }
+
+    func loadGeneration() throws -> String? {
+        generation
+    }
+
+    func replaceGeneration(_ generation: String) throws {
+        if let replaceError {
+            throw replaceError
+        }
+        self.generation = generation
+        replaceCallCount += 1
+        try onReplace?(generation)
+    }
+}

--- a/TiebaPureTests/StateRegressionTests.swift
+++ b/TiebaPureTests/StateRegressionTests.swift
@@ -3,6 +3,7 @@ import SwiftData
 import XCTest
 @testable import TiebaPure
 
+@available(iOS 17.0, *)
 final class StateRegressionTests: XCTestCase {
     private enum ExpectedPersistenceError: Error {
         case writeFailed
@@ -1903,5 +1904,439 @@ final class StateRegressionTests: XCTestCase {
             ),
             .descending
         )
+    }
+}
+
+final class LocalThreadLibraryPersistenceTests: XCTestCase {
+    private enum ExpectedError: Error {
+        case replaceFailed
+    }
+
+    @MainActor
+    func testFileBackendPersistsMutationsAcrossInstances() throws {
+        let fileURL = makeTemporaryFileURL()
+        let first = try FileThreadReadingPositionPersistence(fileURL: fileURL)
+        let older = makePosition(threadID: 1, postID: 101, floor: 1, updatedAt: 1)
+        let newer = makePosition(threadID: 2, postID: 202, floor: 2, updatedAt: 2)
+
+        try first.replaceAll([older])
+        try first.upsert(newer, limit: 10)
+
+        let reopened = try FileThreadReadingPositionPersistence(fileURL: fileURL)
+        XCTAssertEqual(try reopened.load().map(\.threadID), [2, 1])
+        XCTAssertEqual(try reopened.load().first?.postID, 202)
+
+        try reopened.remove(threadID: 2)
+        XCTAssertEqual(try first.load(), [older])
+        try reopened.removeAll()
+        XCTAssertEqual(try first.load(), [])
+        XCTAssertTrue(reopened.hasStateArtifacts)
+    }
+
+    @MainActor
+    func testStoreUsesInjectedFileBackendAndMigratesLegacyDefaults() throws {
+        let fileURL = makeTemporaryFileURL()
+        let defaults = try makeScratchDefaults()
+        let legacyKey = "file-reading-positions"
+        let favoritesKey = "retired-file-favorites"
+        let legacy = [
+            makePosition(threadID: 1, postID: 101, floor: 1, updatedAt: 1),
+            makePosition(threadID: 2, postID: 202, floor: 2, updatedAt: 2)
+        ]
+        defaults.set(try JSONEncoder().encode(legacy), forKey: legacyKey)
+        defaults.set(Data("retired".utf8), forKey: favoritesKey)
+        let persistence = try FileThreadReadingPositionPersistence(fileURL: fileURL)
+
+        let store = LocalThreadLibraryStore(
+            defaults: defaults,
+            favoritesKey: favoritesKey,
+            readingPositionsKey: legacyKey,
+            readingPositionLimit: 2,
+            persistence: persistence,
+            now: { Date(timeIntervalSinceReferenceDate: 3) }
+        )
+
+        XCTAssertEqual(store.readingPositions.map(\.threadID), [2, 1])
+        XCTAssertNil(defaults.object(forKey: legacyKey))
+        XCTAssertNil(defaults.object(forKey: favoritesKey))
+        XCTAssertTrue(store.recordReadingPosition(threadID: 3, postID: 303, floor: 3))
+
+        let reopened = LocalThreadLibraryStore(
+            defaults: defaults,
+            favoritesKey: favoritesKey,
+            readingPositionsKey: legacyKey,
+            readingPositionLimit: 2,
+            persistence: try FileThreadReadingPositionPersistence(fileURL: fileURL)
+        )
+        XCTAssertEqual(reopened.readingPositions.map(\.threadID), [3, 2])
+        XCTAssertEqual(reopened.persistenceAvailability, .available)
+    }
+
+    @MainActor
+    func testFileToDestinationMigrationTreatsActiveFileAsAuthority() throws {
+        let fileURL = makeTemporaryFileURL()
+        let source = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: false
+        ) {
+            throw ExpectedError.replaceFailed
+        }.make()
+        let fileValues = [
+            makePosition(threadID: 1, postID: 105, floor: 5, updatedAt: 5),
+            makePosition(threadID: 2, postID: 202, floor: 2, updatedAt: 2)
+        ]
+        try source.replaceAll(fileValues)
+        let destination = TestThreadReadingPositionPersistence(values: [
+            makePosition(threadID: 1, postID: 101, floor: 1, updatedAt: 1),
+            makePosition(threadID: 1, postID: 100, floor: 0, updatedAt: 0),
+            makePosition(threadID: 3, postID: 303, floor: 3, updatedAt: 3),
+            makePosition(threadID: 3, postID: 304, floor: 4, updatedAt: 4)
+        ])
+
+        let migrated = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true,
+            now: { Date(timeIntervalSinceReferenceDate: 10) }
+        ) { destination }.make()
+
+        XCTAssertTrue(migrated === destination)
+        XCTAssertEqual(destination.values.map(\.threadID), [1, 2])
+        XCTAssertEqual(destination.values.first?.postID, 105)
+        let retainedFile = try FileThreadReadingPositionPersistence(fileURL: fileURL)
+        let state = try XCTUnwrap(retainedFile.loadBackendState())
+        XCTAssertEqual(state.activeBackend, .swiftData)
+        XCTAssertEqual(state.migrationState, .fileMigrationCompleted)
+        XCTAssertEqual(state.retainedFilePositions, fileValues)
+        XCTAssertEqual(state.activation?.completedAt, Date(timeIntervalSinceReferenceDate: 10))
+
+        let reopened = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+        XCTAssertTrue(reopened === destination)
+        XCTAssertEqual(destination.replaceCallCount, 1)
+    }
+
+    @MainActor
+    func testNativeActivationPendingResumesWithItsOriginalGeneration() throws {
+        let fileURL = makeTemporaryFileURL()
+        let file = try FileThreadReadingPositionPersistence(fileURL: fileURL)
+        let generationID = "11111111-1111-1111-1111-111111111111"
+        let pendingState = try file.prepareNativeSwiftDataActivation(
+            generationID: generationID,
+            now: Date(timeIntervalSinceReferenceDate: 1)
+        )
+        XCTAssertEqual(pendingState.migrationState, .nativeActivationPending)
+        let destination = TestThreadReadingPositionPersistence()
+
+        let resolved = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true,
+            now: { Date(timeIntervalSinceReferenceDate: 2) }
+        ) { destination }.make()
+
+        XCTAssertTrue(resolved === destination)
+        XCTAssertEqual(destination.generationID, generationID)
+        let completedState = try XCTUnwrap(file.loadBackendState())
+        XCTAssertEqual(completedState.migrationState, .nativeSwiftData)
+        XCTAssertEqual(completedState.activation?.destinationGenerationID, generationID)
+    }
+
+    @MainActor
+    func testMissingStateWithExistingDestinationMarkerFailsClosed() throws {
+        let fileURL = makeTemporaryFileURL()
+        let destination = TestThreadReadingPositionPersistence()
+        destination.generationID = "11111111-1111-1111-1111-111111111111"
+
+        let resolved = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertEqual(resolved.capability, .unavailable)
+        XCTAssertThrowsError(try resolved.load())
+        XCTAssertNil(
+            try FileThreadReadingPositionPersistence(fileURL: fileURL).loadBackendState()
+        )
+    }
+
+    @MainActor
+    func testFileMigrationKeepsSourceWhenDestinationCommitFails() throws {
+        let fileURL = makeTemporaryFileURL()
+        let source = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: false
+        ) { throw ExpectedError.replaceFailed }.make()
+        let sourceValues = [
+            makePosition(threadID: 7, postID: 707, floor: 7, updatedAt: 7)
+        ]
+        try source.replaceAll(sourceValues)
+        let destination = TestThreadReadingPositionPersistence()
+        destination.replaceError = ExpectedError.replaceFailed
+
+        let resolved = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertFalse(resolved === destination)
+        XCTAssertEqual(try resolved.load(), sourceValues)
+        let state = try XCTUnwrap(
+            try FileThreadReadingPositionPersistence(fileURL: fileURL).loadBackendState()
+        )
+        XCTAssertEqual(state.activeBackend, .secureFiles)
+        XCTAssertTrue(destination.values.isEmpty)
+    }
+
+    @MainActor
+    func testFileMigrationDoesNotWriteReceiptWhenReadbackDiffers() throws {
+        let fileURL = makeTemporaryFileURL()
+        let source = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: false
+        ) { throw ExpectedError.replaceFailed }.make()
+        try source.replaceAll([
+            makePosition(threadID: 4, postID: 404, floor: 4, updatedAt: 4)
+        ])
+        let destination = TestThreadReadingPositionPersistence()
+        destination.corruptReadbackAfterReplace = true
+
+        let resolved = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertFalse(resolved === destination)
+        XCTAssertEqual(try resolved.load().map(\.threadID), [4])
+        let state = try XCTUnwrap(
+            try FileThreadReadingPositionPersistence(fileURL: fileURL).loadBackendState()
+        )
+        XCTAssertEqual(state.activeBackend, .secureFiles)
+    }
+
+    @MainActor
+    func testFileMigrationDefersWhenDestinationIsNotDurable() throws {
+        let fileURL = makeTemporaryFileURL()
+        let source = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: false
+        ) { throw ExpectedError.replaceFailed }.make()
+        try source.replaceAll([
+            makePosition(threadID: 9, postID: 909, floor: 9, updatedAt: 9)
+        ])
+        let destination = TestThreadReadingPositionPersistence(capability: .fallback)
+
+        let resolved = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertFalse(resolved === destination)
+        XCTAssertEqual(try resolved.load().map(\.threadID), [9])
+        XCTAssertEqual(destination.replaceCallCount, 0)
+    }
+
+    @MainActor
+    func testCompletedMigrationKeepsSwiftDataAuthoritativeAfterLegitimateClear() throws {
+        let fileURL = makeTemporaryFileURL()
+        let source = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: false
+        ) { throw ExpectedError.replaceFailed }.make()
+        try source.replaceAll([
+            makePosition(threadID: 5, postID: 505, floor: 5, updatedAt: 5)
+        ])
+        let destination = TestThreadReadingPositionPersistence()
+        _ = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+        destination.values = []
+
+        let reopened = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertTrue(reopened === destination)
+        XCTAssertEqual(try reopened.load(), [])
+        XCTAssertEqual(destination.replaceCallCount, 1)
+    }
+
+    @MainActor
+    func testCompletedMigrationFailsClosedWhenDestinationMarkerIsLost() throws {
+        let fileURL = makeTemporaryFileURL()
+        let source = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: false
+        ) { throw ExpectedError.replaceFailed }.make()
+        try source.replaceAll([
+            makePosition(threadID: 6, postID: 606, floor: 6, updatedAt: 6)
+        ])
+        let destination = TestThreadReadingPositionPersistence()
+        _ = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+        destination.generationID = nil
+
+        let reopened = ThreadReadingPositionPersistenceFactory(
+            fileURL: fileURL,
+            supportsSwiftData: true
+        ) { destination }.make()
+
+        XCTAssertEqual(reopened.capability, .unavailable)
+        XCTAssertThrowsError(try reopened.load())
+        XCTAssertEqual(destination.values.map(\.threadID), [6])
+    }
+
+    @MainActor
+    func testCancelledFileMutationDoesNotCommitAndNextMutationStillSucceeds() async throws {
+        let fileURL = makeTemporaryFileURL()
+        let persistence = try FileThreadReadingPositionPersistence(fileURL: fileURL)
+        try persistence.replaceAll([
+            makePosition(threadID: 1, postID: 101, floor: 1, updatedAt: 1)
+        ])
+        var continuation: AsyncStream<Void>.Continuation?
+        let gate = AsyncStream<Void> { continuation = $0 }
+        let cancelled = Task { @MainActor in
+            var iterator = gate.makeAsyncIterator()
+            _ = await iterator.next()
+            return try await persistence.upsertInBackground(
+                makePosition(threadID: 2, postID: 202, floor: 2, updatedAt: 2),
+                limit: 10
+            )
+        }
+        cancelled.cancel()
+        continuation?.yield(())
+        continuation?.finish()
+
+        switch await cancelled.result {
+        case .success:
+            XCTFail("cancelled mutation unexpectedly committed")
+        case let .failure(error):
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(try persistence.load().map(\.threadID), [1])
+
+        let next = try await persistence.upsertInBackground(
+            makePosition(threadID: 3, postID: 303, floor: 3, updatedAt: 3),
+            limit: 10
+        )
+        XCTAssertEqual(next.map(\.threadID), [3, 1])
+    }
+
+    private func makeTemporaryFileURL(function: String = #function) -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(function)-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory.appendingPathComponent("positions.json", isDirectory: false)
+    }
+
+    private func makeScratchDefaults(function: String = #function) throws -> UserDefaults {
+        let suiteName = "\(function).\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+
+    private func makePosition(
+        threadID: Int64,
+        postID: UInt64,
+        floor: Int,
+        updatedAt: TimeInterval
+    ) -> ThreadReadingPosition {
+        ThreadReadingPosition(
+            threadID: threadID,
+            postID: postID,
+            floor: floor,
+            updatedAt: Date(timeIntervalSinceReferenceDate: updatedAt)
+        )
+    }
+}
+
+@MainActor
+private final class TestThreadReadingPositionPersistence:
+    ThreadReadingPositionMigrationDestination {
+    let capability: PersistenceCapability
+    var values: [ThreadReadingPosition]
+    var replaceError: Error?
+    var corruptReadbackAfterReplace = false
+    var generationID: String?
+    private(set) var replaceCallCount = 0
+
+    init(
+        values: [ThreadReadingPosition] = [],
+        capability: PersistenceCapability = .durable
+    ) {
+        self.values = values
+        self.capability = capability
+    }
+
+    func load() throws -> [ThreadReadingPosition] {
+        if corruptReadbackAfterReplace, replaceCallCount > 0 {
+            return []
+        }
+        return values
+    }
+
+    func replaceAll(
+        _ positions: [ThreadReadingPosition],
+        beforeCommit: () throws -> Void
+    ) throws {
+        replaceCallCount += 1
+        try beforeCommit()
+        if let replaceError { throw replaceError }
+        values = positions
+    }
+
+    func upsert(_ position: ThreadReadingPosition, limit: Int) throws {
+        values = LocalThreadLibraryPolicy.addingReadingPosition(
+            position,
+            to: values,
+            limit: limit
+        )
+    }
+
+    func remove(threadID: Int64) throws {
+        values.removeAll { $0.threadID == threadID }
+    }
+
+    func removeAll(beforeCommit: () throws -> Void) throws {
+        try beforeCommit()
+        values = []
+    }
+
+    func clearAll(beforeCommit: () throws -> Void) throws {
+        try removeAll(beforeCommit: beforeCommit)
+    }
+
+    func backendGenerationID() throws -> String? {
+        generationID
+    }
+
+    func establishNativeBackendMarker(generationID: String) throws {
+        if let existing = self.generationID {
+            guard existing == generationID else { throw ExpectedMarkerError.mismatch }
+            return
+        }
+        self.generationID = generationID
+    }
+
+    func replaceAllForMigration(
+        _ positions: [ThreadReadingPosition],
+        generationID: String
+    ) throws {
+        try replaceAll(positions)
+        self.generationID = generationID
+    }
+
+    private enum ExpectedMarkerError: Error {
+        case mismatch
     }
 }

--- a/TiebaPureTests/SwiftDataOrderedCollectionPersistenceTests.swift
+++ b/TiebaPureTests/SwiftDataOrderedCollectionPersistenceTests.swift
@@ -2,6 +2,7 @@ import SwiftData
 import XCTest
 @testable import TiebaPure
 
+@available(iOS 17.0, *)
 final class SwiftDataOrderedCollectionPersistenceTests: XCTestCase {
     private enum InjectedFailure: Error {
         case beforeCommit

--- a/project.yml
+++ b/project.yml
@@ -34,8 +34,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.6
-        CURRENT_PROJECT_VERSION: 50
+        MARKETING_VERSION: 1.4.7
+        CURRENT_PROJECT_VERSION: 51
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -54,8 +54,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.6
-        CURRENT_PROJECT_VERSION: 50
+        MARKETING_VERSION: 1.4.7
+        CURRENT_PROJECT_VERSION: 51
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 变更

- 为浏览历史、最近贴吧、搜索历史、阅读位置和内容草稿加入 iOS 16 安全文件后端
- 使用原子文件、完整文件保护、权限校验和主备同代恢复，异常时 fail closed
- 为文件后端迁移到 SwiftData 增加 generation marker、pending/active 状态机和回读校验
- 保留 iOS 17 及以上现有 SwiftData 路径；本 PR 暂不降低最低系统版本
- 版本更新为 1.4.7 (51)

## 验证

- XcodeGen 重建一致
- iOS 26.5 单元测试：744 通过，7 条件跳过，0 失败
- 持久化定向测试：96 通过；状态回归：45 通过；草稿迁移：15 通过
- Release 模拟器构建通过
- xcodebuild analyze 通过
- Xcode 26.6 以 iOS 16.4 覆盖编译后，SwiftData 阻塞已清除；剩余阻塞仅为后续 UI 兼容 PR 处理的 iOS 17/18 SwiftUI API