### PR TITLE
修复首页导航、评论点赞与设置页布局

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		66CB3F6B00C11572EF7276D1 /* TiebaUserProfileAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55649E6AEA1AD2EF4813452 /* TiebaUserProfileAPI.swift */; };
 		691639A3C4F64DE3F892A98D /* ContentBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B4550B620AEBC6B7EA4F46 /* ContentBlockView.swift */; };
 		6A3F2F36CE6C23941BD07F7E /* MediaPreviewPresentationArbiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A89193F661C5F61F3470AC /* MediaPreviewPresentationArbiter.swift */; };
+		6B31188D9AA7AE70A00D53EF /* HomeNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F66E0D4FBBBBF5F6DA8C979 /* HomeNavigationTests.swift */; };
 		6BF8CB32442EA2DD70E1BEE9 /* SocialRelationshipStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A829A6D2ABD0F1D55D90E6 /* SocialRelationshipStateTests.swift */; };
 		7189EC19091324F1EF6886C5 /* OrderedCollectionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC583D811BB2682A40FF679 /* OrderedCollectionPersistence.swift */; };
 		71CE2CA03E418210ED2CCF8B /* CapsuleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994E9D3128F82A0683DA39E0 /* CapsuleLabel.swift */; };
@@ -388,6 +389,7 @@
 		9D3DFA01DD01FD4EA295E006 /* ForumHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumHubView.swift; sourceTree = "<group>"; };
 		9DC309A0384A60EB41BF7B46 /* LegacyScrollTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyScrollTelemetry.swift; sourceTree = "<group>"; };
 		9F1C4599FA7188B0D810AE19 /* UserProfileMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileMutationTests.swift; sourceTree = "<group>"; };
+		9F66E0D4FBBBBF5F6DA8C979 /* HomeNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationTests.swift; sourceTree = "<group>"; };
 		A37648A3CE4B69FBC511A204 /* ContentDraftCodecPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftCodecPolicyTests.swift; sourceTree = "<group>"; };
 		A87CD00DD298F86614F66AAD /* Lbs.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lbs.pb.swift; sourceTree = "<group>"; };
 		A8FC3906D642656961F9DAE4 /* ContentSubmissionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSubmissionCoordinator.swift; sourceTree = "<group>"; };
@@ -733,6 +735,7 @@
 				3A20C49C14881A792297DFF2 /* FileOrderedCollectionPersistenceTests.swift */,
 				7F4A700D0BB079E5CEC104C1 /* FixtureDecodingTests.swift */,
 				CBF457C95754D5EAA87ECEFD /* ForumSignTests.swift */,
+				9F66E0D4FBBBBF5F6DA8C979 /* HomeNavigationTests.swift */,
 				99D55E6E9D9C9BE0630B5C89 /* InlineTextReuseTests.swift */,
 				1781B1F0906AC36975BFDE9F /* LegacyScrollTelemetryTests.swift */,
 				DE6967B15A66331DA9F947F0 /* MessageAPITests.swift */,
@@ -1272,6 +1275,7 @@
 				4E2A3DFCCFD09D57BC62A04F /* FileOrderedCollectionPersistenceTests.swift in Sources */,
 				34511F43DA6B267EB2816388 /* FixtureDecodingTests.swift in Sources */,
 				15DF8B955B68CF4317A10AE7 /* ForumSignTests.swift in Sources */,
+				6B31188D9AA7AE70A00D53EF /* HomeNavigationTests.swift in Sources */,
 				E209C76E1A8310E8F94F6A32 /* InlineTextReuseTests.swift in Sources */,
 				D774D89D5189D8CB9A1D877B /* LegacyScrollTelemetryTests.swift in Sources */,
 				80D70D09DAD45ED618094984 /* MessageAPITests.swift in Sources */,
@@ -1397,13 +1401,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.9;
+				MARKETING_VERSION = 1.4.10;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1414,14 +1418,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.9;
+				MARKETING_VERSION = 1.4.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1467,14 +1471,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.9;
+				MARKETING_VERSION = 1.4.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1487,13 +1491,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.9;
+				MARKETING_VERSION = 1.4.10;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -853,6 +853,7 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 replyCount: 3,
                 viewCount: 120,
                 likeCount: 12,
+                firstPostID: 2_001,
                 blocks: [.text("合成摘要，不含真实贴吧用户内容。")] + fourImages,
                 isGood: true
             ),

--- a/TiebaPure/Core/UI/MetadataLine.swift
+++ b/TiebaPure/Core/UI/MetadataLine.swift
@@ -102,25 +102,84 @@ struct InteractionStatsView: View {
     var comments: Int?
     var likes: Int?
     var font: Font = .subheadline
+    var isLiked = false
+    var isLikeUpdating = false
+    var onCommentsTap: (() -> Void)?
+    var onLikesTap: (() -> Void)?
+    var commentsAccessibilityIdentifier: String?
+    var likesAccessibilityIdentifier: String?
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: TiebaPureTheme.Spacing.md) {
+        HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.md) {
             if let comments {
-                stat(systemImage: "bubble.right", value: comments, label: "评论")
+                stat(
+                    systemImage: "bubble.right",
+                    value: comments,
+                    label: "评论",
+                    action: onCommentsTap,
+                    isSelected: false,
+                    isUpdating: false,
+                    accessibilityIdentifier: commentsAccessibilityIdentifier
+                )
                     .frame(maxWidth: .infinity)
             }
             if let likes {
-                stat(systemImage: "hand.thumbsup", value: likes, label: "点赞")
+                stat(
+                    systemImage: isLiked ? "hand.thumbsup.fill" : "hand.thumbsup",
+                    value: likes,
+                    label: "点赞",
+                    action: onLikesTap,
+                    isSelected: isLiked,
+                    isUpdating: isLikeUpdating,
+                    accessibilityIdentifier: likesAccessibilityIdentifier
+                )
                     .frame(maxWidth: .infinity)
             }
         }
         .font(font)
         .foregroundStyle(.secondary)
         .frame(maxWidth: .infinity, alignment: .center)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(
+            children: onCommentsTap != nil || onLikesTap != nil ? .contain : .combine
+        )
     }
 
-    private func stat(systemImage: String, value: Int, label: String) -> some View {
+    @ViewBuilder
+    private func stat(
+        systemImage: String,
+        value: Int,
+        label: String,
+        action: (() -> Void)?,
+        isSelected: Bool,
+        isUpdating: Bool,
+        accessibilityIdentifier: String?
+    ) -> some View {
+        if let action {
+            Button(action: action) {
+                statLabel(
+                    systemImage: systemImage,
+                    value: value,
+                    isSelected: isSelected
+                )
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isUpdating)
+            .accessibilityLabel(label == "点赞" && isSelected ? "取消点赞" : label)
+            .accessibilityValue(
+                label == "评论" ? "当前\(value)条评论" : "当前\(value)个赞"
+            )
+            .accessibilityHint(accessibilityHint(label: label, isUpdating: isUpdating))
+            .accessibilityIdentifier(accessibilityIdentifier ?? "interaction-\(label)-button")
+        } else {
+            statLabel(systemImage: systemImage, value: value, isSelected: isSelected)
+                .accessibilityLabel("\(label)\(value)")
+                .accessibilityIdentifier(accessibilityIdentifier ?? "interaction-\(label)-count")
+        }
+    }
+
+    private func statLabel(systemImage: String, value: Int, isSelected: Bool) -> some View {
         HStack(spacing: TiebaPureTheme.Spacing.xxs) {
             Image(systemName: systemImage)
                 .font(.system(size: TiebaPureTheme.IconSize.inline))
@@ -131,7 +190,14 @@ struct InteractionStatsView: View {
                 .fixedSize(horizontal: true, vertical: false)
         }
         .fixedSize(horizontal: true, vertical: false)
-        .accessibilityLabel("\(label)\(value)")
+        .foregroundStyle(isSelected ? TiebaPureTheme.ColorToken.primaryAccent : Color.secondary)
+    }
+
+    private func accessibilityHint(label: String, isUpdating: Bool) -> String {
+        if isUpdating {
+            return "正在提交"
+        }
+        return label == "评论" ? "进入帖子并定位到评论区" : "双击切换点赞状态"
     }
 }
 

--- a/TiebaPure/Core/UI/ReaderSplitLayout.swift
+++ b/TiebaPure/Core/UI/ReaderSplitLayout.swift
@@ -1,22 +1,29 @@
 import SwiftUI
 
+enum ThreadDetailInitialDestination: Hashable {
+    case replies
+}
+
 /// Identity of a thread shown in the trailing detail column of the
 /// regular-width reader layout.
 struct ReaderSplitThreadRoute: Hashable {
     let threadID: Int64
     let forumID: Int64?
     let initialPostID: UInt64?
+    let initialDestination: ThreadDetailInitialDestination?
     let ownThreadDeletionTarget: OwnThreadDeletionTarget?
 
     init(
         threadID: Int64,
         forumID: Int64?,
         initialPostID: UInt64? = nil,
+        initialDestination: ThreadDetailInitialDestination? = nil,
         ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil
     ) {
         self.threadID = threadID
         self.forumID = forumID
         self.initialPostID = initialPostID
+        self.initialDestination = initialDestination
         self.ownThreadDeletionTarget = ownThreadDeletionTarget
     }
 }
@@ -142,6 +149,7 @@ struct ReaderSplitLayout<Route: Hashable, ListColumn: View, DetailRoot: View>: V
                             threadID: route.threadID,
                             forumID: route.forumID,
                             initialPostID: route.initialPostID,
+                            initialDestination: route.initialDestination,
                             ownThreadDeletionTarget: route.ownThreadDeletionTarget
                         )
                         // Replacing the selection must never reuse the

--- a/TiebaPure/Domain/Mapping/ThreadMapper.swift
+++ b/TiebaPure/Domain/Mapping/ThreadMapper.swift
@@ -36,6 +36,8 @@ enum ThreadMapper {
             replyCount: Int(proto.replyNum),
             viewCount: Int(proto.viewNum),
             likeCount: likeCount(from: proto),
+            firstPostID: proto.firstPostID > 0 ? UInt64(proto.firstPostID) : nil,
+            isLiked: proto.agree.hasAgree_p != 0,
             createdAt: proto.createTime == 0 ? nil : Date(timeIntervalSince1970: TimeInterval(proto.createTime)),
             lastReplyAt: proto.lastTimeInt == 0 ? nil : Date(timeIntervalSince1970: TimeInterval(proto.lastTimeInt)),
             blocks: blocks,

--- a/TiebaPure/Domain/Models/ThreadSummary.swift
+++ b/TiebaPure/Domain/Models/ThreadSummary.swift
@@ -10,6 +10,8 @@ struct ThreadSummary: Identifiable, Equatable, Sendable {
     var replyCount: Int
     var viewCount: Int
     var likeCount: Int
+    var firstPostID: UInt64?
+    var isLiked: Bool
     var createdAt: Date?
     var lastReplyAt: Date?
     var blocks: [ContentBlock]
@@ -27,6 +29,8 @@ struct ThreadSummary: Identifiable, Equatable, Sendable {
         replyCount: Int,
         viewCount: Int,
         likeCount: Int = 0,
+        firstPostID: UInt64? = nil,
+        isLiked: Bool = false,
         createdAt: Date? = nil,
         lastReplyAt: Date? = nil,
         blocks: [ContentBlock],
@@ -43,6 +47,8 @@ struct ThreadSummary: Identifiable, Equatable, Sendable {
         self.replyCount = replyCount
         self.viewCount = viewCount
         self.likeCount = likeCount
+        self.firstPostID = firstPostID
+        self.isLiked = isLiked
         self.createdAt = createdAt
         self.lastReplyAt = lastReplyAt
         self.blocks = blocks

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -4,6 +4,7 @@ struct ForumThreadsView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     @Environment(\.readerSplitOpenThread) private var readerSplitOpenThread
+    @Environment(\.isReaderSplitListColumn) private var isReaderSplitListColumn
     @Environment(\.dismiss) private var dismiss
     let account: Account?
     let forum: Forum
@@ -553,9 +554,12 @@ struct ForumThreadsView: View {
         // `navigationDestination` boundary, so Home/ForumHub pass this
         // closure directly. The environment action remains a fallback for a
         // list embedded directly in a ReaderSplitLayout column.
-        let parentAction = openThreadInParent ?? readerSplitOpenThread?.open
+        let parentAction = openThreadInParent
+            ?? (isReaderSplitListColumn ? readerSplitOpenThread?.open : nil)
         if ForumThreadsOpenRoutingPolicy.destination(
-            hasParentHandler: parentAction != nil
+            hasExplicitParentHandler: openThreadInParent != nil,
+            hasReaderSplitHandler: readerSplitOpenThread != nil,
+            isReaderSplitListColumn: isReaderSplitListColumn
         ) == .parentReader, let parentAction {
             parentAction(ReaderSplitThreadRoute(threadID: threadID, forumID: forumID))
             return
@@ -926,6 +930,17 @@ enum ForumThreadsOpenRoutingPolicy {
     static func destination(hasParentHandler: Bool) -> ForumThreadsOpenDestination {
         hasParentHandler ? .parentReader : .localStack
     }
+
+    static func destination(
+        hasExplicitParentHandler: Bool,
+        hasReaderSplitHandler: Bool,
+        isReaderSplitListColumn: Bool
+    ) -> ForumThreadsOpenDestination {
+        destination(
+            hasParentHandler: hasExplicitParentHandler
+                || (hasReaderSplitHandler && isReaderSplitListColumn)
+        )
+    }
 }
 
 private struct ForumThreadRoute {
@@ -1044,7 +1059,12 @@ struct ForumThreadRow: View {
     var onOpenUser: ((UserSummary) -> Void)?
     var onBlockForum: ((ThreadSummary) -> Void)?
     var onOpenMedia: ((ReaderMediaItem, [ReaderMediaItem], CGRect?, UIImage?, ImagePreviewSourceAnchor?) -> Void)?
+    var onOpenComments: (() -> Void)?
+    var isLikeUpdating = false
+    var onToggleLike: (() -> Void)?
     var threadOpenAccessibilityIdentifier = "thread-open-area"
+    var commentsAccessibilityIdentifier: String?
+    var likesAccessibilityIdentifier: String?
 
     var body: some View {
         ReaderCard(showsDivider: presentation.showsDivider, cornerRadius: presentation.cardRadius) {
@@ -1116,7 +1136,13 @@ struct ForumThreadRow: View {
 
                 InteractionStatsView(
                     comments: thread.replyCount,
-                    likes: thread.likeCount
+                    likes: thread.likeCount,
+                    isLiked: thread.isLiked,
+                    isLikeUpdating: isLikeUpdating,
+                    onCommentsTap: onOpenComments,
+                    onLikesTap: onToggleLike,
+                    commentsAccessibilityIdentifier: commentsAccessibilityIdentifier,
+                    likesAccessibilityIdentifier: likesAccessibilityIdentifier
                 )
                     .padding(.top, TiebaPureTheme.Spacing.xxs)
             }
@@ -1384,6 +1410,8 @@ enum ForumThreadTapTarget {
     case threadBody
     case media
     case stats
+    case comments
+    case likes
 }
 
 enum ForumThreadTapDestination: Equatable {
@@ -1391,6 +1419,8 @@ enum ForumThreadTapDestination: Equatable {
     case user
     case thread
     case media
+    case comments
+    case like
     case none
 }
 
@@ -1407,6 +1437,10 @@ enum ForumThreadTapPolicy {
             return .media
         case .stats:
             return .none
+        case .comments:
+            return .comments
+        case .likes:
+            return .like
         }
     }
 }

--- a/TiebaPure/Features/ForumHub/ForumHubView.swift
+++ b/TiebaPure/Features/ForumHub/ForumHubView.swift
@@ -259,6 +259,7 @@ struct ForumHubView: View {
                     threadID: threadRoute.threadID,
                     forumID: threadRoute.forumID,
                     initialPostID: threadRoute.initialPostID,
+                    initialDestination: threadRoute.initialDestination,
                     ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget,
                     openSearchInParent: { scope in
                         openSearch(scope)
@@ -716,4 +717,3 @@ private struct ForumTileButton: View {
         }
     }
 }
-

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct HomeView: View {
     @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var contentSubmissionSettingsStore: ContentSubmissionSettingsStore
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -28,6 +29,9 @@ struct HomeView: View {
     @State private var pendingPaginationRequest = false
     @State private var paginationRequestScheduled = false
     @State private var splitDetailPath: [ReaderSplitThreadRoute] = []
+    @State private var homeLikeOperationIDs: [Int64: UUID] = [:]
+    @State private var homeLikeTasks: [Int64: Task<Void, Never>] = [:]
+    @State private var likeActionError: String?
 
     var body: some View {
         ReaderSplitLayout(
@@ -54,6 +58,11 @@ struct HomeView: View {
         .toolbar(.visible, for: .tabBar)
         .onChange(of: horizontalSizeClass) { sizeClass in
             foldNavigationForSizeClassChange(to: sizeClass)
+        }
+        .alert("提示", isPresented: likeActionErrorIsPresented) {
+            Button("好", role: .cancel) { likeActionError = nil }
+        } message: {
+            Text(likeActionError ?? "")
         }
     }
 
@@ -103,7 +112,9 @@ struct HomeView: View {
                     threadID: threadRoute.threadID,
                     forumID: threadRoute.forumID,
                     initialPostID: threadRoute.initialPostID,
-                    ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget
+                    initialDestination: threadRoute.initialDestination,
+                    ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget,
+                    openForumInParent: openForum
                 )
                 .interactiveNavigationPopStateSync {
                     removeNavigationRouteIfCurrent(route)
@@ -157,6 +168,7 @@ struct HomeView: View {
             programmaticRefreshToken &+= 1
         }
         .onChange(of: account?.sessionIdentity) { _ in
+            cancelHomeLikeTasks()
             requestGeneration += 1
             loadTask?.cancel()
             threads = []
@@ -234,17 +246,30 @@ struct HomeView: View {
     }
 
     private func removeNavigationRouteIfCurrent(_ route: HomeNavigationRoute) {
-        guard navigationPath.last == route else { return }
-        navigationPath.removeLast()
+        navigationPath = HomeNavigationPathPolicy.removingCurrent(
+            route,
+            from: navigationPath
+        )
     }
 
-    private func openThread(threadID: Int64, forumID: Int64?) {
-        let route = ReaderSplitThreadRoute(threadID: threadID, forumID: forumID)
+    private func openThread(
+        threadID: Int64,
+        forumID: Int64?,
+        initialDestination: ThreadDetailInitialDestination? = nil
+    ) {
+        let route = ReaderSplitThreadRoute(
+            threadID: threadID,
+            forumID: forumID,
+            initialDestination: initialDestination
+        )
         if usesSplitDetailLayout {
             openThreadInSplitDetail(route)
             return
         }
-        navigationPath.append(.thread(route))
+        navigationPath = HomeNavigationPathPolicy.pushing(
+            .thread(route),
+            onto: navigationPath
+        )
     }
 
     private func openThreadInSplitDetail(_ route: ReaderSplitThreadRoute) {
@@ -255,7 +280,10 @@ struct HomeView: View {
     }
 
     private func openThreadInCompactStack(_ route: ReaderSplitThreadRoute) {
-        navigationPath.append(.thread(route))
+        navigationPath = HomeNavigationPathPolicy.pushing(
+            .thread(route),
+            onto: navigationPath
+        )
     }
 
     private func openThreadFromNestedForum(_ route: ReaderSplitThreadRoute) {
@@ -264,6 +292,14 @@ struct HomeView: View {
         } else {
             openThreadInCompactStack(route)
         }
+    }
+
+    private func openForum(_ forum: Forum) {
+        RecentForumStore.shared.save(forum)
+        navigationPath = HomeNavigationPathPolicy.pushing(
+            .fromForum(forum),
+            onto: navigationPath
+        )
     }
 
     /// Keeps the open thread when the split layout appears or collapses
@@ -311,8 +347,7 @@ struct HomeView: View {
                             openThread(threadID: thread.id, forumID: thread.forumID)
                         },
                         onOpenForum: { forum in
-                            RecentForumStore.shared.save(forum)
-                            navigationPath.append(.fromForum(forum))
+                            openForum(forum)
                         },
                         onOpenUser: { selectedUser = $0 },
                         onBlockForum: { blockedThread in
@@ -346,7 +381,21 @@ struct HomeView: View {
                             case .openThread:
                                 openThread(threadID: thread.id, forumID: thread.forumID)
                             }
-                        }
+                        },
+                        onOpenComments: {
+                            openThread(
+                                threadID: thread.id,
+                                forumID: thread.forumID,
+                                initialDestination: .replies
+                            )
+                        },
+                        isLikeUpdating: homeLikeOperationIDs[thread.id] != nil,
+                        onToggleLike: contentSubmissionSettingsStore.likesEnabled
+                            && thread.firstPostID != nil
+                            ? { toggleHomeThreadLike(thread) }
+                            : nil,
+                        commentsAccessibilityIdentifier: "home-comments-button-\(thread.id)",
+                        likesAccessibilityIdentifier: "home-like-button-\(thread.id)"
                     )
                     .onAppear {
                         requestLoadMoreIfNeeded(currentIndex: index, totalCount: threads.count)
@@ -392,6 +441,85 @@ struct HomeView: View {
             .padding(.vertical, TiebaPureTheme.Spacing.sm)
             .readableWidth()
         }
+    }
+
+    private var likeActionErrorIsPresented: Binding<Bool> {
+        Binding(
+            get: { likeActionError != nil },
+            set: { isPresented in
+                if isPresented == false { likeActionError = nil }
+            }
+        )
+    }
+
+    private func toggleHomeThreadLike(_ thread: ThreadSummary) {
+        guard contentSubmissionSettingsStore.likesEnabled else { return }
+        guard homeLikeOperationIDs[thread.id] == nil else { return }
+        guard let account else {
+            likeActionError = "登录后才能点赞。"
+            return
+        }
+        guard let postID = thread.firstPostID, postID > 0 else {
+            likeActionError = "暂时无法获取该帖的点赞信息。"
+            return
+        }
+
+        let operationID = UUID()
+        let requestedSession = account.sessionIdentity
+        let targetState = thread.isLiked == false
+        homeLikeOperationIDs[thread.id] = operationID
+        likeActionError = nil
+
+        let task = Task {
+            do {
+                try await environment.socialMutationCoordinator.setPostLiked(
+                    account: account,
+                    threadID: thread.id,
+                    postID: postID,
+                    objectType: .thread,
+                    liked: targetState
+                )
+                try Task.checkCancellation()
+                guard homeLikeOperationIDs[thread.id] == operationID,
+                      self.account?.sessionIdentity == requestedSession else {
+                    throw CancellationError()
+                }
+                applyHomeThreadLikeState(threadID: thread.id, liked: targetState)
+            } catch is CancellationError {
+                // The coordinator owns an already-started write. This view
+                // only stops stale presentation updates.
+            } catch {
+                guard Task.isCancelled == false,
+                      homeLikeOperationIDs[thread.id] == operationID,
+                      self.account?.sessionIdentity == requestedSession else {
+                    finishHomeLikeOperation(threadID: thread.id, operationID: operationID)
+                    return
+                }
+                likeActionError = ReaderErrorMessage.message(for: error)
+            }
+            finishHomeLikeOperation(threadID: thread.id, operationID: operationID)
+        }
+        homeLikeTasks[thread.id] = task
+    }
+
+    private func applyHomeThreadLikeState(threadID: Int64, liked: Bool) {
+        guard let index = threads.firstIndex(where: { $0.id == threadID }),
+              threads[index].isLiked != liked else { return }
+        threads[index].isLiked = liked
+        let delta = liked ? 1 : -1
+        threads[index].likeCount = max(threads[index].likeCount + delta, 0)
+    }
+
+    private func finishHomeLikeOperation(threadID: Int64, operationID: UUID) {
+        guard homeLikeOperationIDs[threadID] == operationID else { return }
+        homeLikeOperationIDs[threadID] = nil
+        homeLikeTasks[threadID] = nil
+    }
+
+    private func cancelHomeLikeTasks() {
+        homeLikeTasks.values.forEach { $0.cancel() }
+        homeLikeTasks.removeAll()
+        homeLikeOperationIDs.removeAll()
     }
 
     @ViewBuilder
@@ -698,6 +826,23 @@ enum HomeNavigationRoute: Hashable {
             displayName: forum.displayName,
             avatarURL: forum.avatarURL
         )
+    }
+}
+
+enum HomeNavigationPathPolicy {
+    static func pushing(
+        _ route: HomeNavigationRoute,
+        onto navigationPath: [HomeNavigationRoute]
+    ) -> [HomeNavigationRoute] {
+        navigationPath + [route]
+    }
+
+    static func removingCurrent(
+        _ route: HomeNavigationRoute,
+        from navigationPath: [HomeNavigationRoute]
+    ) -> [HomeNavigationRoute] {
+        guard navigationPath.last == route else { return navigationPath }
+        return Array(navigationPath.dropLast())
     }
 }
 

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -24,22 +24,24 @@ struct SettingsView: View {
                     }
                 }
                 .pickerStyle(.inline)
+                .labelsHidden()
                 .accessibilityIdentifier("appearance-picker")
-
-                HStack(spacing: TiebaPureTheme.Spacing.sm) {
-                    Label("当前显示", systemImage: "display")
+            } header: {
+                HStack(alignment: .firstTextBaseline, spacing: TiebaPureTheme.Spacing.sm) {
+                    Text("显示模式")
+                        .accessibilityAddTraits(.isHeader)
+                        .accessibilityIdentifier("appearance-section-title")
 
                     Spacer(minLength: TiebaPureTheme.Spacing.sm)
 
-                    Text(effectiveColorScheme == .dark ? "深色" : "浅色")
+                    Text(effectiveAppearanceTitle)
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                        .accessibilityLabel("当前显示为\(effectiveAppearanceTitle)")
+                        .accessibilityIdentifier("appearance-effective-mode")
                 }
-                .frame(minHeight: 44)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("当前显示为\(effectiveColorScheme == .dark ? "深色" : "浅色")")
-                .accessibilityIdentifier("appearance-effective-mode")
-            } header: {
-                Text("外观")
+                .frame(maxWidth: .infinity)
             } footer: {
                 Text("选择后会立即应用；跟随系统会随 iPhone 的外观设置自动切换。")
             }
@@ -224,6 +226,10 @@ struct SettingsView: View {
             get: { appearanceStore.selection },
             set: { appearanceStore.select($0) }
         )
+    }
+
+    private var effectiveAppearanceTitle: String {
+        effectiveColorScheme == .dark ? "深色" : "浅色"
     }
 
     private var repliesEnabledSelection: Binding<Bool> {

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -14,6 +14,7 @@ struct ThreadDetailView: View {
     let threadID: Int64
     let forumID: Int64?
     let initialPostID: UInt64?
+    let initialDestination: ThreadDetailInitialDestination?
     private let ownThreadDeletionTarget: OwnThreadDeletionTarget?
     private let onOwnThreadDeleted: ((Int64) -> Void)?
     private let onOwnThreadDeletionNeedsRefresh: (() -> Void)?
@@ -40,6 +41,9 @@ struct ThreadDetailView: View {
     @State private var isSearchActive = false
     @State private var didCopyLink = false
     @State private var pendingInitialPostID: UInt64?
+    @State private var pendingInitialDestination: ThreadDetailInitialDestination?
+    @State private var initialDestinationScrollRequest = 0
+    @State private var isReplyDestinationTargetReady = false
     @State private var requestGeneration = 0
     @State private var loadTask: Task<ThreadPage, Error>?
     @State private var showsInlineRefreshAnimation = false
@@ -85,6 +89,7 @@ struct ThreadDetailView: View {
         threadID: Int64,
         forumID: Int64? = nil,
         initialPostID: UInt64? = nil,
+        initialDestination: ThreadDetailInitialDestination? = nil,
         ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil,
         onOwnThreadDeleted: ((Int64) -> Void)? = nil,
         onOwnThreadDeletionNeedsRefresh: (() -> Void)? = nil,
@@ -96,6 +101,7 @@ struct ThreadDetailView: View {
         self.threadID = threadID
         self.forumID = forumID
         self.initialPostID = initialPostID
+        self.initialDestination = initialDestination
         self.ownThreadDeletionTarget = ownThreadDeletionTarget
         self.onOwnThreadDeleted = onOwnThreadDeleted
         self.onOwnThreadDeletionNeedsRefresh = onOwnThreadDeletionNeedsRefresh
@@ -103,6 +109,7 @@ struct ThreadDetailView: View {
         self.openUserInParent = openUserInParent
         self.openForumInParent = openForumInParent
         _pendingInitialPostID = State(initialValue: initialPostID)
+        _pendingInitialDestination = State(initialValue: initialDestination)
     }
 
     var body: some View {
@@ -349,6 +356,7 @@ struct ThreadDetailView: View {
         userResolutionError = nil
         showsInlineRefreshAnimation = false
         pendingInitialPostID = initialPostID
+        pendingInitialDestination = initialDestination
         savedReadingPosition = nil
         didResolveSavedReadingPosition = false
         isResumingReadingPosition = false
@@ -500,6 +508,14 @@ struct ThreadDetailView: View {
                 onSeeLzChange: changeSeeLz,
                 onSortChange: changeReplySort
             )
+            .id(ThreadDetailScrollTarget.replies)
+            .onAppear {
+                isReplyDestinationTargetReady = true
+                requestInitialDestinationScrollIfReady()
+            }
+            .onDisappear {
+                isReplyDestinationTargetReady = false
+            }
         }
     }
 
@@ -1053,7 +1069,11 @@ struct ThreadDetailView: View {
                 guard let request else { return }
                 performScrollRequest(request, proxy: scrollProxy)
             }
+            .onChange(of: initialDestinationScrollRequest) { _ in
+                performInitialDestinationScroll(proxy: scrollProxy)
+            }
             .onAppear {
+                requestInitialDestinationScrollIfReady()
                 // The auto-restore request is issued while the loading state
                 // is still on screen, so this scroll view first materializes
                 // with the request already set — onChange never observes that
@@ -1247,6 +1267,7 @@ struct ThreadDetailView: View {
         guard didResolveSavedReadingPosition == false else { return }
         didResolveSavedReadingPosition = true
         guard initialPostID == nil,
+              initialDestination == nil,
               pendingInitialPostID == nil,
               let position = localThreadLibraryStore.position(for: threadID) else { return }
         savedReadingPosition = position
@@ -1299,6 +1320,19 @@ struct ThreadDetailView: View {
     private func requestScroll(to postID: UInt64) {
         guard postID > 0 else { return }
         scrollRequest = ThreadPostScrollRequest(id: UUID(), postID: postID)
+    }
+
+    private func requestInitialDestinationScrollIfReady() {
+        guard pendingInitialDestination == .replies,
+              isReplyDestinationTargetReady else { return }
+        initialDestinationScrollRequest &+= 1
+    }
+
+    private func performInitialDestinationScroll(proxy: ScrollViewProxy) {
+        guard pendingInitialDestination == .replies,
+              isReplyDestinationTargetReady else { return }
+        pendingInitialDestination = nil
+        proxy.scrollTo(ThreadDetailScrollTarget.replies, anchor: .top)
     }
 
     private func performScrollRequest(
@@ -2054,6 +2088,10 @@ private struct ThreadPostScrollRequest: Equatable {
     var postID: UInt64
 }
 
+private enum ThreadDetailScrollTarget: Hashable {
+    case replies
+}
+
 private struct ThreadPostViewportPreferenceKey: PreferenceKey {
     static var defaultValue: [UInt64: ThreadPostViewportEntry] = [:]
 
@@ -2254,6 +2292,7 @@ private struct ReplyControlBar: View {
                 filterButton(title: "全部回复", isSelected: seeLz == false) {
                     onSeeLzChange(false)
                 }
+                .accessibilityIdentifier("thread-reply-controls")
                 filterButton(title: "只看楼主", isSelected: seeLz) {
                     onSeeLzChange(true)
                 }
@@ -2262,6 +2301,7 @@ private struct ReplyControlBar: View {
                 filterButton(title: "全部回复", isSelected: seeLz == false) {
                     onSeeLzChange(false)
                 }
+                .accessibilityIdentifier("thread-reply-controls")
                 filterButton(title: "只看楼主", isSelected: seeLz) {
                     onSeeLzChange(true)
                 }

--- a/TiebaPureTests/ContentMappingTests.swift
+++ b/TiebaPureTests/ContentMappingTests.swift
@@ -284,6 +284,11 @@ final class ContentMappingTests: XCTestCase {
         thread.replyNum = 10
         thread.viewNum = 20
         thread.agreeNum = 31
+        thread.firstPostID = 123
+        var agree = Tieba_Agree()
+        agree.agreeNum = 31
+        agree.hasAgree_p = 1
+        thread.agree = agree
         thread.isTop = 1
         thread.videoInfo = videoInfo
 
@@ -297,6 +302,8 @@ final class ContentMappingTests: XCTestCase {
         XCTAssertEqual(summary.author.ipAddress, "河南")
         XCTAssertEqual(summary.forumAvatarURL?.absoluteString, "https://example.com/forum.jpg")
         XCTAssertEqual(summary.likeCount, 31)
+        XCTAssertEqual(summary.firstPostID, 123)
+        XCTAssertTrue(summary.isLiked)
         XCTAssertTrue(summary.isTop)
         XCTAssertTrue(summary.hasVideo)
     }

--- a/TiebaPureTests/HomeNavigationTests.swift
+++ b/TiebaPureTests/HomeNavigationTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import TiebaPure
+
+final class HomeNavigationTests: XCTestCase {
+    func testBackFromForumThreadKeepsForumAsCurrentRoute() {
+        let threadA = ReaderSplitThreadRoute(threadID: 101, forumID: 7)
+        let threadB = ReaderSplitThreadRoute(threadID: 202, forumID: 7)
+        let forum = Forum(
+            id: 7,
+            name: "test",
+            displayName: "test forum",
+            avatarURL: nil,
+            memberCount: 0,
+            threadCount: 0
+        )
+
+        var path: [HomeNavigationRoute] = [.thread(threadA)]
+        path = HomeNavigationPathPolicy.pushing(.fromForum(forum), onto: path)
+        path = HomeNavigationPathPolicy.pushing(.thread(threadB), onto: path)
+
+        path = HomeNavigationPathPolicy.removingCurrent(.thread(threadB), from: path)
+
+        XCTAssertEqual(path, [.thread(threadA), .fromForum(forum)])
+    }
+
+    func testStaleRouteRemovalDoesNotPopAnotherLayer() {
+        let threadA = ReaderSplitThreadRoute(threadID: 101, forumID: 7)
+        let threadB = ReaderSplitThreadRoute(threadID: 202, forumID: 7)
+        let path: [HomeNavigationRoute] = [.thread(threadA), .thread(threadB)]
+
+        XCTAssertEqual(
+            HomeNavigationPathPolicy.removingCurrent(.thread(threadA), from: path),
+            path
+        )
+    }
+
+    func testInheritedReaderHandlerDoesNotEscapeCompactLocalStack() {
+        XCTAssertEqual(
+            ForumThreadsOpenRoutingPolicy.destination(
+                hasExplicitParentHandler: false,
+                hasReaderSplitHandler: true,
+                isReaderSplitListColumn: false
+            ),
+            .localStack
+        )
+        XCTAssertEqual(
+            ForumThreadsOpenRoutingPolicy.destination(
+                hasExplicitParentHandler: true,
+                hasReaderSplitHandler: true,
+                isReaderSplitListColumn: false
+            ),
+            .parentReader
+        )
+        XCTAssertEqual(
+            ForumThreadsOpenRoutingPolicy.destination(
+                hasExplicitParentHandler: false,
+                hasReaderSplitHandler: true,
+                isReaderSplitListColumn: true
+            ),
+            .parentReader
+        )
+    }
+}

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -669,6 +669,7 @@ final class TiebaPureSmokeTests: XCTestCase {
             threadID: 123,
             forumID: 7,
             initialPostID: 456,
+            initialDestination: .replies,
             ownThreadDeletionTarget: target
         )
         let compact = HomeSplitDetailBridgePolicy.state(
@@ -687,6 +688,7 @@ final class TiebaPureSmokeTests: XCTestCase {
         XCTAssertEqual(regular.navigationPath, [])
         XCTAssertEqual(regular.splitDetail, readerRoute)
         XCTAssertEqual(regular.splitDetail?.initialPostID, 456)
+        XCTAssertEqual(regular.splitDetail?.initialDestination, .replies)
         XCTAssertEqual(regular.splitDetail?.ownThreadDeletionTarget, target)
     }
 
@@ -1217,6 +1219,12 @@ final class TiebaPureSmokeTests: XCTestCase {
         XCTAssertEqual(InteractionStatsLayout.xPosition(for: .likes, in: 300), 200)
         XCTAssertEqual(InteractionStatsLayout.xPosition(for: .comments, in: 390), 130)
         XCTAssertEqual(InteractionStatsLayout.xPosition(for: .likes, in: 390), 260)
+    }
+
+    func testForumThreadTapPolicyRoutesInteractiveStats() {
+        XCTAssertEqual(ForumThreadTapPolicy.destination(for: .comments), .comments)
+        XCTAssertEqual(ForumThreadTapPolicy.destination(for: .likes), .like)
+        XCTAssertEqual(ForumThreadTapPolicy.destination(for: .stats), .none)
     }
 
     func testHomeMediaActionPolicyPlaysVideoFromFeed() {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -562,6 +562,64 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(waitForLikeState(subpostLikeButton, label: "取消点赞", count: 1))
     }
 
+    func testHomeCommentAndLikeActionsAreInteractive() {
+        let app = launchApp(
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"]
+        )
+
+        let comments = app.buttons["home-comments-button-1001"]
+        XCTAssertTrue(comments.waitForExistence(timeout: 20))
+        XCTAssertTrue(comments.isHittable)
+        XCTAssertGreaterThanOrEqual(comments.frame.width, 44)
+        XCTAssertGreaterThanOrEqual(comments.frame.height, 44)
+        comments.tap()
+
+        let replyControls = app.buttons["thread-reply-controls"]
+        XCTAssertTrue(replyControls.waitForExistence(timeout: 10))
+        let detailScrollView = app.scrollViews["thread-detail-scroll-view"]
+        XCTAssertTrue(
+            waitForHittable(replyControls, expected: true, timeout: 5),
+            "回复控件未进入可点击区域：controls=\(replyControls.frame), app=\(app.frame), scroll=\(detailScrollView.frame)"
+        )
+
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
+        backButton.tap()
+
+        let like = app.buttons["home-like-button-1001"]
+        XCTAssertTrue(like.waitForExistence(timeout: 8))
+        XCTAssertTrue(like.isHittable)
+        XCTAssertGreaterThanOrEqual(like.frame.width, 44)
+        XCTAssertGreaterThanOrEqual(like.frame.height, 44)
+        XCTAssertEqual(like.label, "点赞")
+        XCTAssertEqual(like.value as? String, "当前12个赞")
+        like.tap()
+        XCTAssertTrue(waitForLikeState(like, label: "取消点赞", count: 13))
+    }
+
+    func testHomeLikeFinishesWhileThreadCoversTheFeed() {
+        let app = launchApp(
+            scenario: "slow",
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"]
+        )
+
+        let like = app.buttons["home-like-button-1001"]
+        XCTAssertTrue(like.waitForExistence(timeout: 20))
+        XCTAssertEqual(like.value as? String, "当前12个赞")
+        like.tap()
+
+        openFirstThread(in: app)
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
+        backButton.tap()
+
+        let updatedLike = app.buttons["home-like-button-1001"]
+        XCTAssertTrue(updatedLike.waitForExistence(timeout: 8))
+        XCTAssertTrue(waitForLikeState(updatedLike, label: "取消点赞", count: 13))
+    }
+
     func testLoggedInUserCanAcknowledgeComposeRiskSaveDraftAndPublishThread() {
         let app = launchApp(
             account: "loggedIn",
@@ -2419,6 +2477,41 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(app.navigationBars["首页"].waitForExistence(timeout: 5))
     }
 
+    func testHomeThreadForumThreadBackReturnsToForum() {
+        let app = launchApp()
+        openFirstThread(in: app)
+
+        let forumButton = app.navigationBars.buttons.matching(
+            NSPredicate(format: "label CONTAINS %@", "测试吧")
+        ).firstMatch
+        XCTAssertTrue(forumButton.waitForExistence(timeout: 8))
+        forumButton.tap()
+
+        let forumScrollView = app.scrollViews["forum-threads-scroll-view"]
+        XCTAssertTrue(forumScrollView.waitForExistence(timeout: 10))
+        let forumThreadB = app.descendants(matching: .any)
+            .matching(identifier: "thread-open-area")
+            .element(boundBy: 1)
+        XCTAssertTrue(forumThreadB.waitForExistence(timeout: 8))
+        forumThreadB.tap()
+
+        let threadDetail = app.scrollViews["thread-detail-scroll-view"]
+        XCTAssertTrue(threadDetail.waitForExistence(timeout: 8))
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        XCTAssertTrue(backButton.waitForExistence(timeout: 5))
+        backButton.tap()
+
+        XCTAssertTrue(
+            threadDetail.waitForNonExistence(timeout: 5),
+            "返回帖子 B 后详情页应关闭，不能直接显示帖子 A"
+        )
+        XCTAssertTrue(
+            forumScrollView.waitForExistence(timeout: 5),
+            "返回帖子 B 后应保留所属贴吧列表"
+        )
+        XCTAssertFalse(app.navigationBars["首页"].exists)
+    }
+
     func testRepeatedUserProfileRightSwipesNeverSkipTheThread() {
         let app = launchApp()
         openFirstThread(in: app)
@@ -4231,6 +4324,7 @@ final class TiebaPureUITests: XCTestCase {
         settingsEntry.tap()
         XCTAssertTrue(app.navigationBars["设置"].waitForExistence(timeout: 8))
         XCTAssertTrue(waitForAppearance(expectedSystemAppearance, in: app))
+        assertAppearanceHeaderLayout(in: app)
 
         let darkOption = appearanceOption("深色", in: app)
         XCTAssertTrue(darkOption.waitForExistence(timeout: 5))
@@ -4255,6 +4349,22 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(systemOption.waitForExistence(timeout: 5))
         systemOption.tap()
         XCTAssertTrue(waitForAppearance(expectedSystemAppearance, in: app))
+    }
+
+    func testAppearanceHeaderKeepsEffectiveModeTrailingAtAccessibilityXXXL() {
+        let app = launchApp(additionalArguments: [
+            "-UIPreferredContentSizeCategoryName",
+            "UICTContentSizeCategoryAccessibilityXXXL"
+        ])
+        rootTab("我的", in: app).tap()
+
+        let settingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(settingsEntry, in: app, maxSwipes: 8))
+        settingsEntry.tap()
+        XCTAssertTrue(app.navigationBars["设置"].waitForExistence(timeout: 8))
+
+        assertAppearanceHeaderLayout(in: app)
+        attachScreenshot(named: "fixture-settings-appearance-header-axxxl")
     }
 
     func testReadingSettingsPersistAndApplyToNewThreadAndManualMedia() {
@@ -5231,6 +5341,28 @@ final class TiebaPureUITests: XCTestCase {
         let predicate = NSPredicate(format: "label CONTAINS %@", appearance)
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: effectiveMode)
         return XCTWaiter.wait(for: [expectation], timeout: 5) == .completed
+    }
+
+    private func assertAppearanceHeaderLayout(
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let title = app.descendants(matching: .any)["appearance-section-title"]
+        let effectiveMode = app.descendants(matching: .any)["appearance-effective-mode"]
+        XCTAssertTrue(title.waitForExistence(timeout: 5), file: file, line: line)
+        XCTAssertTrue(effectiveMode.waitForExistence(timeout: 5), file: file, line: line)
+
+        let titleFrame = title.frame
+        let effectiveFrame = effectiveMode.frame
+        XCTAssertGreaterThan(effectiveFrame.minX, titleFrame.maxX, file: file, line: line)
+        XCTAssertEqual(titleFrame.midY, effectiveFrame.midY, accuracy: 4, file: file, line: line)
+        XCTAssertLessThanOrEqual(effectiveFrame.maxX, app.frame.maxX - 12, file: file, line: line)
+        XCTAssertGreaterThan(effectiveFrame.height, 0, file: file, line: line)
+
+        let firstOption = appearanceOption("跟随系统", in: app)
+        XCTAssertTrue(firstOption.waitForExistence(timeout: 5), file: file, line: line)
+        XCTAssertGreaterThan(firstOption.frame.minY, max(titleFrame.maxY, effectiveFrame.maxY), file: file, line: line)
     }
 
     private func waitForLikeState(

--- a/project.yml
+++ b/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.9
-        CURRENT_PROJECT_VERSION: 53
+        MARKETING_VERSION: 1.4.10
+        CURRENT_PROJECT_VERSION: 54
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -56,8 +56,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.9
-        CURRENT_PROJECT_VERSION: 53
+        MARKETING_VERSION: 1.4.10
+        CURRENT_PROJECT_VERSION: 54
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容

- 修复从首页帖子进入贴吧、再进入其他帖子后返回时跳过贴吧的问题。
- 让首页评论与点赞区域可交互：评论可直接定位到回复区，点赞会校验设置和登录状态并正确同步数量。
- 修复点赞请求期间切换页面导致首页显示旧状态的问题。
- 将设置页当前生效的浅色或深色模式放到“显示模式”标题右侧。
- 版本更新为 1.4.10 (54)。

## 验证

- 首页导航、评论、点赞和设置布局定向单元及 UI 回归测试通过。
- 慢点赞请求期间进入帖子、返回首页后的状态同步测试通过。
- XcodeGen 重建一致，变更检查通过。

Fixes #38
Fixes #39
Fixes #40