### PR TITLE
Harden content submission risk handling

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		495A0B83D2525B63E0EF0799 /* VoicePlaybackCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C21E4C8027927C8D821B1B6 /* VoicePlaybackCoordinator.swift */; };
 		4979452A9C2D300494708927 /* Blocklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6740440D181E8F5AA32033 /* Blocklist.swift */; };
 		4A8E23945EF79EAEFE3019DC /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797B6083214EC5E9FF58648 /* MultipartFormData.swift */; };
+		4AA30396C89848D6E874828A /* TiebaSubmissionChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFB1A84AD3090A9581D1DA7 /* TiebaSubmissionChallenge.swift */; };
 		4C637302510F02D057F7F18D /* AuthSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D258A9BF97B365AE98B663F /* AuthSessionTests.swift */; };
 		4CC783BD1274CE79745DE038 /* LoginWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159C859125D33A23786365A /* LoginWebView.swift */; };
 		4D7D3D4E33E7C375230D2F29 /* Post.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50FDF3AC3742333D5202EC /* Post.pb.swift */; };
@@ -79,6 +80,7 @@
 		568856E8203C6DDBCBD7F027 /* PbFloor_PbFloorRequest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532EEE9965373A3008560F53 /* PbFloor_PbFloorRequest.pb.swift */; };
 		5A56CE0B756E52E025521190 /* Error.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221856558BEBEBF7F21F19A9 /* Error.pb.swift */; };
 		5B4467804B2B693EBB8D89D6 /* PostRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADF8B92CA2483FCA22CEEE6 /* PostRowView.swift */; };
+		5B9AC5C434DB275F2F83B65F /* ContentSubmissionChallengeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE6112C89D517C91A860C0B /* ContentSubmissionChallengeTests.swift */; };
 		5BC60D81A144316FA7381D09 /* LegacyScrollTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC309A0384A60EB41BF7B46 /* LegacyScrollTelemetry.swift */; };
 		5C55104E13B0C728DDDAD257 /* Page.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7D805CD76F1E84BC119F98 /* Page.pb.swift */; };
 		5C75A4BE925EE2D5EBB01684 /* SubPostList.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9DDCEE2EB7CAB5604D83C90 /* SubPostList.pb.swift */; };
@@ -374,6 +376,7 @@
 		8F256CCF10CED308966BFC23 /* TiebaThreadStoreAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaThreadStoreAPI.swift; sourceTree = "<group>"; };
 		8F9E3067B91DE94BBC410176 /* AlaLiveInfo.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlaLiveInfo.pb.swift; sourceTree = "<group>"; };
 		8FBDD5BC8E767866E1874011 /* SwiftDataOrderedCollectionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataOrderedCollectionPersistenceTests.swift; sourceTree = "<group>"; };
+		8FFB1A84AD3090A9581D1DA7 /* TiebaSubmissionChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaSubmissionChallenge.swift; sourceTree = "<group>"; };
 		9349EF851351C624AE35FF31 /* ReaderSplitLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSplitLayout.swift; sourceTree = "<group>"; };
 		93DFFE894245E0C72DB94FFD /* SearchRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRoute.swift; sourceTree = "<group>"; };
 		93E0B943190782C7374C3690 /* ForumThreadCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumThreadCategory.swift; sourceTree = "<group>"; };
@@ -422,6 +425,7 @@
 		DB22109F3B9CFD8850C4BEE0 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		DBA0A4653556BD11ACA8C0A3 /* AnonymousLiveSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLiveSmokeTests.swift; sourceTree = "<group>"; };
 		DBE21672E6B943EA241211C2 /* VideoPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewTests.swift; sourceTree = "<group>"; };
+		DDE6112C89D517C91A860C0B /* ContentSubmissionChallengeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSubmissionChallengeTests.swift; sourceTree = "<group>"; };
 		DE6967B15A66331DA9F947F0 /* MessageAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAPITests.swift; sourceTree = "<group>"; };
 		E425761E05D459199869361A /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		E442EEBED99D57F019D339D0 /* VoiceAudioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceAudioClient.swift; sourceTree = "<group>"; };
@@ -498,6 +502,7 @@
 				7F9A3625B3F19C2F07165809 /* TiebaRequestBuilder.swift */,
 				B8606C99A4A56953BB1FA0ED /* TiebaSearchAPI.swift */,
 				5B099CE340C14B26B97B9E57 /* TiebaSocialAPI.swift */,
+				8FFB1A84AD3090A9581D1DA7 /* TiebaSubmissionChallenge.swift */,
 				8F256CCF10CED308966BFC23 /* TiebaThreadStoreAPI.swift */,
 				B55649E6AEA1AD2EF4813452 /* TiebaUserProfileAPI.swift */,
 			);
@@ -720,6 +725,7 @@
 				36B7B87BD4A9EB32A9F340FC /* ContentFilterTests.swift */,
 				EA31C128D796A3D90D001643 /* ContentMappingTests.swift */,
 				622845B4F081A6D04395156C /* ContentReplyFeatureTests.swift */,
+				DDE6112C89D517C91A860C0B /* ContentSubmissionChallengeTests.swift */,
 				C3B9F1DB7C284253E1A90DCA /* ContentSubmissionCoordinatorTests.swift */,
 				83A586DD3DD949672854FF9E /* ContentSubmissionNetworkTests.swift */,
 				FD21B955EE2D4C98D90CD394 /* CrossVersionStateRegressionTests.swift */,
@@ -1221,6 +1227,7 @@
 				A6537596454795C265B252AD /* TiebaRequestBuilder.swift in Sources */,
 				5DF9D42AF53D712C923B9A3D /* TiebaSearchAPI.swift in Sources */,
 				C7A32644A038BA4FDE2C2864 /* TiebaSocialAPI.swift in Sources */,
+				4AA30396C89848D6E874828A /* TiebaSubmissionChallenge.swift in Sources */,
 				32FB7209CF53027C77B378A7 /* TiebaThreadStoreAPI.swift in Sources */,
 				61AC96A8DF8D9A6671239F30 /* TiebaURL.swift in Sources */,
 				66CB3F6B00C11572EF7276D1 /* TiebaUserProfileAPI.swift in Sources */,
@@ -1257,6 +1264,7 @@
 				AC68D0057C4A48786599AB69 /* ContentFilterTests.swift in Sources */,
 				CF454E1295D97B7FE03A3DDA /* ContentMappingTests.swift in Sources */,
 				63731BB53CEC877F1A7F871A /* ContentReplyFeatureTests.swift in Sources */,
+				5B9AC5C434DB275F2F83B65F /* ContentSubmissionChallengeTests.swift in Sources */,
 				B744513E4012208DC9BA3056 /* ContentSubmissionCoordinatorTests.swift in Sources */,
 				2E614B406807B5BAFBCA4918 /* ContentSubmissionNetworkTests.swift in Sources */,
 				3188EE996CB318CB2D3BE009 /* CrossVersionStateRegressionTests.swift in Sources */,
@@ -1389,13 +1397,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.8;
+				MARKETING_VERSION = 1.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1406,14 +1414,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.8;
+				MARKETING_VERSION = 1.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1459,14 +1467,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.8;
+				MARKETING_VERSION = 1.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1479,13 +1487,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.8;
+				MARKETING_VERSION = 1.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Core/Network/TiebaContentSubmissionAPI.swift
+++ b/TiebaPure/Core/Network/TiebaContentSubmissionAPI.swift
@@ -100,7 +100,7 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
         let postIDs: [String]
         let hasUnparseableIdentifier: Bool
         let message: String
-        let verificationMD5: String
+        let challengePayload: TiebaWebSubmissionChallengePayload
 
         private enum CodingKeys: String, CodingKey {
             case result
@@ -109,10 +109,10 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
             case threadID = "tid"
             case postID = "pid"
             case message = "msg"
-            case verificationMD5 = "vcode_md5"
         }
 
         init(from decoder: Swift.Decoder) throws {
+            challengePayload = try TiebaWebSubmissionChallengePayload(from: decoder)
             let container = try decoder.container(keyedBy: CodingKeys.self)
             hasResult = container.contains(.result)
             result = container.submissionInt(forKey: .result)
@@ -130,7 +130,6 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
                         .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
             }
             message = container.submissionString(forKey: .message) ?? ""
-            verificationMD5 = container.submissionString(forKey: .verificationMD5) ?? ""
         }
     }
 
@@ -145,7 +144,7 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
     let threadIDs: [String]
     let postIDs: [String]
     let hasUnparseableIdentifier: Bool
-    let verificationMD5: String
+    private let challengePayload: TiebaWebSubmissionChallengePayload
     private let data: DataDTO?
 
     private enum CodingKeys: String, CodingKey {
@@ -156,11 +155,11 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
         case legacyErrorMessage = "err_msg"
         case threadID = "tid"
         case postID = "pid"
-        case verificationMD5 = "vcode_md5"
         case data
     }
 
     init(from decoder: Swift.Decoder) throws {
+        challengePayload = try TiebaWebSubmissionChallengePayload(from: decoder)
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let decodedData = try? container.decodeIfPresent(DataDTO.self, forKey: .data)
         data = decodedData
@@ -201,7 +200,6 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
                 && container.submissionIdentifierString(forKey: $0)?
                     .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
         } || (decodedData?.hasUnparseableIdentifier ?? false)
-        verificationMD5 = container.submissionString(forKey: .verificationMD5) ?? ""
     }
 
     var submissionReceipt: ContentSubmissionReceipt {
@@ -239,10 +237,11 @@ private struct TiebaWebThreadSubmissionResponseDTO: Decodable {
                TiebaAPIError.isSessionExpired(code: code, message: message) {
                 throw ContentSubmissionError.sessionExpired
             }
-            if verificationMD5.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-                || data?.verificationMD5.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-                || messages.contains(where: \.requiresSubmissionVerification) {
-                throw ContentSubmissionError.verificationRequired(message: message)
+            if let challenge = TiebaWebSubmissionChallengePayload.challenge(
+                from: [challengePayload] + [data?.challengePayload].compactMap { $0 },
+                messages: messages
+            ) {
+                throw ContentSubmissionError.verificationRequired(challenge)
             }
             if let code, code != 0 {
                 throw ContentSubmissionError.business(code: code, message: message)
@@ -346,6 +345,7 @@ struct TiebaWebReplySubmissionResponseDTO: Decodable {
         let threadIDs: [String]
         let postIDs: [String]
         let hasUnparseableIdentifier: Bool
+        let challengePayload: TiebaWebSubmissionChallengePayload
 
         private enum CodingKeys: String, CodingKey {
             case result
@@ -364,6 +364,7 @@ struct TiebaWebReplySubmissionResponseDTO: Decodable {
         }
 
         init(from decoder: Swift.Decoder) throws {
+            challengePayload = try TiebaWebSubmissionChallengePayload(from: decoder)
             let container = try decoder.container(keyedBy: CodingKeys.self)
             hasResult = container.contains(.result)
             result = container.submissionInt(forKey: .result)
@@ -403,6 +404,8 @@ struct TiebaWebReplySubmissionResponseDTO: Decodable {
     private let threadIDs: [String]
     private let postIDs: [String]
     private let hasUnparseableIdentifier: Bool
+    private let challengePayload: TiebaWebSubmissionChallengePayload
+    private let nestedChallengePayload: TiebaWebSubmissionChallengePayload?
 
     private enum CodingKeys: String, CodingKey {
         case result
@@ -422,8 +425,10 @@ struct TiebaWebReplySubmissionResponseDTO: Decodable {
     }
 
     init(from decoder: Swift.Decoder) throws {
+        challengePayload = try TiebaWebSubmissionChallengePayload(from: decoder)
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let data = try? container.decodeIfPresent(DataDTO.self, forKey: .data)
+        nestedChallengePayload = data?.challengePayload
         hasResult = container.contains(.result) || (data?.hasResult ?? false)
         let topResult = container.submissionInt(forKey: .result)
         if let topResult, let nestedResult = data?.result, topResult != nestedResult {
@@ -486,8 +491,11 @@ struct TiebaWebReplySubmissionResponseDTO: Decodable {
         if let code, TiebaAPIError.isSessionExpired(code: code, message: message) {
             throw ContentSubmissionError.sessionExpired
         }
-        if normalizedMessages.contains(where: \.requiresSubmissionVerification) {
-            throw ContentSubmissionError.verificationRequired(message: message)
+        if let challenge = TiebaWebSubmissionChallengePayload.challenge(
+            from: [challengePayload] + [nestedChallengePayload].compactMap { $0 },
+            messages: normalizedMessages
+        ) {
+            throw ContentSubmissionError.verificationRequired(challenge)
         }
         if let code, code != 0 {
             throw ContentSubmissionError.business(code: code, message: message)
@@ -514,9 +522,45 @@ struct TiebaWebReplySubmissionResponseDTO: Decodable {
     }
 }
 
+struct TiebaWebTBSResponseDTO: Decodable, Equatable {
+    let tbs: String
+    let isLogin: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case tbs
+        case isLogin = "is_login"
+    }
+
+    init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        tbs = container.submissionString(forKey: .tbs) ?? ""
+        switch container.submissionString(forKey: .isLogin)?.lowercased() {
+        case "1", "true":
+            isLogin = true
+        case "0", "false":
+            isLogin = false
+        default:
+            isLogin = nil
+        }
+    }
+
+    func validatedTBS() throws -> String {
+        guard isLogin == true else {
+            throw ContentSubmissionError.sessionExpired
+        }
+        let value = tbs.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.isEmpty == false else {
+            throw TiebaMutationError.missingTBS
+        }
+        return value
+    }
+}
+
 enum TiebaContentSubmissionRequestFactory {
     static let clientVersion = "12.35.1.0"
-    static let postingLoginClientVersion = "22.5.1.0"
+
+    private static let webUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) "
+        + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"
 
     private static var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
@@ -762,65 +806,65 @@ enum TiebaContentSubmissionRequestFactory {
         account: Account,
         forumName: String
     ) throws -> [String: String] {
-        guard BaiduCredentialPolicy.isValid(account) else {
-            throw ContentSubmissionError.sessionExpired
-        }
         var referer = URLComponents(url: TiebaEndpoint.base.appending(path: "/f"), resolvingAgainstBaseURL: false)
         referer?.queryItems = [.init(name: "kw", value: forumName)]
-        return [
-            "Accept": "application/json, text/javascript, */*; q=0.01",
-            "Origin": TiebaEndpoint.base.absoluteString,
-            "Referer": referer?.url?.absoluteString ?? TiebaEndpoint.base.absoluteString,
-            "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) "
-                + "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
-            "X-Requested-With": "XMLHttpRequest",
-            // Do not reuse Account.minimalCookieHeader here: the web write only
-            // needs these two validated credentials and must not expose BAIDUID.
-            "Cookie": "BDUSS=\(account.bduss); STOKEN=\(account.stoken)"
-        ]
+        return try webMutationHeaders(
+            account: account,
+            referer: referer?.url?.absoluteString ?? TiebaEndpoint.base.absoluteString
+        )
     }
 
     static func webReplyHeaders(
         account: Account,
         threadID: Int64
     ) throws -> [String: String] {
-        guard BaiduCredentialPolicy.isValid(account) else {
-            throw ContentSubmissionError.sessionExpired
-        }
         guard threadID > 0 else {
             throw ContentSubmissionValidationError.invalidThread
         }
-        return webMutationHeaders(
+        return try webMutationHeaders(
             account: account,
             referer: "https://tieba.baidu.com/p/\(threadID)?lp=5028&mo_device=1&is_jingpost=0&pn=1&"
         )
     }
 
-    static func webUploadHeaders(account: Account) throws -> [String: String] {
-        guard BaiduCredentialPolicy.isValid(account) else {
-            throw ContentSubmissionError.sessionExpired
-        }
-        return webMutationHeaders(account: account, referer: nil)
+    static func webUploadHeaders(
+        account: Account,
+        threadID: Int64
+    ) throws -> [String: String] {
+        try webReplyHeaders(account: account, threadID: threadID)
+    }
+
+    static func webTBSHeaders(account: Account) throws -> [String: String] {
+        try webBaseHeaders(account: account)
     }
 
     private static func webMutationHeaders(
         account: Account,
         referer: String?
-    ) -> [String: String] {
-        var headers = [
-            "Accept": "application/json, text/plain, */*",
-            "Host": "tieba.baidu.com",
-            "Origin": TiebaEndpoint.base.absoluteString,
-            "User-Agent": "Mozilla/5.0 (Linux; Android 13; Pixel 7 Build/TQ3A.230805.001; wv) "
-                + "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 "
-                + "Chrome/109.0.5414.86 Mobile Safari/537.36 tieba/11.10.8.6 skin/default",
-            "X-Requested-With": "XMLHttpRequest",
-            "Cookie": "BDUSS=\(account.bduss); STOKEN=\(account.stoken)"
-        ]
+    ) throws -> [String: String] {
+        var headers = try webBaseHeaders(account: account)
+        headers["Origin"] = TiebaEndpoint.base.absoluteString
+        headers["X-Requested-With"] = "XMLHttpRequest"
         if let referer {
             headers["Referer"] = referer
         }
         return headers
+    }
+
+    private static func webBaseHeaders(account: Account) throws -> [String: String] {
+        guard BaiduCredentialPolicy.isValid(account) else {
+            throw ContentSubmissionError.sessionExpired
+        }
+        return [
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "zh-CN,zh;q=0.9",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+            "User-Agent": webUserAgent,
+            // The web publishing endpoints need only these validated credentials.
+            // Keep BAIDUID out of write and TBS requests to minimize disclosure.
+            "Cookie": "BDUSS=\(account.bduss); STOKEN=\(account.stoken)"
+        ]
     }
 
     private static func applyFloorReplyTarget(
@@ -907,22 +951,15 @@ extension TiebaAPI {
     }
 
     func strictlyRefreshedPostingTBS(for account: Account) async throws -> String {
-        guard BaiduCredentialPolicy.isValid(account) else {
-            throw ContentSubmissionError.sessionExpired
-        }
-        let response: LoginResponseDTO
+        let headers = try TiebaContentSubmissionRequestFactory.webTBSHeaders(account: account)
+        let timestamp = Int64(Date().timeIntervalSince1970 * 1_000)
+        let response: TiebaWebTBSResponseDTO
         do {
-            response = try await client.postForm(
-                .postingLogin,
-                fields: [
-                    "_client_version": TiebaContentSubmissionRequestFactory.postingLoginClientVersion,
-                    "bdusstoken": account.bduss
-                ],
-                headers: [
-                    "User-Agent": "tieba/\(TiebaContentSubmissionRequestFactory.postingLoginClientVersion) skin/default"
-                ],
-                signingSecret: "tiebaclient!!!",
-                as: LoginResponseDTO.self
+            response = try await client.getJSON(
+                .webTBS,
+                queryItems: [.init(name: "t", value: String(timestamp))],
+                headers: headers,
+                as: TiebaWebTBSResponseDTO.self
             )
         } catch is CancellationError {
             throw CancellationError()
@@ -933,32 +970,7 @@ extension TiebaAPI {
         }
 
         try Task.checkCancellation()
-        let code = Int(response.errorCode ?? "0") ?? -1
-        guard code == 0 else {
-            do {
-                try TiebaResponseValidator.validate(
-                    code: code,
-                    message: response.errorMessage ?? ""
-                )
-            } catch let error as TiebaAPIError {
-                if case .sessionExpired = error {
-                    throw ContentSubmissionError.sessionExpired
-                }
-                throw ContentSubmissionError.business(
-                    code: code,
-                    message: "发布登录校验失败（\(code)）：\(response.errorMessage ?? "")"
-                )
-            }
-            throw ContentSubmissionError.business(
-                code: code,
-                message: response.errorMessage ?? ""
-            )
-        }
-        let tbs = response.anti?.tbs.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard tbs.isEmpty == false else {
-            throw TiebaMutationError.missingTBS
-        }
-        return tbs
+        return try response.validatedTBS()
     }
 
     private func sendFinalMutation<Response: SwiftProtobuf.Message>(
@@ -1028,9 +1040,11 @@ extension TiebaAPI {
         account: Account,
         request: ContentSubmissionRequest
     ) async throws -> ContentSubmissionReceipt {
+        let threadID = request.target.threadID ?? 0
         let uploadedImageInfo = try await uploadWebImages(
             request.images,
-            account: account
+            account: account,
+            threadID: threadID
         )
         try Task.checkCancellation()
 
@@ -1055,7 +1069,6 @@ extension TiebaAPI {
             uploadedImageInfo: uploadedImageInfo,
             timestamp: timestamp
         )
-        let threadID = request.target.threadID ?? 0
         let headers = try TiebaContentSubmissionRequestFactory.webReplyHeaders(
             account: account,
             threadID: threadID
@@ -1084,10 +1097,14 @@ extension TiebaAPI {
 
     private func uploadWebImages(
         _ images: [ContentSubmissionImage],
-        account: Account
+        account: Account,
+        threadID: Int64
     ) async throws -> String {
         guard images.isEmpty == false else { return "" }
-        let headers = try TiebaContentSubmissionRequestFactory.webUploadHeaders(account: account)
+        let headers = try TiebaContentSubmissionRequestFactory.webUploadHeaders(
+            account: account,
+            threadID: threadID
+        )
         var imageInfo: [String] = []
         imageInfo.reserveCapacity(images.count)
         for (index, image) in images.enumerated() {
@@ -1253,7 +1270,13 @@ private func validateSubmissionStatus(
     }
     if verification.requiresVerification
         || messages.contains(where: \.requiresSubmissionVerification) {
-        throw ContentSubmissionError.verificationRequired(message: message)
+        let challenge = ContentSubmissionChallenge(
+            message: message,
+            verificationMD5: SubmissionSecret(verification.vcodeMd5),
+            verificationType: verification.vcodeType,
+            pictureURL: validatedBaiduChallengeURL(verification.vcodePicURL)
+        )
+        throw ContentSubmissionError.verificationRequired(challenge)
     }
     guard code == 0 else {
         throw ContentSubmissionError.business(code: code, message: message)
@@ -1263,7 +1286,9 @@ private func validateSubmissionStatus(
 private extension Tieba_SubmissionVerificationInfo {
     var requiresVerification: Bool {
         let value = needVcode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return value.isEmpty == false && value != "0" && value != "false"
+        return (value.isEmpty == false && value != "0" && value != "false")
+            || SubmissionSecret(vcodeMd5) != nil
+            || vcodePicURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
 }
 

--- a/TiebaPure/Core/Network/TiebaEndpoint.swift
+++ b/TiebaPure/Core/Network/TiebaEndpoint.swift
@@ -35,6 +35,7 @@ enum TiebaEndpoint {
     case addThreadStore
     case removeThreadStore
     case agreePost
+    case webTBS
     case webAddThread
     case webAddPost(timestamp: Int64)
     case webUploadPicture(nonce: String)
@@ -128,6 +129,8 @@ enum TiebaEndpoint {
             return Self.appBase.appending(path: "/c/c/post/rmstore")
         case .agreePost:
             return Self.socialBase.appending(path: "/c/c/agree/opAgree")
+        case .webTBS:
+            return Self.base.appending(path: "/dc/common/tbs")
         case .webAddThread:
             return Self.base.appending(path: "/f/commit/thread/add")
         case let .webAddPost(timestamp):

--- a/TiebaPure/Core/Network/TiebaSubmissionChallenge.swift
+++ b/TiebaPure/Core/Network/TiebaSubmissionChallenge.swift
@@ -1,0 +1,436 @@
+import Foundation
+
+struct TiebaWebSubmissionChallengePayload: Decodable {
+    struct Fields: Decodable {
+        struct Extra: Decodable {
+            let textImage: String?
+            let slideImage: String?
+            let endpoint: String?
+            let successImage: String?
+            let slideEndpoint: String?
+
+            private enum CodingKeys: String, CodingKey {
+                case textImage = "textimg"
+                case slideImage = "slideimg"
+                case endpoint
+                case successImage = "successimg"
+                case slideEndpoint = "slideendpoint"
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                textImage = container.challengeString(forKey: .textImage)
+                slideImage = container.challengeString(forKey: .slideImage)
+                endpoint = container.challengeString(forKey: .endpoint)
+                successImage = container.challengeString(forKey: .successImage)
+                slideEndpoint = container.challengeString(forKey: .slideEndpoint)
+            }
+        }
+
+        struct AntiState: Decodable {
+            let canPost: String?
+            let canPostAgain: String?
+            let forbidFlag: String?
+            let forbidInformation: String?
+            let blockState: String?
+            let hideState: String?
+            let verificationState: String?
+            let daysToFree: Int?
+            let hasChance: Bool?
+
+            private enum CodingKeys: String, CodingKey {
+                case canPost = "ifpost"
+                case canPostAgain = "ifposta"
+                case forbidFlag = "forbid_flag"
+                case forbidInformation = "forbid_info"
+                case blockState = "block_stat"
+                case hideState = "hide_stat"
+                case verificationState = "vcode_stat"
+                case daysToFree = "days_tofree"
+                case hasChance = "has_chance"
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                canPost = container.challengeString(forKey: .canPost)
+                canPostAgain = container.challengeString(forKey: .canPostAgain)
+                forbidFlag = container.challengeString(forKey: .forbidFlag)
+                forbidInformation = container.challengeString(forKey: .forbidInformation)
+                blockState = container.challengeString(forKey: .blockState)
+                hideState = container.challengeString(forKey: .hideState)
+                verificationState = container.challengeString(forKey: .verificationState)
+                daysToFree = container.challengeInt(forKey: .daysToFree)
+                hasChance = container.challengeBool(forKey: .hasChance)
+            }
+        }
+
+        let needVerification: String?
+        let verificationMD5: String?
+        let previousVerificationType: String?
+        let verificationType: String?
+        let passToken: String?
+        let blockContent: String?
+        let blockCancel: String?
+        let blockConfirm: String?
+        let pictureURL: String?
+        let extra: Extra?
+        let antiState: AntiState?
+        let extensionMessage: String?
+        let toastMessage: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case needVerification = "need_vcode"
+            case verificationMD5 = "vcode_md5"
+            case previousVerificationType = "vcode_prev_type"
+            case verificationType = "vcode_type"
+            case passToken = "pass_token"
+            case blockContent = "block_content"
+            case blockCancel = "block_cancel"
+            case blockConfirm = "block_confirm"
+            case pictureURL = "vcode_pic_url"
+            case extra = "vcode_extra"
+            case antiState = "anti_stat"
+            case extensionMessage = "ext_msg"
+            case toast
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            needVerification = container.challengeString(forKey: .needVerification)
+            verificationMD5 = container.challengeString(forKey: .verificationMD5)
+            previousVerificationType = container.challengeString(forKey: .previousVerificationType)
+            verificationType = container.challengeString(forKey: .verificationType)
+            passToken = container.challengeString(forKey: .passToken)
+            blockContent = container.challengeString(forKey: .blockContent)
+            blockCancel = container.challengeString(forKey: .blockCancel)
+            blockConfirm = container.challengeString(forKey: .blockConfirm)
+            pictureURL = container.challengeString(forKey: .pictureURL)
+            extra = try? container.decodeIfPresent(Extra.self, forKey: .extra)
+            antiState = try? container.decodeIfPresent(AntiState.self, forKey: .antiState)
+            extensionMessage = container.challengeString(forKey: .extensionMessage)
+            toastMessage = Self.decodeToast(from: container)
+        }
+
+        private static func decodeToast(
+            from container: KeyedDecodingContainer<CodingKeys>
+        ) -> String? {
+            if let value = container.challengeString(forKey: .toast) {
+                return value
+            }
+            guard let toast = try? container.nestedContainer(
+                keyedBy: DynamicCodingKey.self,
+                forKey: .toast
+            ) else {
+                return nil
+            }
+            for key in ["content", "text", "message", "msg"] {
+                guard let codingKey = DynamicCodingKey(stringValue: key) else { continue }
+                if let value = toast.challengeString(forKey: codingKey) {
+                    return value
+                }
+            }
+            return nil
+        }
+    }
+
+    let fields: [Fields]
+
+    private enum CodingKeys: String, CodingKey {
+        case info
+        case anti
+    }
+
+    init(from decoder: Decoder) throws {
+        let direct = try Fields(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let info = try? container.decodeIfPresent(Fields.self, forKey: .info)
+        let anti = try? container.decodeIfPresent(Fields.self, forKey: .anti)
+        fields = [direct] + [info, anti].compactMap { $0 }
+    }
+
+    static func challenge(
+        from payloads: [TiebaWebSubmissionChallengePayload],
+        messages: [String]
+    ) -> ContentSubmissionChallenge? {
+        let fields = payloads.flatMap(\.fields)
+        let normalizedMessages = messages.compactMap {
+            ContentSubmissionChallenge.sanitizedDisplayText($0)
+        }
+        let messageRequiresVerification = normalizedMessages.contains {
+            $0.requiresSubmissionVerificationChallenge
+        }
+        let fieldsRequireVerification = fields.contains { field in
+            field.needVerification.requiresSubmissionVerificationFlag
+                || SubmissionSecret(field.verificationMD5) != nil
+                || SubmissionSecret(field.passToken) != nil
+                || field.pictureURL.challengeNonempty
+                || field.antiState?.verificationState.requiresSubmissionVerificationFlag == true
+                || field.blockContent.challengeNonempty
+        }
+        guard messageRequiresVerification || fieldsRequireVerification else { return nil }
+
+        var hasConflict = false
+        let verificationMD5 = uniqueSecret(
+            fields.map(\.verificationMD5),
+            hasConflict: &hasConflict
+        )
+        let passToken = uniqueSecret(fields.map(\.passToken), hasConflict: &hasConflict)
+        let verificationType = uniqueDisplayText(
+            fields.map(\.verificationType),
+            hasConflict: &hasConflict
+        )
+        let previousVerificationType = uniqueDisplayText(
+            fields.map(\.previousVerificationType),
+            hasConflict: &hasConflict
+        )
+        let pictureURL = uniqueChallengeURL(
+            fields.map(\.pictureURL),
+            hasConflict: &hasConflict
+        )
+
+        let blockContent = uniqueDisplayText(fields.map(\.blockContent), hasConflict: &hasConflict)
+        let blockCancel = uniqueDisplayText(fields.map(\.blockCancel), hasConflict: &hasConflict)
+        let blockConfirm = uniqueDisplayText(fields.map(\.blockConfirm), hasConflict: &hasConflict)
+        let blockPrompt: ContentSubmissionBlockPrompt? = [
+            blockContent,
+            blockCancel,
+            blockConfirm
+        ].contains(where: { $0 != nil })
+            ? ContentSubmissionBlockPrompt(
+                content: blockContent,
+                cancelTitle: blockCancel,
+                confirmTitle: blockConfirm
+            )
+            : nil
+
+        let extras = fields.compactMap(\.extra)
+        let extra = makeExtra(extras, hasConflict: &hasConflict)
+        let antiState = makeAntiState(fields.compactMap(\.antiState), hasConflict: &hasConflict)
+        let extensionMessage = uniqueDisplayText(
+            fields.map(\.extensionMessage),
+            hasConflict: &hasConflict
+        )
+        let toastMessage = uniqueDisplayText(fields.map(\.toastMessage), hasConflict: &hasConflict)
+        let displayMessage = normalizedMessages.first
+            ?? blockContent
+            ?? toastMessage
+            ?? extensionMessage
+            ?? "贴吧要求完成安全验证，当前版本暂时无法继续。"
+
+        return ContentSubmissionChallenge(
+            message: displayMessage,
+            verificationMD5: verificationMD5,
+            verificationType: verificationType,
+            previousVerificationType: previousVerificationType,
+            pictureURL: pictureURL,
+            passToken: passToken,
+            blockPrompt: blockPrompt,
+            extra: extra,
+            antiState: antiState,
+            extensionMessage: extensionMessage,
+            toastMessage: toastMessage,
+            hasConflictingPayload: hasConflict
+        )
+    }
+
+    private static func makeExtra(
+        _ extras: [Fields.Extra],
+        hasConflict: inout Bool
+    ) -> ContentSubmissionChallengeExtra? {
+        let value = ContentSubmissionChallengeExtra(
+            textImageURL: uniqueChallengeURL(extras.map(\.textImage), hasConflict: &hasConflict),
+            slideImageURL: uniqueChallengeURL(extras.map(\.slideImage), hasConflict: &hasConflict),
+            endpointURL: uniqueChallengeURL(extras.map(\.endpoint), hasConflict: &hasConflict),
+            successImageURL: uniqueChallengeURL(extras.map(\.successImage), hasConflict: &hasConflict),
+            slideEndpointURL: uniqueChallengeURL(extras.map(\.slideEndpoint), hasConflict: &hasConflict)
+        )
+        return [
+            value.textImageURL,
+            value.slideImageURL,
+            value.endpointURL,
+            value.successImageURL,
+            value.slideEndpointURL
+        ].contains(where: { $0 != nil }) ? value : nil
+    }
+
+    private static func makeAntiState(
+        _ states: [Fields.AntiState],
+        hasConflict: inout Bool
+    ) -> ContentSubmissionAntiState? {
+        guard states.isEmpty == false else { return nil }
+        return ContentSubmissionAntiState(
+            canPost: uniqueDisplayText(states.map(\.canPost), hasConflict: &hasConflict),
+            canPostAgain: uniqueDisplayText(states.map(\.canPostAgain), hasConflict: &hasConflict),
+            forbidFlag: uniqueDisplayText(states.map(\.forbidFlag), hasConflict: &hasConflict),
+            forbidInformation: uniqueDisplayText(
+                states.map(\.forbidInformation),
+                hasConflict: &hasConflict
+            ),
+            blockState: uniqueDisplayText(states.map(\.blockState), hasConflict: &hasConflict),
+            hideState: uniqueDisplayText(states.map(\.hideState), hasConflict: &hasConflict),
+            verificationState: uniqueDisplayText(
+                states.map(\.verificationState),
+                hasConflict: &hasConflict
+            ),
+            daysToFree: uniqueValue(states.map(\.daysToFree), hasConflict: &hasConflict),
+            hasChance: uniqueValue(states.map(\.hasChance), hasConflict: &hasConflict)
+        )
+    }
+}
+
+private func uniqueSecret(
+    _ values: [String?],
+    hasConflict: inout Bool
+) -> SubmissionSecret? {
+    let values = Set(values.compactMap(SubmissionSecret.init))
+    guard values.count <= 1 else {
+        hasConflict = true
+        return nil
+    }
+    return values.first
+}
+
+private func uniqueDisplayText(
+    _ values: [String?],
+    hasConflict: inout Bool
+) -> String? {
+    let values = Set(values.compactMap {
+        ContentSubmissionChallenge.sanitizedDisplayText($0)
+    })
+    guard values.count <= 1 else {
+        hasConflict = true
+        return nil
+    }
+    return values.first
+}
+
+private func uniqueChallengeURL(
+    _ values: [String?],
+    hasConflict: inout Bool
+) -> URL? {
+    let normalizedValues = Set(values.compactMap { value -> String? in
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    })
+    guard normalizedValues.count <= 1 else {
+        hasConflict = true
+        return nil
+    }
+    return validatedBaiduChallengeURL(normalizedValues.first)
+}
+
+private func uniqueValue<Value: Hashable>(
+    _ values: [Value?],
+    hasConflict: inout Bool
+) -> Value? {
+    let values = Set(values.compactMap { $0 })
+    guard values.count <= 1 else {
+        hasConflict = true
+        return nil
+    }
+    return values.first
+}
+
+func validatedBaiduChallengeURL(_ value: String?) -> URL? {
+    guard let value,
+          let components = URLComponents(string: value),
+          components.scheme?.lowercased() == "https",
+          components.user == nil,
+          components.password == nil,
+          let url = TiebaURL.webpage(value),
+          let host = url.host?.lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".")) else {
+        return nil
+    }
+    return ["baidu.com", "bdimg.com", "bdstatic.com"].contains { suffix in
+        host == suffix || host.hasSuffix(".\(suffix)")
+    } ? url : nil
+}
+
+private extension Optional where Wrapped == String {
+    var challengeNonempty: Bool {
+        self?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    }
+
+    var requiresSubmissionVerificationFlag: Bool {
+        guard let raw = self?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              raw.isEmpty == false else {
+            return false
+        }
+        return ["0", "false", "no", "off", "none"].contains(raw) == false
+    }
+}
+
+private extension String {
+    var requiresSubmissionVerificationChallenge: Bool {
+        let value = lowercased()
+        return value.contains("验证码")
+            || value.contains("安全验证")
+            || value.contains("captcha")
+            || value.contains("verify")
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func challengeString(forKey key: Key) -> String? {
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Int64.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decodeIfPresent(UInt64.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decodeIfPresent(Double.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? decodeIfPresent(Bool.self, forKey: key) {
+            return value ? "1" : "0"
+        }
+        return nil
+    }
+
+    func challengeInt(forKey key: Key) -> Int? {
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            return Int(value)
+        }
+        return nil
+    }
+
+    func challengeBool(forKey key: Key) -> Bool? {
+        if let value = try? decodeIfPresent(Bool.self, forKey: key) {
+            return value
+        }
+        if let value = try? decodeIfPresent(Int.self, forKey: key) {
+            return value == 0 ? false : value == 1 ? true : nil
+        }
+        if let value = try? decodeIfPresent(String.self, forKey: key) {
+            switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "0", "false": return false
+            case "1", "true": return true
+            default: return nil
+            }
+        }
+        return nil
+    }
+}
+
+private struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        stringValue = String(intValue)
+        self.intValue = intValue
+    }
+}

--- a/TiebaPure/Domain/Models/ContentSubmission.swift
+++ b/TiebaPure/Domain/Models/ContentSubmission.swift
@@ -367,13 +367,162 @@ enum ContentSubmissionImageInspector {
     }
 }
 
-enum ContentSubmissionError: Error, Equatable, LocalizedError {
+struct SubmissionSecret: Equatable, Hashable, Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    private let storage: String
+
+    init?(_ value: String?) {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.isEmpty == false,
+              normalized.utf8.count <= 4_096,
+              normalized.unicodeScalars.contains(where: { scalar in
+                  CharacterSet.controlCharacters.contains(scalar)
+              }) == false else {
+            return nil
+        }
+        storage = normalized
+    }
+
+    var value: String { storage }
+    var description: String { "<redacted>" }
+    var debugDescription: String { "<redacted>" }
+    var customMirror: Mirror {
+        Mirror(self, children: ["value": "<redacted>"])
+    }
+}
+
+struct ContentSubmissionBlockPrompt: Equatable, Sendable {
+    let content: String?
+    let cancelTitle: String?
+    let confirmTitle: String?
+}
+
+struct ContentSubmissionChallengeExtra: Equatable, Sendable {
+    let textImageURL: URL?
+    let slideImageURL: URL?
+    let endpointURL: URL?
+    let successImageURL: URL?
+    let slideEndpointURL: URL?
+}
+
+struct ContentSubmissionAntiState: Equatable, Sendable {
+    let canPost: String?
+    let canPostAgain: String?
+    let forbidFlag: String?
+    let forbidInformation: String?
+    let blockState: String?
+    let hideState: String?
+    let verificationState: String?
+    let daysToFree: Int?
+    let hasChance: Bool?
+}
+
+struct ContentSubmissionChallenge: Equatable, Sendable {
+    let message: String
+    let verificationMD5: SubmissionSecret?
+    let verificationType: String?
+    let previousVerificationType: String?
+    let pictureURL: URL?
+    let passToken: SubmissionSecret?
+    let blockPrompt: ContentSubmissionBlockPrompt?
+    let extra: ContentSubmissionChallengeExtra?
+    let antiState: ContentSubmissionAntiState?
+    let extensionMessage: String?
+    let toastMessage: String?
+    let hasConflictingPayload: Bool
+
+    init(
+        message: String,
+        verificationMD5: SubmissionSecret? = nil,
+        verificationType: String? = nil,
+        previousVerificationType: String? = nil,
+        pictureURL: URL? = nil,
+        passToken: SubmissionSecret? = nil,
+        blockPrompt: ContentSubmissionBlockPrompt? = nil,
+        extra: ContentSubmissionChallengeExtra? = nil,
+        antiState: ContentSubmissionAntiState? = nil,
+        extensionMessage: String? = nil,
+        toastMessage: String? = nil,
+        hasConflictingPayload: Bool = false
+    ) {
+        let secrets = [verificationMD5, passToken].compactMap { $0 }
+        self.message = Self.redactedDisplayText(message, secrets: secrets) ?? ""
+        self.verificationMD5 = verificationMD5
+        self.verificationType = Self.sanitizedDisplayText(verificationType)
+        self.previousVerificationType = Self.sanitizedDisplayText(previousVerificationType)
+        self.pictureURL = pictureURL
+        self.passToken = passToken
+        self.blockPrompt = blockPrompt.map {
+            ContentSubmissionBlockPrompt(
+                content: Self.redactedDisplayText($0.content, secrets: secrets),
+                cancelTitle: Self.redactedDisplayText($0.cancelTitle, secrets: secrets),
+                confirmTitle: Self.redactedDisplayText($0.confirmTitle, secrets: secrets)
+            )
+        }
+        self.extra = extra
+        self.antiState = antiState.map {
+            ContentSubmissionAntiState(
+                canPost: Self.redactedDisplayText($0.canPost, secrets: secrets),
+                canPostAgain: Self.redactedDisplayText($0.canPostAgain, secrets: secrets),
+                forbidFlag: Self.redactedDisplayText($0.forbidFlag, secrets: secrets),
+                forbidInformation: Self.redactedDisplayText(
+                    $0.forbidInformation,
+                    secrets: secrets
+                ),
+                blockState: Self.redactedDisplayText($0.blockState, secrets: secrets),
+                hideState: Self.redactedDisplayText($0.hideState, secrets: secrets),
+                verificationState: Self.redactedDisplayText(
+                    $0.verificationState,
+                    secrets: secrets
+                ),
+                daysToFree: $0.daysToFree,
+                hasChance: $0.hasChance
+            )
+        }
+        self.extensionMessage = Self.redactedDisplayText(extensionMessage, secrets: secrets)
+        self.toastMessage = Self.redactedDisplayText(toastMessage, secrets: secrets)
+        self.hasConflictingPayload = hasConflictingPayload
+    }
+
+    static func sanitizedDisplayText(_ value: String?, limit: Int = 512) -> String? {
+        guard let value else { return nil }
+        let scalars = value.unicodeScalars.filter { scalar in
+            CharacterSet.controlCharacters.contains(scalar) == false
+                || scalar == "\n"
+                || scalar == "\t"
+        }
+        let normalized = String(String.UnicodeScalarView(scalars))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.isEmpty == false else { return nil }
+        return String(normalized.prefix(limit))
+    }
+
+    private static func redactedDisplayText(
+        _ value: String?,
+        secrets: [SubmissionSecret],
+        limit: Int = 512
+    ) -> String? {
+        guard var value = sanitizedDisplayText(value, limit: limit) else { return nil }
+        for secret in secrets {
+            value = value.replacingOccurrences(of: secret.value, with: "<redacted>")
+        }
+        return String(value.prefix(limit))
+    }
+}
+
+enum ContentSubmissionError: Error, Equatable, LocalizedError,
+    CustomStringConvertible, CustomDebugStringConvertible {
     case notLoggedIn
     case sessionExpired
-    case verificationRequired(message: String)
+    case verificationRequired(ContentSubmissionChallenge)
     case business(code: Int, message: String)
     case outcomeUnknown
     case unsupported(message: String)
+
+    static func verificationRequired(message: String) -> ContentSubmissionError {
+        .verificationRequired(ContentSubmissionChallenge(message: message))
+    }
 
     var errorDescription: String? {
         switch self {
@@ -381,8 +530,10 @@ enum ContentSubmissionError: Error, Equatable, LocalizedError {
             return "请先登录后再发布。"
         case .sessionExpired:
             return "登录已失效，请重新登录后再试。"
-        case let .verificationRequired(message):
-            return message.isEmpty ? "贴吧要求完成安全验证，当前版本暂时无法继续。" : message
+        case let .verificationRequired(challenge):
+            return challenge.message.isEmpty
+                ? "贴吧要求完成安全验证，当前版本暂时无法继续。"
+                : challenge.message
         case let .business(_, message):
             return message.isEmpty ? "贴吧未接受这次发布，请稍后再试。" : message
         case .outcomeUnknown:
@@ -391,4 +542,7 @@ enum ContentSubmissionError: Error, Equatable, LocalizedError {
             return message
         }
     }
+
+    var description: String { errorDescription ?? "发布失败。" }
+    var debugDescription: String { description }
 }

--- a/TiebaPure/Features/Compose/ContentComposerPresentation.swift
+++ b/TiebaPure/Features/Compose/ContentComposerPresentation.swift
@@ -7,7 +7,7 @@ struct ContentComposerRoute: Identifiable, Equatable {
 }
 
 enum ContentSubmissionRiskPolicy {
-    static let acknowledgementKey = "TiebaPure.contentSubmissionRiskAcknowledged.v1"
+    static let acknowledgementKey = "TiebaPure.contentSubmissionRiskAcknowledged.v2"
 
     static func hasAcknowledged(defaults: UserDefaults = .standard) -> Bool {
         defaults.bool(forKey: acknowledgementKey)
@@ -142,7 +142,7 @@ struct ContentComposerPresentation: View {
                 ContentSubmissionRiskPolicy.acknowledge()
             }
         } message: {
-            Text("发布和回复使用非官方实验接口，账号可能受到贴吧限制。发送结果无法确认时，应用不会自动重发，请先刷新确认。")
+            Text("TiebaPure 通过非官方实验接口发帖和回复。使用时可能触发贴吧风控，导致内容被隐藏或删除、发帖或回帖等账号功能受限；极端情况下账号可能被冻结。若发送结果无法确认，应用不会自动重发，请先刷新页面核对。")
         }
         .confirmationDialog(
             "删除损坏草稿？",

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -48,13 +48,13 @@ struct SettingsView: View {
                 Toggle(isOn: newThreadsEnabledSelection) {
                     Label("允许发帖", systemImage: "square.and.pencil")
                 }
-                .accessibilityHint("关闭后不能发布新主题")
+                .accessibilityHint("开启后可通过非官方实验接口发布新主题；内容可能被隐藏或删除，账号可能受限或冻结")
                 .accessibilityIdentifier("settings-new-threads-enabled-toggle")
 
                 Toggle(isOn: repliesEnabledSelection) {
                     Label("允许回帖", systemImage: "bubble.left.and.bubble.right")
                 }
-                .accessibilityHint("开启后可以回复帖子、楼层和楼中楼")
+                .accessibilityHint("开启后可通过非官方实验接口回复帖子、楼层和楼中楼；内容可能被隐藏或删除，账号可能受限或冻结")
                 .accessibilityIdentifier("settings-replies-enabled-toggle")
 
                 Toggle(isOn: likesEnabledSelection) {
@@ -81,7 +81,7 @@ struct SettingsView: View {
             } header: {
                 Text("内容")
             } footer: {
-                Text("发帖和点赞默认开启，回帖默认关闭。关闭点赞后仍会显示点赞数量；尚未确认过发布风险时，首次发帖或回帖会显示非官方接口说明。设置和屏蔽规则仅保存在本机。")
+                Text("发帖和回帖使用非官方实验接口。开启并使用后，可能触发贴吧风控，造成内容被隐藏或删除、账号功能受限；极端情况下账号可能被冻结。请确认能够承担风险后再使用。关闭点赞后仍会显示点赞数量；设置和屏蔽规则仅保存在本机。")
             }
 
             if let account {

--- a/TiebaPureTests/ContentComposerPolicyTests.swift
+++ b/TiebaPureTests/ContentComposerPolicyTests.swift
@@ -167,6 +167,16 @@ final class ContentComposerPolicyTests: XCTestCase {
         XCTAssertFalse(ContentSubmissionRiskPolicy.hasAcknowledged(defaults: defaults))
     }
 
+    func testLegacyRiskAcknowledgementDoesNotSuppressCurrentWarning() throws {
+        let suiteName = "dev.infinityf4p.tiebapure.composer-risk-legacy-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: "TiebaPure.contentSubmissionRiskAcknowledged.v1")
+
+        XCTAssertFalse(ContentSubmissionRiskPolicy.hasAcknowledged(defaults: defaults))
+    }
+
     func testImageDimensionsFollowEXIFOrientation() {
         let upright = ContentSubmissionImageInspector.displayPixelDimensions(
             width: 4_032,

--- a/TiebaPureTests/ContentReplyFeatureTests.swift
+++ b/TiebaPureTests/ContentReplyFeatureTests.swift
@@ -4,6 +4,85 @@ import XCTest
 
 @MainActor
 final class ContentReplyFeatureTests: XCTestCase {
+    func testSubmissionChallengeSecretsStayRedactedFromDescriptionsAndErrors() throws {
+        let md5 = try XCTUnwrap(SubmissionSecret("fixture-verification-secret"))
+        let passToken = try XCTUnwrap(SubmissionSecret("fixture-pass-token"))
+        let challenge = ContentSubmissionChallenge(
+            message: "请完成安全验证",
+            verificationMD5: md5,
+            passToken: passToken
+        )
+        let error = ContentSubmissionError.verificationRequired(challenge)
+
+        XCTAssertEqual(md5.description, "<redacted>")
+        XCTAssertEqual(md5.debugDescription, "<redacted>")
+        XCTAssertFalse(String(describing: md5).contains("fixture-verification-secret"))
+        XCTAssertFalse(String(reflecting: md5).contains("fixture-verification-secret"))
+        XCTAssertFalse(String(reflecting: error).contains("fixture-verification-secret"))
+        XCTAssertFalse(String(reflecting: error).contains("fixture-pass-token"))
+        XCTAssertFalse(error.localizedDescription.contains("fixture-verification-secret"))
+        XCTAssertFalse(error.localizedDescription.contains("fixture-pass-token"))
+        XCTAssertEqual(error.localizedDescription, "请完成安全验证")
+    }
+
+    func testSubmissionChallengeSanitizesControlCharactersAndLimitsDisplayText() {
+        let challenge = ContentSubmissionChallenge(
+            message: "  请\u{0}完成验证  ",
+            extensionMessage: String(repeating: "扩", count: 600),
+            toastMessage: "\u{7}提示"
+        )
+
+        XCTAssertEqual(challenge.message, "请完成验证")
+        XCTAssertEqual(challenge.extensionMessage?.count, 512)
+        XCTAssertEqual(challenge.toastMessage, "提示")
+    }
+
+    func testSubmissionChallengeRedactsSecretsEchoedByServerMessages() throws {
+        let md5 = try XCTUnwrap(SubmissionSecret("fixture-verification-secret"))
+        let passToken = try XCTUnwrap(SubmissionSecret("fixture-pass-token"))
+        let challenge = ContentSubmissionChallenge(
+            message: "验证 fixture-verification-secret token fixture-pass-token",
+            verificationMD5: md5,
+            passToken: passToken,
+            blockPrompt: ContentSubmissionBlockPrompt(
+                content: "拦截 fixture-verification-secret",
+                cancelTitle: "取消",
+                confirmTitle: "继续 fixture-pass-token"
+            ),
+            antiState: ContentSubmissionAntiState(
+                canPost: nil,
+                canPostAgain: nil,
+                forbidFlag: nil,
+                forbidInformation: "原因 fixture-pass-token",
+                blockState: nil,
+                hideState: nil,
+                verificationState: nil,
+                daysToFree: nil,
+                hasChance: nil
+            ),
+            extensionMessage: "补充 fixture-verification-secret",
+            toastMessage: "提示 fixture-pass-token"
+        )
+        let error = ContentSubmissionError.verificationRequired(challenge)
+        let renderedValues = [
+            challenge.message,
+            challenge.blockPrompt?.content,
+            challenge.blockPrompt?.confirmTitle,
+            challenge.antiState?.forbidInformation,
+            challenge.extensionMessage,
+            challenge.toastMessage,
+            error.localizedDescription,
+            error.description,
+            error.debugDescription
+        ].compactMap { $0 }
+
+        for value in renderedValues {
+            XCTAssertFalse(value.contains("fixture-verification-secret"))
+            XCTAssertFalse(value.contains("fixture-pass-token"))
+        }
+        XCTAssertTrue(challenge.message.contains("<redacted>"))
+    }
+
     func testReplySettingDefaultsOffPersistsAndRemovesDefaultOverride() throws {
         let suiteName = "dev.infinityf4p.tiebapure.reply-settings-tests.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/TiebaPureTests/ContentSubmissionChallengeTests.swift
+++ b/TiebaPureTests/ContentSubmissionChallengeTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+@testable import TiebaPure
+
+final class ContentSubmissionChallengeTests: XCTestCase {
+    func testStructuredChallengeParsesKnownInfoExtraAndAntiFields() throws {
+        let payload = try decode(#"""
+        {
+          "info": {
+            "need_vcode": true,
+            "vcode_md5": "fixture-md5",
+            "vcode_prev_type": "old",
+            "vcode_type": "slide",
+            "pass_token": "fixture-pass-token",
+            "block_content": "请完成验证",
+            "block_cancel": "取消",
+            "block_confirm": "验证",
+            "vcode_pic_url": "https://tieba.baidu.com/challenge.png",
+            "vcode_extra": {
+              "textimg": "https://himg.bdimg.com/text.png",
+              "slideendpoint": "https://tieba.baidu.com/challenge/slide"
+            },
+            "anti_stat": {
+              "ifpost": 0,
+              "forbid_flag": "1",
+              "forbid_info": "需要验证",
+              "vcode_stat": 1,
+              "days_tofree": 3,
+              "has_chance": true
+            }
+          },
+          "ext_msg": "补充说明",
+          "toast": {"content":"验证提示"}
+        }
+        """#)
+
+        let challenge = try XCTUnwrap(TiebaWebSubmissionChallengePayload.challenge(
+            from: [payload],
+            messages: ["请完成安全验证"]
+        ))
+
+        XCTAssertEqual(challenge.message, "请完成安全验证")
+        XCTAssertEqual(challenge.verificationMD5?.value, "fixture-md5")
+        XCTAssertEqual(challenge.passToken?.value, "fixture-pass-token")
+        XCTAssertEqual(challenge.verificationType, "slide")
+        XCTAssertEqual(challenge.previousVerificationType, "old")
+        XCTAssertEqual(challenge.pictureURL?.host, "tieba.baidu.com")
+        XCTAssertEqual(challenge.blockPrompt?.confirmTitle, "验证")
+        XCTAssertEqual(challenge.extra?.textImageURL?.host, "himg.bdimg.com")
+        XCTAssertEqual(challenge.extra?.slideEndpointURL?.path, "/challenge/slide")
+        XCTAssertEqual(challenge.antiState?.verificationState, "1")
+        XCTAssertEqual(challenge.antiState?.daysToFree, 3)
+        XCTAssertEqual(challenge.antiState?.hasChance, true)
+        XCTAssertEqual(challenge.extensionMessage, "补充说明")
+        XCTAssertEqual(challenge.toastMessage, "验证提示")
+        XCTAssertFalse(challenge.hasConflictingPayload)
+    }
+
+    func testConflictingCredentialsAreDiscardedWithoutGuessing() throws {
+        let top = try decode(#"{"need_vcode":1,"vcode_md5":"first","pass_token":"one"}"#)
+        let nested = try decode(#"{"need_vcode":1,"vcode_md5":"second","pass_token":"two"}"#)
+
+        let challenge = try XCTUnwrap(TiebaWebSubmissionChallengePayload.challenge(
+            from: [top, nested],
+            messages: []
+        ))
+
+        XCTAssertNil(challenge.verificationMD5)
+        XCTAssertNil(challenge.passToken)
+        XCTAssertTrue(challenge.hasConflictingPayload)
+    }
+
+    func testChallengeURLsRejectHTTPUserInfoPrivateAndForeignHosts() throws {
+        let values = [
+            "http://tieba.baidu.com/challenge",
+            "https://user@tieba.baidu.com/challenge",
+            "https://127.0.0.1/challenge",
+            "https://example.com/challenge"
+        ]
+
+        for value in values {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "need_vcode": 1,
+                "vcode_pic_url": value
+            ])
+            let payload = try JSONDecoder().decode(
+                TiebaWebSubmissionChallengePayload.self,
+                from: data
+            )
+            let challenge = try XCTUnwrap(TiebaWebSubmissionChallengePayload.challenge(
+                from: [payload],
+                messages: []
+            ))
+            XCTAssertNil(challenge.pictureURL, value)
+        }
+    }
+
+    func testFalseFlagDoesNotCreateChallengeButUnknownNonemptyFlagFailsClosed() throws {
+        for value in ["0", "false", "off", "none"] {
+            let payload = try decode("{\"need_vcode\":\"\(value)\"}")
+            XCTAssertNil(TiebaWebSubmissionChallengePayload.challenge(
+                from: [payload],
+                messages: []
+            ))
+        }
+
+        let unknown = try decode(#"{"need_vcode":"unexpected-state"}"#)
+        XCTAssertNotNil(TiebaWebSubmissionChallengePayload.challenge(
+            from: [unknown],
+            messages: []
+        ))
+    }
+
+    func testVerificationMessageRemainsFallbackWhenStructuredFieldsAreAbsent() throws {
+        let empty = try decode("{}")
+        let challenge = try XCTUnwrap(TiebaWebSubmissionChallengePayload.challenge(
+            from: [empty],
+            messages: ["captcha required"]
+        ))
+        XCTAssertEqual(challenge.message, "captcha required")
+    }
+
+    private func decode(_ json: String) throws -> TiebaWebSubmissionChallengePayload {
+        try JSONDecoder().decode(
+            TiebaWebSubmissionChallengePayload.self,
+            from: Data(json.utf8)
+        )
+    }
+}

--- a/TiebaPureTests/ContentSubmissionNetworkTests.swift
+++ b/TiebaPureTests/ContentSubmissionNetworkTests.swift
@@ -110,6 +110,25 @@ final class ContentSubmissionRequestFactoryTests: XCTestCase {
         XCTAssertFalse(headers["Cookie", default: ""].contains("BAIDUID"))
         XCTAssertEqual(headers["Origin"], "https://tieba.baidu.com")
         XCTAssertEqual(headers["Referer"], "https://tieba.baidu.com/f?kw=fixture")
+
+        let tbsHeaders = try TiebaContentSubmissionRequestFactory.webTBSHeaders(account: Self.account)
+        let replyHeaders = try TiebaContentSubmissionRequestFactory.webReplyHeaders(
+            account: Self.account,
+            threadID: 1001
+        )
+        let uploadHeaders = try TiebaContentSubmissionRequestFactory.webUploadHeaders(
+            account: Self.account,
+            threadID: 1001
+        )
+        for candidate in [tbsHeaders, replyHeaders, uploadHeaders] {
+            XCTAssertEqual(candidate["Cookie"], headers["Cookie"])
+            XCTAssertEqual(candidate["User-Agent"], headers["User-Agent"])
+            XCTAssertEqual(candidate["Accept"], headers["Accept"])
+            XCTAssertEqual(candidate["Accept-Language"], headers["Accept-Language"])
+        }
+        XCTAssertNil(tbsHeaders["Origin"])
+        XCTAssertNil(tbsHeaders["X-Requested-With"])
+        XCTAssertEqual(uploadHeaders["Referer"], replyHeaders["Referer"])
     }
 
     func testReplyBodyPreservesLeadingTrailingWhitespaceAndLineBreaks() throws {
@@ -471,6 +490,69 @@ final class FixtureContentSubmissionTests: XCTestCase {
 #endif
 
 final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
+    func testStrictWebTBSRefreshAcceptsSupportedLoginShapesAndUsesWebIdentity() async throws {
+        for payload in [
+            #"{"tbs":" fresh-tbs ","is_login":1}"#,
+            #"{"tbs":"fresh-tbs","is_login":true}"#,
+            #"{"tbs":"fresh-tbs","is_login":"1"}"#
+        ] {
+            let harness = makeAPI(mode: .tbsResponse(Data(payload.utf8)))
+            defer { SubmissionURLProtocol.remove(id: harness.id) }
+
+            let tbs = try await harness.api.strictlyRefreshedPostingTBS(for: Self.account)
+
+            XCTAssertEqual(tbs, "fresh-tbs")
+            let records = SubmissionURLProtocol.records(id: harness.id)
+            XCTAssertEqual(records.count, 1)
+            let request = try XCTUnwrap(records.first)
+            XCTAssertEqual(request.path, "/dc/common/tbs")
+            XCTAssertEqual(request.method, "GET")
+            XCTAssertEqual(request.scheme, "https")
+            XCTAssertEqual(request.host, "tieba.baidu.com")
+            XCTAssertNil(request.body)
+            XCTAssertNotNil(Int64(Self.queryFields(from: request)["t", default: ""]))
+            XCTAssertEqual(request.header(named: "Cookie"), "BDUSS=fixture-bduss; STOKEN=fixture-stoken")
+            XCTAssertFalse(request.header(named: "Cookie")?.contains("BAIDUID") ?? true)
+            XCTAssertTrue(request.header(named: "User-Agent")?.contains("iPhone OS 18_0") == true)
+            XCTAssertNil(request.header(named: "Origin"))
+            XCTAssertNil(request.header(named: "X-Requested-With"))
+        }
+    }
+
+    func testStrictWebTBSRefreshRejectsLoggedOutResponseEvenWithNonemptyTBS() async {
+        for loginValue in ["0", "false", #""0""#] {
+            let payload = Data(#"{"tbs":"anonymous-tbs","is_login":\#(loginValue)}"#.utf8)
+            let harness = makeAPI(mode: .tbsResponse(payload))
+            defer { SubmissionURLProtocol.remove(id: harness.id) }
+
+            do {
+                _ = try await harness.api.strictlyRefreshedPostingTBS(for: Self.account)
+                XCTFail("Expected logged-out TBS response to be rejected")
+            } catch let error as ContentSubmissionError {
+                XCTAssertEqual(error, .sessionExpired)
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), ["/dc/common/tbs"])
+        }
+    }
+
+    func testStrictWebTBSRefreshRejectsMissingTBSBeforeMutation() async {
+        let harness = makeAPI(mode: .tbsResponse(Data(#"{"tbs":"","is_login":1}"#.utf8)))
+        defer { SubmissionURLProtocol.remove(id: harness.id) }
+
+        do {
+            _ = try await harness.api.submitContent(account: Self.account, request: Self.textReply)
+            XCTFail("Expected empty TBS to stop submission")
+        } catch let error as TiebaMutationError {
+            XCTAssertEqual(error, .missingTBS)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), ["/dc/common/tbs"])
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 0)
+    }
+
     func testAllReplyTargetsUseExactWebFormAndNeverBootstrapOrFallback() async throws {
         let cases: [(ContentSubmissionKind, Set<String>, String)] = [
             (
@@ -502,17 +584,18 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
                 )
                 XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: 9001))
                 XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
-                    "/c/s/login",
+                    "/dc/common/tbs",
                     "/mo/q/apubpost"
                 ])
                 let bootstrapCalls = await bootstrap.callCount()
                 XCTAssertEqual(bootstrapCalls, 0)
 
-                let mutation = try XCTUnwrap(SubmissionURLProtocol.records(id: harness.id).last)
+                let records = SubmissionURLProtocol.records(id: harness.id)
+                let tbsRequest = try XCTUnwrap(records.first)
+                let mutation = try XCTUnwrap(records.last)
                 XCTAssertEqual(mutation.scheme, "https")
                 XCTAssertEqual(mutation.host, "tieba.baidu.com")
                 XCTAssertEqual(mutation.method, "POST")
-                XCTAssertEqual(mutation.header(named: "Host"), "tieba.baidu.com")
                 XCTAssertEqual(
                     mutation.header(named: "Cookie"),
                     "BDUSS=fixture-bduss; STOKEN=fixture-stoken"
@@ -525,10 +608,9 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
                 )
                 XCTAssertEqual(mutation.header(named: "X-Requested-With"), "XMLHttpRequest")
                 XCTAssertEqual(mutation.header(named: "Accept"), "application/json, text/plain, */*")
-                XCTAssertTrue(
-                    mutation.header(named: "User-Agent")?
-                        .hasSuffix("tieba/11.10.8.6 skin/default") == true
-                )
+                XCTAssertEqual(mutation.header(named: "Cookie"), tbsRequest.header(named: "Cookie"))
+                XCTAssertEqual(mutation.header(named: "User-Agent"), tbsRequest.header(named: "User-Agent"))
+                XCTAssertTrue(mutation.header(named: "User-Agent")?.contains("iPhone OS 18_0") == true)
 
                 let fields = try Self.formFields(from: mutation)
                 XCTAssertEqual(Set(fields.keys), expectedKeys)
@@ -594,7 +676,7 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
 
         XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 7001, postID: 7002))
         XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
-            "/c/s/login",
+            "/dc/common/tbs",
             "/f/commit/thread/add"
         ])
         let bootstrapCalls = await bootstrap.callCount()
@@ -602,7 +684,9 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         XCTAssertEqual(SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id), 1)
         XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id), 0)
 
-        let mutation = try XCTUnwrap(SubmissionURLProtocol.records(id: harness.id).last)
+        let records = SubmissionURLProtocol.records(id: harness.id)
+        let tbsRequest = try XCTUnwrap(records.first)
+        let mutation = try XCTUnwrap(records.last)
         XCTAssertEqual(mutation.scheme, "https")
         XCTAssertEqual(mutation.host, "tieba.baidu.com")
         XCTAssertEqual(mutation.method, "POST")
@@ -612,6 +696,9 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
             "BDUSS=fixture-bduss; STOKEN=fixture-stoken"
         )
         XCTAssertFalse(mutation.header(named: "Cookie")?.contains("BAIDUID") ?? true)
+        XCTAssertEqual(mutation.header(named: "Cookie"), tbsRequest.header(named: "Cookie"))
+        XCTAssertEqual(mutation.header(named: "User-Agent"), tbsRequest.header(named: "User-Agent"))
+        XCTAssertTrue(mutation.header(named: "User-Agent")?.contains("iPhone OS 18_0") == true)
         XCTAssertTrue(
             mutation.header(named: "Content-Type")?
                 .hasPrefix("application/x-www-form-urlencoded") == true
@@ -742,7 +829,10 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
             ),
             (
                 #"{"result":0,"err_code":40,"err_msg":"请完成安全验证","data":{"vcode_md5":"fixture-md5"}}"#,
-                .verificationRequired(message: "请完成安全验证")
+                .verificationRequired(ContentSubmissionChallenge(
+                    message: "请完成安全验证",
+                    verificationMD5: SubmissionSecret("fixture-md5")
+                ))
             )
         ]
 
@@ -759,6 +849,51 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
             )
             SubmissionURLProtocol.remove(id: harness.id)
         }
+    }
+
+    func testWebThreadStructuredChallengeIsTypedWithoutRetryingFinalWrite() async throws {
+        let payload = #"""
+        {
+          "result": 0,
+          "err_code": 40,
+          "err_msg": "请完成安全验证",
+          "data": {
+            "info": {
+              "need_vcode": 1,
+              "vcode_md5": "fixture-md5",
+              "vcode_type": "slide",
+              "pass_token": "fixture-pass-token",
+              "vcode_pic_url": "https://tieba.baidu.com/challenge.png",
+              "anti_stat": {"vcode_stat":1,"days_tofree":3}
+            },
+            "ext_msg": "验证后可继续"
+          }
+        }
+        """#
+        let harness = makeAPI(mode: .finalResponse(Data(payload.utf8)))
+        defer { SubmissionURLProtocol.remove(id: harness.id) }
+
+        do {
+            _ = try await harness.api.submitContent(
+                account: Self.account,
+                request: Self.newThreadRequest()
+            )
+            XCTFail("Expected structured verification challenge")
+        } catch let ContentSubmissionError.verificationRequired(challenge) {
+            XCTAssertEqual(challenge.message, "请完成安全验证")
+            XCTAssertEqual(challenge.verificationMD5?.value, "fixture-md5")
+            XCTAssertEqual(challenge.verificationType, "slide")
+            XCTAssertEqual(challenge.passToken?.value, "fixture-pass-token")
+            XCTAssertEqual(challenge.pictureURL?.host, "tieba.baidu.com")
+            XCTAssertEqual(challenge.antiState?.verificationState, "1")
+            XCTAssertEqual(challenge.antiState?.daysToFree, 3)
+            XCTAssertEqual(challenge.extensionMessage, "验证后可继续")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/f/commit/thread/add", id: harness.id), 1)
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/thread/add", id: harness.id), 0)
     }
 
     func testWebThreadAmbiguousResponsesHaveUnknownOutcomeWithoutFallbackOrRetry() async {
@@ -918,6 +1053,46 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         }
     }
 
+    func testWebReplyStructuredChallengeAndSessionPriorityStayTyped() async throws {
+        let challengePayload = #"""
+        {
+          "error_code": 40,
+          "error_msg": "请完成安全验证",
+          "data": {
+            "info": {
+              "need_vcode": true,
+              "vcode_md5": "fixture-reply-md5",
+              "pass_token": "fixture-reply-token"
+            }
+          }
+        }
+        """#
+        let harness = makeAPI(mode: .finalResponse(Data(challengePayload.utf8)))
+        defer { SubmissionURLProtocol.remove(id: harness.id) }
+
+        do {
+            _ = try await harness.api.submitContent(account: Self.account, request: Self.textReply)
+            XCTFail("Expected structured reply challenge")
+        } catch let ContentSubmissionError.verificationRequired(challenge) {
+            XCTAssertEqual(challenge.verificationMD5?.value, "fixture-reply-md5")
+            XCTAssertEqual(challenge.passToken?.value, "fixture-reply-token")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 1)
+
+        let sessionPayload = #"""
+        {"error_code":110001,"error_msg":"用户未登录","need_vcode":1,"vcode_md5":"ignored"}
+        """#
+        let sessionHarness = makeAPI(mode: .finalResponse(Data(sessionPayload.utf8)))
+        defer { SubmissionURLProtocol.remove(id: sessionHarness.id) }
+        await assertSubmissionError(
+            from: sessionHarness.api,
+            request: Self.textReply,
+            equals: .sessionExpired
+        )
+    }
+
     func testWebReplyMalformedTopLevelOrNestedStatusFieldsHaveUnknownOutcome() async {
         let payloads = [
             #"{"result":true,"tid":1001,"pid":9001}"#,
@@ -1020,7 +1195,7 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         let records = SubmissionURLProtocol.records(id: harness.id)
         XCTAssertEqual(records.map(\.path), [
             "/mo/q/cooluploadpic",
-            "/c/s/login",
+            "/dc/common/tbs",
             "/mo/q/apubpost"
         ])
         let bootstrapCalls = await bootstrap.callCount()
@@ -1030,7 +1205,6 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         XCTAssertEqual(upload.scheme, "https")
         XCTAssertEqual(upload.host, "tieba.baidu.com")
         XCTAssertEqual(upload.method, "POST")
-        XCTAssertEqual(upload.header(named: "Host"), "tieba.baidu.com")
         XCTAssertEqual(Self.queryFields(from: upload)["type"], "ajax")
         XCTAssertFalse(Self.queryFields(from: upload)["r", default: ""].isEmpty)
         XCTAssertEqual(
@@ -1039,24 +1213,27 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         )
         XCTAssertFalse(upload.header(named: "Cookie")?.contains("BAIDUID") ?? true)
         XCTAssertEqual(upload.header(named: "Origin"), "https://tieba.baidu.com")
-        XCTAssertNil(upload.header(named: "Referer"))
+        XCTAssertEqual(
+            upload.header(named: "Referer"),
+            "https://tieba.baidu.com/p/1001?lp=5028&mo_device=1&is_jingpost=0&pn=1&"
+        )
         XCTAssertEqual(upload.header(named: "X-Requested-With"), "XMLHttpRequest")
         XCTAssertEqual(upload.header(named: "Accept"), "application/json, text/plain, */*")
-        XCTAssertTrue(
-            upload.header(named: "User-Agent")?
-                .hasSuffix("tieba/11.10.8.6 skin/default") == true
-        )
+        XCTAssertTrue(upload.header(named: "User-Agent")?.contains("iPhone OS 18_0") == true)
         let uploadFields = try Self.formFields(from: upload)
         XCTAssertEqual(Set(uploadFields.keys), ["pic"])
         XCTAssertEqual(uploadFields["pic"], imageData.base64EncodedString())
 
-        let login = try XCTUnwrap(records.first(where: { $0.path == "/c/s/login" }))
-        let loginFields = try Self.formFields(from: login)
-        XCTAssertEqual(loginFields["_client_version"], "22.5.1.0")
-        XCTAssertEqual(loginFields["bdusstoken"], "fixture-bduss")
-        XCTAssertEqual(Set(loginFields.keys), Set(["_client_version", "bdusstoken", "sign"]))
+        let tbsRequest = try XCTUnwrap(records.first(where: { $0.path == "/dc/common/tbs" }))
+        XCTAssertEqual(tbsRequest.method, "GET")
+        XCTAssertNil(tbsRequest.body)
+        XCTAssertNotNil(Int64(Self.queryFields(from: tbsRequest)["t", default: ""]))
 
         let mutation = try XCTUnwrap(records.last)
+        for identityHeader in ["Cookie", "User-Agent", "Accept", "Accept-Language"] {
+            XCTAssertEqual(upload.header(named: identityHeader), tbsRequest.header(named: identityHeader))
+            XCTAssertEqual(mutation.header(named: identityHeader), tbsRequest.header(named: identityHeader))
+        }
         let mutationFields = try Self.formFields(from: mutation)
         XCTAssertEqual(mutationFields["co"], "带图回复")
         XCTAssertEqual(mutationFields["upload_img_info"], Self.fixtureImageInfo)
@@ -1092,7 +1269,7 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
                 equals: expected
             )
             XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), ["/mo/q/cooluploadpic"])
-            XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/s/login", id: harness.id), 0)
+            XCTAssertEqual(SubmissionURLProtocol.count(path: "/dc/common/tbs", id: harness.id), 0)
             XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 0)
             XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
             SubmissionURLProtocol.remove(id: harness.id)
@@ -1170,7 +1347,7 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
 
         XCTAssertEqual(receipt, ContentSubmissionReceipt(threadID: 1001, postID: 9001))
         XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
-            "/c/s/login",
+            "/dc/common/tbs",
             "/mo/q/apubpost"
         ])
     }
@@ -1187,7 +1364,7 @@ final class ContentSubmissionNetworkIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(SubmissionURLProtocol.paths(id: harness.id), [
-            "/c/s/login"
+            "/dc/common/tbs"
         ])
         XCTAssertEqual(SubmissionURLProtocol.count(path: "/mo/q/apubpost", id: harness.id), 0)
         XCTAssertEqual(SubmissionURLProtocol.count(path: "/c/c/post/add", id: harness.id), 0)
@@ -1484,6 +1661,7 @@ private enum SubmissionStubMode: Sendable {
     case finalResponse(Data)
     case uploadResponse(Data)
     case uploadTransportFailure
+    case tbsResponse(Data)
     case tbsRefreshFailure
     case finalTransportFailure
     case finalDecodeFailure
@@ -1577,13 +1755,15 @@ private final class SubmissionURLProtocol: URLProtocol {
                 contentType: "application/json"
             )
 
-        case "/c/s/login":
+        case "/dc/common/tbs":
             if case .tbsRefreshFailure = mode {
                 respond(statusCode: 503, payload: Data("unavailable".utf8))
+            } else if case let .tbsResponse(payload) = mode {
+                respond(statusCode: 200, payload: payload, contentType: "application/json")
             } else {
                 respond(
                     statusCode: 200,
-                    payload: Data(#"{"error_code":"0","anti":{"tbs":"fresh-tbs"}}"#.utf8),
+                    payload: Data(#"{"tbs":"fresh-tbs","is_login":1}"#.utf8),
                     contentType: "application/json"
                 )
             }
@@ -1601,7 +1781,7 @@ private final class SubmissionURLProtocol: URLProtocol {
                 respond(statusCode: 200, payload: Data([0x0f]))
             case .holdFinalRequestUntilCancellation:
                 break
-            case .tbsRefreshFailure, .uploadResponse, .uploadTransportFailure:
+            case .tbsRefreshFailure, .tbsResponse, .uploadResponse, .uploadTransportFailure:
                 client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
             }
 

--- a/project.yml
+++ b/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.8
-        CURRENT_PROJECT_VERSION: 52
+        MARKETING_VERSION: 1.4.9
+        CURRENT_PROJECT_VERSION: 53
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -56,8 +56,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.8
-        CURRENT_PROJECT_VERSION: 52
+        MARKETING_VERSION: 1.4.9
+        CURRENT_PROJECT_VERSION: 53
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## Changes

- Use the authenticated web TBS endpoint and a consistent web identity for TBS, image upload, new-thread, and reply requests.
- Parse structured verification and anti-abuse responses, reject conflicting or unsafe challenge data, and redact challenge secrets from user-facing errors.
- Expand posting and reply risk disclosures and update the app version to 1.4.9 (53).

## Validation

- iOS Simulator Debug build
- Focused iOS 26.5 tests: 68 passed, 0 failed, 0 skipped
- XcodeGen regeneration produced a stable project