### PR TITLE
修复 iOS 18 深层导航与文字选择卡死

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		09C2C3D3FC8AA2D05ACBF2F0 /* PbPage_PbPageResponse.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E50CC9DC6A0FEE9D095B963 /* PbPage_PbPageResponse.pb.swift */; };
 		0E9AD304E9D62F985EBE1408 /* FrsPage_FrsPage.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80CE02414B9F8BD668C519D /* FrsPage_FrsPage.pb.swift */; };
 		0F308182AFB5A18BA8EBAC46 /* AccountThreadFavoritesLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFD6B34343B4446671A80AA /* AccountThreadFavoritesLoader.swift */; };
+		0FDD60F2042590962835D92D /* NavigationSourceLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0CC744E002AC4C09B973D6 /* NavigationSourceLifecycle.swift */; };
 		10FEEBCE86FD4048957AD02B /* ContentDraftPersistenceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C06BE869912F233C314E5A /* ContentDraftPersistenceFactory.swift */; };
 		116B9F91820A3F111B4D0150 /* ContentDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE52F261111609A3D8E1D30 /* ContentDraftTests.swift */; };
 		1173DB2C53FF026697D5DEB8 /* OrderedCollectionPersistenceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2856CD40A8BF8EC9A8007C76 /* OrderedCollectionPersistenceFactory.swift */; };
@@ -144,6 +145,7 @@
 		BB1C38F18849E8E8287BCCA7 /* SocialMutationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5B4C5570D72B5D840721B1 /* SocialMutationCoordinator.swift */; };
 		BC0174E4104B48F4D4A8B291 /* SwiftDataOrderedCollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBDD5BC8E767866E1874011 /* SwiftDataOrderedCollectionPersistenceTests.swift */; };
 		BE171315B6CB8B7FCA968A65 /* PbFloor_PbFloorResponse.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A967D18B7F1F21562A66FCA /* PbFloor_PbFloorResponse.pb.swift */; };
+		BE37D589510658CE415782CD /* NavigationSourceLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA707FB3466F64C9B7BB74F3 /* NavigationSourceLifecycleTests.swift */; };
 		BE4F2342007F0803F98D82B7 /* SubPost.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB42F9B13D5397C990ED17F /* SubPost.pb.swift */; };
 		BED7DAF338555164F980FDE9 /* FileOrderedCollectionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A92826CC55F5EE91B72934 /* FileOrderedCollectionPersistence.swift */; };
 		BF200F41FA7A88C525623215 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E425761E05D459199869361A /* AboutView.swift */; };
@@ -334,6 +336,7 @@
 		594CFFAE35B27CDF27D9B903 /* SecurityRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityRegressionTests.swift; sourceTree = "<group>"; };
 		5A967D18B7F1F21562A66FCA /* PbFloor_PbFloorResponse.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PbFloor_PbFloorResponse.pb.swift; sourceTree = "<group>"; };
 		5B099CE340C14B26B97B9E57 /* TiebaSocialAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaSocialAPI.swift; sourceTree = "<group>"; };
+		5D0CC744E002AC4C09B973D6 /* NavigationSourceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSourceLifecycle.swift; sourceTree = "<group>"; };
 		5D5F7218DA6FD8845675AE38 /* MetadataLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataLine.swift; sourceTree = "<group>"; };
 		5E2FAEA095A18F41BED60B8D /* EmoticonResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmoticonResourceTests.swift; sourceTree = "<group>"; };
 		5E7B54C9EC311DDB57FEBB4F /* ThreadAuthorBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadAuthorBadgeTests.swift; sourceTree = "<group>"; };
@@ -409,6 +412,7 @@
 		B99D4BFCB0FC486AF2592D85 /* VideoInfo.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoInfo.pb.swift; sourceTree = "<group>"; };
 		B9A92826CC55F5EE91B72934 /* FileOrderedCollectionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOrderedCollectionPersistence.swift; sourceTree = "<group>"; };
 		BA50FDF3AC3742333D5202EC /* Post.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.pb.swift; sourceTree = "<group>"; };
+		BA707FB3466F64C9B7BB74F3 /* NavigationSourceLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationSourceLifecycleTests.swift; sourceTree = "<group>"; };
 		BC9BED7F7A1BE8C617FE2F15 /* TiebaEmoticonRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaEmoticonRepository.swift; sourceTree = "<group>"; };
 		C017341C9C78B3832CB8A72F /* PbContent.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PbContent.pb.swift; sourceTree = "<group>"; };
 		C25F6DDA828E44F9B5A0E5D9 /* TiebaPureTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPureTheme.swift; sourceTree = "<group>"; };
@@ -522,6 +526,7 @@
 				9DC309A0384A60EB41BF7B46 /* LegacyScrollTelemetry.swift */,
 				277C554E042BEC92DDCC065C /* MediaGridView.swift */,
 				5D5F7218DA6FD8845675AE38 /* MetadataLine.swift */,
+				5D0CC744E002AC4C09B973D6 /* NavigationSourceLifecycle.swift */,
 				431A697F330BBEC18E2252D0 /* ReaderCard.swift */,
 				9349EF851351C624AE35FF31 /* ReaderSplitLayout.swift */,
 				475452DA26606C9EEF2982D2 /* ReaderStateView.swift */,
@@ -740,6 +745,7 @@
 				1781B1F0906AC36975BFDE9F /* LegacyScrollTelemetryTests.swift */,
 				DE6967B15A66331DA9F947F0 /* MessageAPITests.swift */,
 				2758D17C77814946EB5560DA /* MultipartFormDataTests.swift */,
+				BA707FB3466F64C9B7BB74F3 /* NavigationSourceLifecycleTests.swift */,
 				481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */,
 				C60B7C87AF367770BAF70762 /* SearchAPITests.swift */,
 				594CFFAE35B27CDF27D9B903 /* SecurityRegressionTests.swift */,
@@ -1170,6 +1176,7 @@
 				F60F13E9F3CF7AA790EE1C4A /* MessagesView.swift in Sources */,
 				D3F2C72D1BAA5E6241C68B52 /* MetadataLine.swift in Sources */,
 				4A8E23945EF79EAEFE3019DC /* MultipartFormData.swift in Sources */,
+				0FDD60F2042590962835D92D /* NavigationSourceLifecycle.swift in Sources */,
 				7189EC19091324F1EF6886C5 /* OrderedCollectionPersistence.swift in Sources */,
 				1173DB2C53FF026697D5DEB8 /* OrderedCollectionPersistenceFactory.swift in Sources */,
 				FB6002A8AEF7E1213AC7EA87 /* OwnThreadMutationState.swift in Sources */,
@@ -1280,6 +1287,7 @@
 				D774D89D5189D8CB9A1D877B /* LegacyScrollTelemetryTests.swift in Sources */,
 				80D70D09DAD45ED618094984 /* MessageAPITests.swift in Sources */,
 				D92FF26A20CE55595F45B81F /* MultipartFormDataTests.swift in Sources */,
+				BE37D589510658CE415782CD /* NavigationSourceLifecycleTests.swift in Sources */,
 				9C4E81261CE11986A7FC94CA /* PersistenceBoundaryTests.swift in Sources */,
 				FA2D7EBC13B9CDAE43B9DAC0 /* SearchAPITests.swift in Sources */,
 				D3B0D1E46535FF84CB41BAB7 /* SecurityRegressionTests.swift in Sources */,

--- a/TiebaPure/Core/UI/InteractiveNavigationPop.swift
+++ b/TiebaPure/Core/UI/InteractiveNavigationPop.swift
@@ -40,6 +40,12 @@ enum NativeEdgePopGestureActivationPolicy {
     }
 }
 
+enum NavigationPopGestureControlHostingPolicy {
+    static func requiresController(systemMajorVersion: Int, isEnabled: Bool) -> Bool {
+        isEnabled == false || systemMajorVersion < 26
+    }
+}
+
 private enum NavigationPopGestureDiagnostics {
     static let identifier = "navigation-pop-gesture-diagnostics"
 
@@ -56,16 +62,24 @@ extension View {
     /// Keeps navigation system-owned while allowing a short, explicit critical
     /// section (such as a dispatched destructive write) to suspend both native
     /// pop recognizers. The original enabled state is restored afterwards.
+    @ViewBuilder
     func fullScreenInteractiveNavigationPop(isEnabled: Bool = true) -> some View {
-        let exposesDiagnostics = NavigationPopGestureDiagnostics.isEnabled
-        return background(
-            NativeNavigationPopGestureControl(isEnabled: isEnabled)
-                .frame(
-                    width: exposesDiagnostics ? 1 : 0,
-                    height: exposesDiagnostics ? 1 : 0
-                )
-                .accessibilityHidden(exposesDiagnostics == false)
-        )
+        if NavigationPopGestureControlHostingPolicy.requiresController(
+            systemMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+            isEnabled: isEnabled
+        ) {
+            let exposesDiagnostics = NavigationPopGestureDiagnostics.isEnabled
+            background(
+                NativeNavigationPopGestureControl(isEnabled: isEnabled)
+                    .frame(
+                        width: exposesDiagnostics ? 1 : 0,
+                        height: exposesDiagnostics ? 1 : 0
+                    )
+                    .accessibilityHidden(exposesDiagnostics == false)
+            )
+        } else {
+            self
+        }
     }
 
     /// No longer captures page screenshots. Retained as a source-compatible

--- a/TiebaPure/Core/UI/NavigationSourceLifecycle.swift
+++ b/TiebaPure/Core/UI/NavigationSourceLifecycle.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct NavigationSourceLifecycleState: Equatable {
+    private(set) var isOpeningParentDestination = false
+
+    mutating func beginParentNavigation() {
+        isOpeningParentDestination = true
+    }
+
+    mutating func didAppear() {
+        isOpeningParentDestination = false
+    }
+
+    func shouldTearDown(isPresentingLocalDestination: Bool) -> Bool {
+        isPresentingLocalDestination == false && isOpeningParentDestination == false
+    }
+}

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -25,6 +25,7 @@ struct ForumThreadsView: View {
     @State private var activeSearch: ForumSearchLaunchRoute?
     @State private var activeThread: ForumThreadRoute?
     @State private var selectedUser: UserSummary?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
     @State private var selectedCategory: ForumThreadCategory
     @State private var latestSortCategory: ForumThreadCategory
     @State private var requestGeneration = 0
@@ -254,7 +255,13 @@ struct ForumThreadsView: View {
                   SocialRelationshipState.sameForum(change.forum, forum) else { return }
             isUpdatingForumFollow = change.isPending
         }
+        .onAppear { navigationSourceLifecycle.didAppear() }
         .onDisappear {
+            guard navigationSourceLifecycle.shouldTearDown(
+                isPresentingLocalDestination: activeSearch != nil
+                    || activeThread != nil
+                    || selectedUser != nil
+            ) else { return }
             cancelSubmissionNavigation()
             loadTask?.cancel()
             requestGeneration += 1
@@ -561,6 +568,9 @@ struct ForumThreadsView: View {
             hasReaderSplitHandler: readerSplitOpenThread != nil,
             isReaderSplitListColumn: isReaderSplitListColumn
         ) == .parentReader, let parentAction {
+            if isReaderSplitListColumn == false {
+                navigationSourceLifecycle.beginParentNavigation()
+            }
             parentAction(ReaderSplitThreadRoute(threadID: threadID, forumID: forumID))
             return
         }
@@ -668,6 +678,9 @@ struct ForumThreadsView: View {
             forum: forum
         ) else { return }
         if let openSearchInParent {
+            if isReaderSplitListColumn == false {
+                navigationSourceLifecycle.beginParentNavigation()
+            }
             openSearchInParent(route)
         } else {
             activeSearch = route
@@ -776,6 +789,9 @@ struct ForumThreadsView: View {
 
     private func openUser(_ user: UserSummary) {
         if let openUserInParent {
+            if isReaderSplitListColumn == false {
+                navigationSourceLifecycle.beginParentNavigation()
+            }
             openUserInParent(user)
         } else {
             selectedUser = user

--- a/TiebaPure/Features/ForumList/ForumListView.swift
+++ b/TiebaPure/Features/ForumList/ForumListView.swift
@@ -4,6 +4,7 @@ struct ForumListView: View {
     @EnvironmentObject private var environment: AppEnvironment
     @Environment(\.dismiss) private var dismiss
     let account: Account
+    private let openForumInParent: ((Forum) -> Void)?
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     @State private var forums: [Forum] = []
     @State private var isLoading = false
@@ -13,6 +14,15 @@ struct ForumListView: View {
     @State private var requestGeneration = 0
     @State private var loadTask: Task<[Forum], Error>?
     @State private var selectedForum: ForumHubRoute?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
+
+    init(
+        account: Account,
+        openForumInParent: ((Forum) -> Void)? = nil
+    ) {
+        self.account = account
+        self.openForumInParent = openForumInParent
+    }
 
     private var visibleForums: [Forum] {
         ForumListPresentationPolicy.visibleForums(
@@ -124,7 +134,11 @@ struct ForumListView: View {
                 .accessibilityLabel("设置")
             }
         }
+        .onAppear { navigationSourceLifecycle.didAppear() }
         .onDisappear {
+            guard navigationSourceLifecycle.shouldTearDown(
+                isPresentingLocalDestination: selectedForum != nil
+            ) else { return }
             loadTask?.cancel()
             requestGeneration += 1
             isLoading = false
@@ -191,7 +205,12 @@ struct ForumListView: View {
     private func openForum(_ forum: Forum) {
         guard ForumListTapPolicy.destination(for: .rowBackground) == .forum else { return }
         RecentForumStore.shared.save(forum)
-        selectedForum = ForumHubRoute(forum: forum)
+        if let openForumInParent {
+            navigationSourceLifecycle.beginParentNavigation()
+            openForumInParent(forum)
+        } else {
+            selectedForum = ForumHubRoute(forum: forum)
+        }
     }
 
     private func reload() async {

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -20,7 +20,6 @@ struct HomeView: View {
     @State private var didLoad = false
     @State private var errorMessage: String?
     @State private var navigationPath: [HomeNavigationRoute] = []
-    @State private var selectedUser: UserSummary?
     @State private var programmaticRefreshToken = 0
     @State private var lastScenePhase: ScenePhase = .inactive
     @State private var scrollToTopRequest = 0
@@ -114,6 +113,9 @@ struct HomeView: View {
                     initialPostID: threadRoute.initialPostID,
                     initialDestination: threadRoute.initialDestination,
                     ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget,
+                    openUserInParent: { user in
+                        openUser(user, sourceThreadID: threadRoute.threadID)
+                    },
                     openForumInParent: openForum
                 )
                 .interactiveNavigationPopStateSync {
@@ -132,19 +134,28 @@ struct HomeView: View {
                     ),
                     openThreadInParent: { route in
                         openThreadFromNestedForum(route)
+                    },
+                    openUserInParent: { user in
+                        openUser(user, sourceThreadID: nil)
                     }
                 )
                 .interactiveNavigationPopStateSync {
                     removeNavigationRouteIfCurrent(route)
                 }
-            }
-        }
-        .navigationDestination(isPresented: selectedUserIsActive) {
-            if let selectedUser {
-                UserProfileView(account: account, user: selectedUser)
-                    .interactiveNavigationPopStateSync {
-                        self.selectedUser = nil
-                    }
+            case let .user(user, sourceThreadID):
+                UserProfileView(
+                    account: account,
+                    user: user,
+                    sourceThreadID: sourceThreadID,
+                    onReturnToSourceThread: {
+                        removeNavigationRouteIfCurrent(route)
+                    },
+                    openThreadInParent: openThreadFromNestedForum,
+                    openForumInParent: openForum
+                )
+                .interactiveNavigationPopStateSync {
+                    removeNavigationRouteIfCurrent(route)
+                }
             }
         }
         .interactiveNavigationPopRevealSource()
@@ -157,11 +168,10 @@ struct HomeView: View {
             // the covered feed, matching the iOS tab-reselect convention. In
             // the split layout the detail selection likewise clears back to
             // the placeholder without reloading.
-            if navigationPath.isEmpty == false || activeSearch != nil || selectedUser != nil
+            if navigationPath.isEmpty == false || activeSearch != nil
                 || splitDetailPath.isEmpty == false {
                 navigationPath = []
                 activeSearch = nil
-                selectedUser = nil
                 splitDetailPath = []
                 return
             }
@@ -180,7 +190,6 @@ struct HomeView: View {
             paginationRequestScheduled = false
             errorMessage = nil
             navigationPath = []
-            selectedUser = nil
             splitDetailPath = []
             Task { await reload(trigger: .initial) }
         }
@@ -232,15 +241,6 @@ struct HomeView: View {
                 if isActive == false {
                     activeSearch = nil
                 }
-            }
-        )
-    }
-
-    private var selectedUserIsActive: Binding<Bool> {
-        Binding(
-            get: { selectedUser != nil },
-            set: { isActive in
-                if isActive == false { selectedUser = nil }
             }
         )
     }
@@ -302,6 +302,13 @@ struct HomeView: View {
         )
     }
 
+    private func openUser(_ user: UserSummary, sourceThreadID: Int64?) {
+        navigationPath = HomeNavigationPathPolicy.pushing(
+            .user(user: user, sourceThreadID: sourceThreadID),
+            onto: navigationPath
+        )
+    }
+
     /// Keeps the open thread when the split layout appears or collapses
     /// mid-session (e.g. iPad Split View resizes across the width threshold).
     private func foldNavigationForSizeClassChange(to sizeClass: UserInterfaceSizeClass?) {
@@ -349,7 +356,7 @@ struct HomeView: View {
                         onOpenForum: { forum in
                             openForum(forum)
                         },
-                        onOpenUser: { selectedUser = $0 },
+                        onOpenUser: { openUser($0, sourceThreadID: nil) },
                         onBlockForum: { blockedThread in
                             blocklistStore.addForum(
                                 id: blockedThread.forumID,
@@ -818,6 +825,7 @@ enum HomeMediaActionPolicy {
 enum HomeNavigationRoute: Hashable {
     case thread(ReaderSplitThreadRoute)
     case forum(id: Int64, name: String, displayName: String, avatarURL: URL?)
+    case user(user: UserSummary, sourceThreadID: Int64?)
 
     static func fromForum(_ forum: Forum) -> HomeNavigationRoute {
         .forum(

--- a/TiebaPure/Features/Messages/MessagesView.swift
+++ b/TiebaPure/Features/Messages/MessagesView.swift
@@ -4,6 +4,7 @@ struct MessagesView: View {
     @EnvironmentObject private var environment: AppEnvironment
 
     let account: Account?
+    private let openThreadInParent: ((ReaderSplitThreadRoute) -> Void)?
 
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     @State private var kind: MessageKind = .reply
@@ -16,6 +17,15 @@ struct MessagesView: View {
     @State private var requestGeneration = 0
     @State private var loadTask: Task<MessagesPage, Error>?
     @State private var activeMessage: MessageItem?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
+
+    init(
+        account: Account?,
+        openThreadInParent: ((ReaderSplitThreadRoute) -> Void)? = nil
+    ) {
+        self.account = account
+        self.openThreadInParent = openThreadInParent
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -58,7 +68,11 @@ struct MessagesView: View {
         .onChange(of: blocklistStore.entries) { _ in
             items.removeAll { TiebaContentFilter.shouldKeep(message: $0) == false }
         }
+        .onAppear { navigationSourceLifecycle.didAppear() }
         .onDisappear {
+            guard navigationSourceLifecycle.shouldTearDown(
+                isPresentingLocalDestination: activeMessage != nil
+            ) else { return }
             loadTask?.cancel()
             loadTask = nil
             requestGeneration += 1
@@ -117,7 +131,7 @@ struct MessagesView: View {
         ScrollView {
             LazyVStack(spacing: 0) {
                 ForEach(Array(items.enumerated()), id: \.element.id) { index, message in
-                    ReaderCard(action: { activeMessage = message }) {
+                    ReaderCard(action: { openMessage(message) }) {
                         MessageRow(message: message)
                     }
                     .accessibilityHint("打开该帖子并定位到相关楼层")
@@ -175,6 +189,20 @@ struct MessagesView: View {
             accessibilityIdentifier: "messages-refresh-animation"
         ) {
             await reload()
+        }
+    }
+
+    private func openMessage(_ message: MessageItem) {
+        let route = ReaderSplitThreadRoute(
+            threadID: message.threadID,
+            forumID: nil,
+            initialPostID: message.postID
+        )
+        if let openThreadInParent {
+            navigationSourceLifecycle.beginParentNavigation()
+            openThreadInParent(route)
+        } else {
+            activeMessage = message
         }
     }
 

--- a/TiebaPure/Features/Profile/BrowsingHistoryView.swift
+++ b/TiebaPure/Features/Profile/BrowsingHistoryView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct BrowsingHistoryView: View {
     let account: Account?
+    private let openThreadInParent: ((ReaderSplitThreadRoute) -> Void)?
 
     @Environment(\.editMode) private var editMode
     @Environment(\.scenePhase) private var scenePhase
@@ -17,6 +18,14 @@ struct BrowsingHistoryView: View {
     @State private var showsClearConfirmation = false
     @State private var showsDeleteSelectionConfirmation = false
     @State private var showsPersistenceError = false
+
+    init(
+        account: Account?,
+        openThreadInParent: ((ReaderSplitThreadRoute) -> Void)? = nil
+    ) {
+        self.account = account
+        self.openThreadInParent = openThreadInParent
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -177,7 +186,7 @@ struct BrowsingHistoryView: View {
                             )
                         } else {
                             Button {
-                                activeEntry = entry
+                                openEntry(entry)
                             } label: {
                                 BrowsingHistoryRow(entry: entry)
                             }
@@ -193,6 +202,18 @@ struct BrowsingHistoryView: View {
             }
             .listStyle(.plain)
             .accessibilityIdentifier("browsing-history-list")
+        }
+    }
+
+    private func openEntry(_ entry: BrowsingHistoryEntry) {
+        let route = ReaderSplitThreadRoute(
+            threadID: entry.threadID,
+            forumID: entry.forumID
+        )
+        if let openThreadInParent {
+            openThreadInParent(route)
+        } else {
+            activeEntry = entry
         }
     }
 

--- a/TiebaPure/Features/Profile/FollowedUsersView.swift
+++ b/TiebaPure/Features/Profile/FollowedUsersView.swift
@@ -2,6 +2,15 @@ import SwiftUI
 
 struct FollowedUsersView: View {
     let account: Account
+    private let openUserInParent: ((UserSummary) -> Void)?
+
+    init(
+        account: Account,
+        openUserInParent: ((UserSummary) -> Void)? = nil
+    ) {
+        self.account = account
+        self.openUserInParent = openUserInParent
+    }
 
     var body: some View {
         UserRelationshipsView(
@@ -13,7 +22,8 @@ struct FollowedUsersView: View {
                 portrait: account.portrait
             ),
             kind: .following,
-            navigationTitle: "关注的用户"
+            navigationTitle: "关注的用户",
+            openUserInParent: openUserInParent
         )
     }
 }
@@ -27,6 +37,7 @@ struct UserRelationshipsView: View {
     let user: UserSummary
     let kind: UserRelationshipKind
     let navigationTitle: String
+    private let openUserInParent: ((UserSummary) -> Void)?
 
     @State private var users: [UserSummary] = []
     @State private var nextPage = 1
@@ -38,17 +49,20 @@ struct UserRelationshipsView: View {
     @State private var requestGeneration = 0
     @State private var loadTask: Task<UserRelationshipPage, Error>?
     @State private var selectedUser: UserSummary?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
 
     init(
         account: Account?,
         user: UserSummary,
         kind: UserRelationshipKind,
-        navigationTitle: String? = nil
+        navigationTitle: String? = nil,
+        openUserInParent: ((UserSummary) -> Void)? = nil
     ) {
         self.account = account
         self.user = user
         self.kind = kind
         self.navigationTitle = navigationTitle ?? kind.navigationTitle
+        self.openUserInParent = openUserInParent
     }
 
     var body: some View {
@@ -74,7 +88,7 @@ struct UserRelationshipsView: View {
                 List {
                     ForEach(users, id: \.self) { relationshipUser in
                         Button {
-                            selectedUser = relationshipUser
+                            openUser(relationshipUser)
                         } label: {
                             UserRelationshipRow(user: relationshipUser)
                         }
@@ -162,9 +176,24 @@ struct UserRelationshipsView: View {
             selectedUser = nil
             dismiss()
         }
-        .onDisappear { cancelRequests() }
+        .onAppear { navigationSourceLifecycle.didAppear() }
+        .onDisappear {
+            guard navigationSourceLifecycle.shouldTearDown(
+                isPresentingLocalDestination: selectedUser != nil
+            ) else { return }
+            cancelRequests()
+        }
         .accessibilityIdentifier(kind == .following ? "followed-users-screen" : "followers-screen")
         .fullScreenInteractiveNavigationPop()
+    }
+
+    private func openUser(_ user: UserSummary) {
+        if let openUserInParent {
+            navigationSourceLifecycle.beginParentNavigation()
+            openUserInParent(user)
+        } else {
+            selectedUser = user
+        }
     }
 
     private var loadingText: String {

--- a/TiebaPure/Features/Profile/MeView.swift
+++ b/TiebaPure/Features/Profile/MeView.swift
@@ -6,22 +6,15 @@ struct MeView: View {
     @ObservedObject private var browsingHistoryStore = BrowsingHistoryStore.shared
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     @State private var showsLogin = false
-    @State private var showsMessages = false
-    @State private var showsFollowedForums = false
-    @State private var showsOwnProfile = false
-    @State private var showsBrowsingHistory = false
-    @State private var showsFollowedUsers = false
-    @State private var showsThreadFavorites = false
-    @State private var showsSettings = false
-    @State private var showsAbout = false
+    @State private var navigationPath: [MeNavigationRoute] = []
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             Form {
                 if let account {
                     Section("账号") {
                         Button {
-                            showsOwnProfile = true
+                            openUser(userSummary(for: account), sourceThreadID: nil)
                         } label: {
                             HStack(spacing: TiebaPureTheme.Spacing.sm) {
                                 AvatarView(
@@ -57,7 +50,7 @@ struct MeView: View {
                         .accessibilityIdentifier("me-user-profile-button")
 
                         Button {
-                            showsMessages = true
+                            navigationPath.append(.messages)
                         } label: {
                             Label("消息", systemImage: "bell")
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -69,7 +62,7 @@ struct MeView: View {
                         .accessibilityIdentifier("me-messages-entry")
 
                         Button {
-                            showsFollowedUsers = true
+                            navigationPath.append(.followedUsers)
                         } label: {
                             Label("关注的用户", systemImage: "person.2")
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -80,7 +73,7 @@ struct MeView: View {
                         .accessibilityIdentifier("followed-users-entry")
 
                         Button {
-                            showsFollowedForums = true
+                            navigationPath.append(.followedForums)
                         } label: {
                             Label("关注的吧", systemImage: "star")
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -112,7 +105,7 @@ struct MeView: View {
 
                 Section("浏览") {
                     Button {
-                        showsThreadFavorites = true
+                        navigationPath.append(.threadFavorites)
                     } label: {
                         Label("帖子收藏", systemImage: "star")
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -124,7 +117,7 @@ struct MeView: View {
                     .accessibilityIdentifier("thread-favorites-entry")
 
                     Button {
-                        showsBrowsingHistory = true
+                        navigationPath.append(.browsingHistory)
                     } label: {
                         HStack(spacing: TiebaPureTheme.Spacing.sm) {
                             Label("浏览历史", systemImage: "clock.arrow.circlepath")
@@ -147,7 +140,7 @@ struct MeView: View {
 
                 Section("应用") {
                     Button {
-                        showsSettings = true
+                        navigationPath.append(.settings)
                     } label: {
                         Label("设置", systemImage: "gearshape")
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -158,7 +151,7 @@ struct MeView: View {
                     .accessibilityIdentifier("app-settings-entry")
 
                     Button {
-                        showsAbout = true
+                        navigationPath.append(.about)
                     } label: {
                         Label("关于 TiebaPure", systemImage: "info.circle")
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -170,61 +163,8 @@ struct MeView: View {
             }
             .navigationTitle("我的")
             .interactiveNavigationPopRevealSource()
-            .navigationDestination(isPresented: $showsBrowsingHistory) {
-                BrowsingHistoryView(account: account)
-                    .interactiveNavigationPopStateSync {
-                        showsBrowsingHistory = false
-                    }
-            }
-            .navigationDestination(isPresented: $showsThreadFavorites) {
-                ThreadFavoritesView(account: account)
-                    .interactiveNavigationPopStateSync {
-                        showsThreadFavorites = false
-                    }
-            }
-            .navigationDestination(isPresented: $showsSettings) {
-                SettingsView(account: account)
-                    .interactiveNavigationPopStateSync {
-                        showsSettings = false
-                    }
-            }
-            .navigationDestination(isPresented: $showsAbout) {
-                AboutView()
-                    .interactiveNavigationPopStateSync {
-                        showsAbout = false
-                    }
-            }
-            .navigationDestination(isPresented: $showsMessages) {
-                if let account {
-                    MessagesView(account: account)
-                        .interactiveNavigationPopStateSync {
-                            showsMessages = false
-                        }
-                }
-            }
-            .navigationDestination(isPresented: $showsFollowedForums) {
-                if let account {
-                    ForumListView(account: account)
-                        .interactiveNavigationPopStateSync {
-                            showsFollowedForums = false
-                        }
-                }
-            }
-            .navigationDestination(isPresented: $showsFollowedUsers) {
-                if let account {
-                    FollowedUsersView(account: account)
-                        .interactiveNavigationPopStateSync {
-                            showsFollowedUsers = false
-                        }
-                }
-            }
-            .navigationDestination(isPresented: $showsOwnProfile) {
-                if let account {
-                    UserProfileView(account: account, user: userSummary(for: account))
-                        .interactiveNavigationPopStateSync {
-                            showsOwnProfile = false
-                        }
-                }
+            .navigationDestination(for: MeNavigationRoute.self) { route in
+                destination(for: route)
             }
             .sheet(isPresented: $showsLogin) {
                 NavigationStack {
@@ -244,14 +184,7 @@ struct MeView: View {
                 if newValue != nil {
                     showsLogin = false
                 } else {
-                    showsMessages = false
-                    showsFollowedForums = false
-                    showsOwnProfile = false
-                    showsBrowsingHistory = false
-                    showsFollowedUsers = false
-                    showsThreadFavorites = false
-                    showsSettings = false
-                    showsAbout = false
+                    navigationPath = []
                 }
             }
         }
@@ -281,5 +214,130 @@ struct MeView: View {
             displayName: account.displayName,
             portrait: account.portrait
         )
+    }
+
+    @ViewBuilder
+    private func destination(for route: MeNavigationRoute) -> some View {
+        switch route {
+        case .messages:
+            if let account {
+                MessagesView(account: account, openThreadInParent: openThread)
+            }
+        case .followedForums:
+            if let account {
+                ForumListView(account: account, openForumInParent: openForum)
+            }
+        case .followedUsers:
+            if let account {
+                FollowedUsersView(account: account, openUserInParent: { user in
+                    openUser(user, sourceThreadID: nil)
+                })
+            }
+        case .threadFavorites:
+            ThreadFavoritesView(account: account, openThreadInParent: openThread)
+        case .browsingHistory:
+            BrowsingHistoryView(account: account, openThreadInParent: openThread)
+        case .settings:
+            SettingsView(account: account)
+        case .about:
+            AboutView()
+        case let .thread(threadRoute):
+            ThreadDetailView(
+                account: account,
+                threadID: threadRoute.threadID,
+                forumID: threadRoute.forumID,
+                initialPostID: threadRoute.initialPostID,
+                initialDestination: threadRoute.initialDestination,
+                ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget,
+                openUserInParent: { user in
+                    openUser(user, sourceThreadID: threadRoute.threadID)
+                },
+                openForumInParent: openForum
+            )
+        case let .forum(id, name, displayName, avatarURL):
+            ForumThreadsView(
+                account: account,
+                forum: Forum(
+                    id: id,
+                    name: name,
+                    displayName: displayName,
+                    avatarURL: avatarURL,
+                    memberCount: 0,
+                    threadCount: 0
+                ),
+                openThreadInParent: openThread,
+                openUserInParent: { user in
+                    openUser(user, sourceThreadID: nil)
+                }
+            )
+        case let .user(user, sourceThreadID):
+            UserProfileView(
+                account: account,
+                user: user,
+                sourceThreadID: sourceThreadID,
+                onReturnToSourceThread: {
+                    navigationPath = MeNavigationPathPolicy.removingCurrent(
+                        route,
+                        from: navigationPath
+                    )
+                },
+                openThreadInParent: openThread,
+                openForumInParent: openForum
+            )
+        }
+    }
+
+    private func openThread(_ route: ReaderSplitThreadRoute) {
+        navigationPath = MeNavigationPathPolicy.pushing(.thread(route), onto: navigationPath)
+    }
+
+    private func openForum(_ forum: Forum) {
+        navigationPath = MeNavigationPathPolicy.pushing(.fromForum(forum), onto: navigationPath)
+    }
+
+    private func openUser(_ user: UserSummary, sourceThreadID: Int64?) {
+        navigationPath = MeNavigationPathPolicy.pushing(
+            .user(user: user, sourceThreadID: sourceThreadID),
+            onto: navigationPath
+        )
+    }
+}
+
+enum MeNavigationRoute: Hashable {
+    case messages
+    case followedForums
+    case followedUsers
+    case threadFavorites
+    case browsingHistory
+    case settings
+    case about
+    case thread(ReaderSplitThreadRoute)
+    case forum(id: Int64, name: String, displayName: String, avatarURL: URL?)
+    case user(user: UserSummary, sourceThreadID: Int64?)
+
+    static func fromForum(_ forum: Forum) -> MeNavigationRoute {
+        .forum(
+            id: forum.id,
+            name: forum.name,
+            displayName: forum.displayName,
+            avatarURL: forum.avatarURL
+        )
+    }
+}
+
+enum MeNavigationPathPolicy {
+    static func pushing(
+        _ route: MeNavigationRoute,
+        onto path: [MeNavigationRoute]
+    ) -> [MeNavigationRoute] {
+        path + [route]
+    }
+
+    static func removingCurrent(
+        _ route: MeNavigationRoute,
+        from path: [MeNavigationRoute]
+    ) -> [MeNavigationRoute] {
+        guard path.last == route else { return path }
+        return Array(path.dropLast())
     }
 }

--- a/TiebaPure/Features/Profile/ThreadFavoritesView.swift
+++ b/TiebaPure/Features/Profile/ThreadFavoritesView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// a copy of it.
 struct ThreadFavoritesView: View {
     let account: Account?
+    private let openThreadInParent: ((ReaderSplitThreadRoute) -> Void)?
 
     @EnvironmentObject private var environment: AppEnvironment
     @Environment(\.editMode) private var editMode
@@ -23,6 +24,15 @@ struct ThreadFavoritesView: View {
     @State private var removalTasks: [UUID: Task<Void, Never>] = [:]
     @State private var removalOperations = ThreadFavoritesRemovalOperationState()
     @State private var pendingRemoteRemovalThreadIDs = Set<Int64>()
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
+
+    init(
+        account: Account?,
+        openThreadInParent: ((ReaderSplitThreadRoute) -> Void)? = nil
+    ) {
+        self.account = account
+        self.openThreadInParent = openThreadInParent
+    }
 
     var body: some View {
         dialogs
@@ -31,6 +41,7 @@ struct ThreadFavoritesView: View {
                 await reloadAfterPendingFavoriteWrites(account: account)
             }
             .onAppear {
+                navigationSourceLifecycle.didAppear()
                 libraryStore.reload()
                 // Collecting happens on the thread screen, so coming back here
                 // has to re-read the list instead of trusting what it had.
@@ -44,6 +55,9 @@ struct ThreadFavoritesView: View {
                 Task { await reloadAfterPendingFavoriteWrites(account: account) }
             }
             .onDisappear {
+                guard navigationSourceLifecycle.shouldTearDown(
+                    isPresentingLocalDestination: activeFavorite != nil
+                ) else { return }
                 loader.cancel()
                 cancelRemovalPresentation()
             }
@@ -235,7 +249,7 @@ struct ThreadFavoritesView: View {
                         )
                     } else {
                         Button {
-                            activeFavorite = favorite
+                            openFavorite(favorite)
                         } label: {
                             ThreadFavoriteRow(
                                 favorite: favorite,
@@ -267,6 +281,20 @@ struct ThreadFavoritesView: View {
             await reload()
         }
         .accessibilityIdentifier("thread-favorites-list")
+    }
+
+    private func openFavorite(_ favorite: AccountThreadFavorite) {
+        let route = ReaderSplitThreadRoute(
+            threadID: favorite.threadID,
+            forumID: favorite.forumID > 0 ? favorite.forumID : nil,
+            initialPostID: initialPostID(for: favorite)
+        )
+        if let openThreadInParent {
+            navigationSourceLifecycle.beginParentNavigation()
+            openThreadInParent(route)
+        } else {
+            activeFavorite = favorite
+        }
     }
 
     @ViewBuilder

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -61,6 +61,7 @@ struct UserProfileView: View {
     @State private var selectedThread: UserProfileThreadRoute?
     @State private var selectedForum: Forum?
     @State private var selectedRelationshipKind: UserRelationshipKind?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
     @State private var showsProfileEditor = false
     @State private var pendingProfileEditRequest: UserProfileEditRequest?
 
@@ -220,7 +221,13 @@ struct UserProfileView: View {
                 requestReadOnlyThreadRefresh()
             }
         }
+        .onAppear { navigationSourceLifecycle.didAppear() }
         .onDisappear {
+            guard navigationSourceLifecycle.shouldTearDown(
+                isPresentingLocalDestination: selectedThread != nil
+                    || selectedForum != nil
+                    || selectedRelationshipKind != nil
+            ) else { return }
             cancelRequests()
             requestGeneration += 1
             isLoadingProfile = false
@@ -423,6 +430,7 @@ struct UserProfileView: View {
             targetsByThreadID: deletionTargetsByThreadID
         )
         if let openThreadInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openThreadInParent(
                 ReaderSplitThreadRoute(
                     threadID: thread.id,
@@ -557,6 +565,7 @@ struct UserProfileView: View {
 
     private func openForum(_ forum: Forum) {
         if let openForumInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openForumInParent(forum)
         } else {
             selectedForum = forum

--- a/TiebaPure/Features/Search/SearchResultsView.swift
+++ b/TiebaPure/Features/Search/SearchResultsView.swift
@@ -56,6 +56,7 @@ struct SearchResultsView: View {
     @State private var activeThread: SearchThreadRoute?
     @State private var activeForum: Forum?
     @State private var selectedUser: UserSummary?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
     @State private var requestGeneration = 0
     @State private var loadTask: Task<SearchResultsPage, Error>?
     @State private var showsHistoryPersistenceError = false
@@ -147,7 +148,13 @@ struct SearchResultsView: View {
         .onChange(of: blocklistStore.entries) { _ in
             results.removeAll { TiebaContentFilter.shouldKeep(searchResult: $0) == false }
         }
+        .onAppear { navigationSourceLifecycle.didAppear() }
         .onDisappear {
+            guard navigationSourceLifecycle.shouldTearDown(
+                isPresentingLocalDestination: activeThread != nil
+                    || activeForum != nil
+                    || selectedUser != nil
+            ) else { return }
             loadTask?.cancel()
             requestGeneration += 1
             isLoading = false
@@ -453,6 +460,7 @@ struct SearchResultsView: View {
 
     private func openThread(_ route: SearchThreadRoute) {
         if let openThreadInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openThreadInParent(route)
         } else {
             activeThread = route
@@ -461,6 +469,7 @@ struct SearchResultsView: View {
 
     private func openForum(_ forum: Forum) {
         if let openForumInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openForumInParent(forum)
         } else {
             activeForum = forum
@@ -469,6 +478,7 @@ struct SearchResultsView: View {
 
     private func openUser(_ user: UserSummary) {
         if let openUserInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openUserInParent(user)
         } else {
             selectedUser = user

--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -552,6 +552,10 @@ final class InlineContentTextView: UITextView {
         addGestureRecognizer(recognizer)
     }
 
+    func setPlainTextTapEnabled(_ isEnabled: Bool) {
+        plainTextTapRecognizer?.isEnabled = isEnabled
+    }
+
     /// Returns a view the lazy stack dropped to a blank state. Everything the
     /// representable configures in `makeUIView` is reapplied there, so this only
     /// has to drop the content, this app's own recognizer, and the metrics
@@ -771,11 +775,10 @@ final class InlineContentTextView: UITextView {
         guard super.point(inside: point, with: event), isSelectable else {
             return false
         }
-        let target = tapTarget(at: point)
         if allowsTextSelection {
-            return target != .outsideText
+            return true
         }
-        return target == .link
+        return tapTarget(at: point) == .link
     }
 
     func tapTarget(at point: CGPoint) -> InlineContentTextTapTarget {
@@ -1105,6 +1108,7 @@ struct InlineContentText: UIViewRepresentable {
         textView.isSelectable = supportsInteraction
         textView.isUserInteractionEnabled = supportsInteraction
         textView.allowsTextSelection = allowsTextSelection
+        textView.setPlainTextTapEnabled(onPlainTextTap != nil)
         textView.panGestureRecognizer.isEnabled = false
         if abs(textView.contentOffset.x) > 0.01 || abs(textView.contentOffset.y) > 0.01 {
             textView.setContentOffset(.zero, animated: false)
@@ -1244,7 +1248,8 @@ struct InlineContentText: UIViewRepresentable {
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            true
+            gestureRecognizer is UITapGestureRecognizer
+                && otherGestureRecognizer is UITapGestureRecognizer
         }
 
         @objc func handlePlainTextTap(_ recognizer: UITapGestureRecognizer) {
@@ -1263,7 +1268,9 @@ struct InlineContentText: UIViewRepresentable {
             interaction: UITextItemInteraction
         ) -> Bool {
             if let user = InlineUserProfileLink.user(from: URL) {
-                onOpenUser?(user)
+                DispatchQueue.main.async { [weak self] in
+                    self?.onOpenUser?(user)
+                }
                 return false
             }
             guard let safeURL = TiebaURL.webpage(URL.absoluteString) else { return false }

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -35,6 +35,8 @@ struct ThreadDetailView: View {
     @State private var didApplyDefaultReplySort = false
     @State private var selectedSubpostPost: Post?
     @State private var selectedUser: UserSummary?
+    @State private var selectedForum: Forum?
+    @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
     @State private var userResolutionTask: Task<Void, Never>?
     @State private var userResolutionGeneration = 0
     @State private var userResolutionError: String?
@@ -183,6 +185,14 @@ struct ThreadDetailView: View {
                     .interactiveNavigationPopStateSync {
                         self.selectedUser = nil
                     }
+                }
+            }
+            .navigationDestination(isPresented: selectedForumIsActive) {
+                if let selectedForum {
+                    ForumThreadsView(account: account, forum: selectedForum)
+                        .interactiveNavigationPopStateSync {
+                            self.selectedForum = nil
+                        }
                 }
             }
     }
@@ -391,6 +401,11 @@ struct ThreadDetailView: View {
     }
 
     private func handleDisappear() {
+        guard navigationSourceLifecycle.shouldTearDown(
+            isPresentingLocalDestination: isSearchActive
+                || selectedUser != nil
+                || selectedForum != nil
+        ) else { return }
         isPageVisible = false
         let readingPositionRequest = readingPersistenceRequest(allowWhileLoading: true)
         readingTrackingState.cancelPendingCommit()
@@ -416,6 +431,7 @@ struct ThreadDetailView: View {
     }
 
     private func handleAppear() {
+        navigationSourceLifecycle.didAppear()
         isPageVisible = true
         completeOwnThreadDeletionNavigationIfPossible()
     }
@@ -617,6 +633,15 @@ struct ThreadDetailView: View {
         )
     }
 
+    private var selectedForumIsActive: Binding<Bool> {
+        Binding(
+            get: { selectedForum != nil },
+            set: { isActive in
+                if isActive == false { selectedForum = nil }
+            }
+        )
+    }
+
     @ToolbarContentBuilder
     private var navigationToolbar: some ToolbarContent {
         ToolbarItem(placement: .principal) {
@@ -632,25 +657,14 @@ struct ThreadDetailView: View {
     @ViewBuilder
     private var forumToolbarTitle: some View {
         if let forum = threadPage?.forum {
-            if let openForumInParent {
-                Button {
-                    openForumInParent(forum)
-                } label: {
-                    ForumToolbarTitle(forum: forum)
-                        .frame(minHeight: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-            } else {
-                NavigationLink {
-                    ForumThreadsView(account: account, forum: forum)
-                } label: {
-                    ForumToolbarTitle(forum: forum)
-                        .frame(minHeight: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+            Button {
+                openForum(forum)
+            } label: {
+                ForumToolbarTitle(forum: forum)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
         } else {
             ForumToolbarTitle(forum: nil)
         }
@@ -726,6 +740,7 @@ struct ThreadDetailView: View {
         if ThreadDetailSearchOpenRoutingPolicy.destination(
             hasParentHandler: openSearchInParent != nil
         ) == .parentPath, let openSearchInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openSearchInParent(scope)
         } else {
             isSearchActive = true
@@ -1018,9 +1033,19 @@ struct ThreadDetailView: View {
 
     private func presentUser(_ user: UserSummary) {
         if let openUserInParent {
+            navigationSourceLifecycle.beginParentNavigation()
             openUserInParent(user)
         } else {
             selectedUser = user
+        }
+    }
+
+    private func openForum(_ forum: Forum) {
+        if let openForumInParent {
+            navigationSourceLifecycle.beginParentNavigation()
+            openForumInParent(forum)
+        } else {
+            selectedForum = forum
         }
     }
 

--- a/TiebaPureTests/HomeNavigationTests.swift
+++ b/TiebaPureTests/HomeNavigationTests.swift
@@ -34,6 +34,27 @@ final class HomeNavigationTests: XCTestCase {
         )
     }
 
+    func testUserOpenedFromThreadIsOwnedByTheSameTypedPath() {
+        let thread = ReaderSplitThreadRoute(threadID: 101, forumID: 7)
+        let user = UserSummary(
+            id: 9,
+            name: "user",
+            displayName: "User",
+            portrait: ""
+        )
+        var path: [HomeNavigationRoute] = [.thread(thread)]
+
+        path = HomeNavigationPathPolicy.pushing(
+            .user(user: user, sourceThreadID: thread.threadID),
+            onto: path
+        )
+
+        XCTAssertEqual(
+            HomeNavigationPathPolicy.removingCurrent(path.last!, from: path),
+            [.thread(thread)]
+        )
+    }
+
     func testInheritedReaderHandlerDoesNotEscapeCompactLocalStack() {
         XCTAssertEqual(
             ForumThreadsOpenRoutingPolicy.destination(

--- a/TiebaPureTests/NavigationSourceLifecycleTests.swift
+++ b/TiebaPureTests/NavigationSourceLifecycleTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import TiebaPure
+
+final class NavigationSourceLifecycleTests: XCTestCase {
+    func testLocalDestinationKeepsSourceAliveUntilItReappears() {
+        var state = NavigationSourceLifecycleState()
+
+        XCTAssertFalse(state.shouldTearDown(isPresentingLocalDestination: true))
+
+        state.didAppear()
+        XCTAssertTrue(state.shouldTearDown(isPresentingLocalDestination: false))
+    }
+
+    func testParentDestinationKeepsSourceAliveUntilItReappears() {
+        var state = NavigationSourceLifecycleState()
+
+        state.beginParentNavigation()
+        XCTAssertFalse(state.shouldTearDown(isPresentingLocalDestination: false))
+
+        state.didAppear()
+        XCTAssertTrue(state.shouldTearDown(isPresentingLocalDestination: false))
+    }
+
+    func testNavigationGestureControllerHostsEdgeSystemsOrExplicitDisable() {
+        XCTAssertTrue(
+            NavigationPopGestureControlHostingPolicy.requiresController(
+                systemMajorVersion: 16,
+                isEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            NavigationPopGestureControlHostingPolicy.requiresController(
+                systemMajorVersion: 18,
+                isEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            NavigationPopGestureControlHostingPolicy.requiresController(
+                systemMajorVersion: 26,
+                isEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            NavigationPopGestureControlHostingPolicy.requiresController(
+                systemMajorVersion: 26,
+                isEnabled: false
+            )
+        )
+    }
+
+    func testMeHistoryThreadUserPathReturnsOneLevelAtATime() {
+        let thread = ReaderSplitThreadRoute(threadID: 101, forumID: 7)
+        let user = UserSummary(
+            id: 9,
+            name: "user",
+            displayName: "User",
+            portrait: ""
+        )
+        var path: [MeNavigationRoute] = [.browsingHistory]
+        path = MeNavigationPathPolicy.pushing(.thread(thread), onto: path)
+        let userRoute = MeNavigationRoute.user(user: user, sourceThreadID: thread.threadID)
+        path = MeNavigationPathPolicy.pushing(userRoute, onto: path)
+
+        path = MeNavigationPathPolicy.removingCurrent(userRoute, from: path)
+
+        XCTAssertEqual(path, [.browsingHistory, .thread(thread)])
+    }
+
+    func testMeFollowedUserThreadPathReturnsToProfile() {
+        let user = UserSummary(
+            id: 9,
+            name: "user",
+            displayName: "User",
+            portrait: ""
+        )
+        let userRoute = MeNavigationRoute.user(user: user, sourceThreadID: nil)
+        let thread = ReaderSplitThreadRoute(threadID: 101, forumID: 7)
+        var path: [MeNavigationRoute] = [.followedUsers, userRoute]
+        path = MeNavigationPathPolicy.pushing(.thread(thread), onto: path)
+
+        path = MeNavigationPathPolicy.removingCurrent(.thread(thread), from: path)
+
+        XCTAssertEqual(path, [.followedUsers, userRoute])
+    }
+}

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -351,6 +351,127 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(waitForLabelContaining("已定位搜索命中回复", in: app, maxSwipes: 10))
     }
 
+    func testIssue37MessagesThreadUserNavigationStaysResponsive() {
+        let app = launchApp(account: "loggedIn")
+        rootTab("我的", in: app).tap()
+
+        let messagesEntry = app.buttons["me-messages-entry"]
+        XCTAssertTrue(messagesEntry.waitForExistence(timeout: 8))
+        messagesEntry.tap()
+        let atSegment = app.segmentedControls.buttons["@我的"]
+        XCTAssertTrue(atSegment.waitForExistence(timeout: 8))
+        atSegment.tap()
+
+        let atRow = app.buttons["message-row-at-1001-2002"]
+        XCTAssertTrue(atRow.waitForExistence(timeout: 8))
+        atRow.tap()
+        XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
+
+        let authorButton = visibleThreadAuthorButton(in: app)
+        XCTAssertTrue(authorButton.exists)
+        authorButton.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+    }
+
+    func testIssue37BrowsingHistoryThreadUserNavigationStaysResponsive() {
+        let app = launchApp()
+        openFirstThread(in: app)
+        app.navigationBars.buttons.firstMatch.tap()
+        rootTab("我的", in: app).tap()
+
+        XCTAssertTrue(waitForElement(named: "browsing-history-entry", in: app, maxSwipes: 4))
+        app.buttons["browsing-history-entry"].tap()
+        let historyRow = app.buttons["browsing-history-row-1001"]
+        XCTAssertTrue(historyRow.waitForExistence(timeout: 8))
+        historyRow.tap()
+        XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
+
+        let authorButton = visibleThreadAuthorButton(in: app)
+        XCTAssertTrue(authorButton.exists)
+        authorButton.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+    }
+
+    func testIssue37ThreadFavoriteThreadUserNavigationStaysResponsive() {
+        let app = launchApp(account: "loggedIn")
+        openFirstThread(in: app)
+        let favoriteButton = app.buttons["thread-favorite-button"]
+        XCTAssertTrue(favoriteButton.waitForExistence(timeout: 8))
+        favoriteButton.tap()
+        expectation(
+            for: NSPredicate(format: "label == %@", "取消收藏帖子"),
+            evaluatedWith: favoriteButton
+        )
+        waitForExpectations(timeout: 5)
+        app.navigationBars.buttons.firstMatch.tap()
+        rootTab("我的", in: app).tap()
+
+        XCTAssertTrue(waitForElement(named: "thread-favorites-entry", in: app, maxSwipes: 4))
+        app.buttons["thread-favorites-entry"].tap()
+        let favoriteRow = app.buttons["thread-favorite-row-1001"]
+        XCTAssertTrue(favoriteRow.waitForExistence(timeout: 8))
+        favoriteRow.tap()
+        XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
+
+        let authorButton = visibleThreadAuthorButton(in: app)
+        XCTAssertTrue(authorButton.exists)
+        authorButton.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+    }
+
+    func testIssue37FollowedUserProfileThreadNavigationStaysResponsive() {
+        let app = launchApp(account: "loggedIn")
+        rootTab("我的", in: app).tap()
+        let entry = app.buttons["followed-users-entry"]
+        XCTAssertTrue(entry.waitForExistence(timeout: 8))
+        entry.tap()
+
+        let followedUser = app.buttons["followed-user-row-1"]
+        XCTAssertTrue(followedUser.waitForExistence(timeout: 8))
+        followedUser.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+
+        let thread = app.buttons["user-profile-thread-row-1002"]
+        XCTAssertTrue(thread.waitForExistence(timeout: 8))
+        XCTAssertTrue(scrollToHittable(thread, in: app.scrollViews["user-profile-screen"]))
+        thread.tap()
+        XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
+    }
+
+    func testIssue37FollowedForumThreadUserNavigationStaysResponsive() {
+        let app = launchApp(account: "loggedIn")
+        rootTab("我的", in: app).tap()
+        let followedForums = app.buttons["关注的吧"]
+        XCTAssertTrue(followedForums.waitForExistence(timeout: 8))
+        followedForums.tap()
+
+        let forumRow = app.buttons.matching(identifier: "followed-forum-row").firstMatch
+        XCTAssertTrue(forumRow.waitForExistence(timeout: 8))
+        forumRow.tap()
+        XCTAssertTrue(app.navigationBars["测试吧"].waitForExistence(timeout: 8))
+        openFirstThread(in: app)
+
+        let authorButton = visibleThreadAuthorButton(in: app)
+        XCTAssertTrue(authorButton.exists)
+        authorButton.tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["user-profile-screen"]
+                .waitForExistence(timeout: 8)
+        )
+    }
+
     func testLoggedInUserCanToggleProfileFollowState() {
         let app = launchApp(account: "loggedIn")
         openFirstThread(in: app)
@@ -2391,9 +2512,9 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(rootTab("我的", in: app).exists)
     }
 
-    func testLegacyNativeEdgePopRecognizerIsReadyInSwiftUINavigationStack() throws {
-        guard #unavailable(iOS 17.0) else {
-            throw XCTSkip("Only iOS 16 uses this legacy NavigationStack diagnostic")
+    func testPreIOS26NativeEdgePopRecognizerIsReadyInSwiftUINavigationStack() throws {
+        guard #unavailable(iOS 26.0) else {
+            throw XCTSkip("iOS 26 uses the native content-pop recognizer")
         }
 
         let app = launchApp(additionalArguments: ["UITEST_NAVIGATION_POP_DIAGNOSTICS"])
@@ -3564,6 +3685,50 @@ final class TiebaPureUITests: XCTestCase {
         copyControl.tap()
         XCTAssertFalse(app.navigationBars["回复用户"].exists, "长按复制不得触发回帖编辑器")
         XCTAssertTrue(app.buttons["更多"].exists)
+    }
+
+    func testIssue37RepeatedProfileNavigationAndTextSelectionStayResponsive() {
+        let app = launchApp(
+            scenario: "longContent",
+            account: "loggedIn",
+            additionalArguments: ["UITEST_RESET_CONTENT_SUBMISSION"],
+            disableAnimations: false
+        )
+        openFirstThread(in: app)
+
+        for iteration in 0..<3 {
+            let author = app.buttons["thread-main-user-button"]
+            XCTAssertTrue(author.waitForExistence(timeout: 8))
+            XCTAssertTrue(waitForHittable(author, expected: true, timeout: 5))
+            author.tap()
+
+            let profile = app.descendants(matching: .any)["user-profile-screen"]
+            XCTAssertTrue(
+                profile.waitForExistence(timeout: 8),
+                "第\(iteration + 1)次打开用户主页时界面失去响应"
+            )
+
+            let back = app.navigationBars["用户主页"].buttons.element(boundBy: 0)
+            XCTAssertTrue(waitForHittable(back, expected: true, timeout: 5))
+            back.tap()
+            XCTAssertTrue(
+                app.descendants(matching: .any)["thread-favorite-button"]
+                    .waitForExistence(timeout: 8),
+                "第\(iteration + 1)次返回帖子时越过了来源页或界面失去响应"
+            )
+        }
+
+        let mainText = app.descendants(matching: .any)["thread-main-text"]
+        XCTAssertTrue(mainText.waitForExistence(timeout: 8))
+        XCTAssertTrue(waitForHittable(mainText, expected: true, timeout: 5))
+        mainText.coordinate(withNormalizedOffset: CGVector(dx: 0.45, dy: 0.2))
+            .press(forDuration: 1.2)
+
+        let copyControl = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label IN %@", ["复制", "拷贝", "Copy"]))
+            .firstMatch
+        XCTAssertTrue(copyControl.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForHittable(copyControl, expected: true, timeout: 5))
     }
 
     func testSubpostRightSwipeDismissesTheWholeSheet() {
@@ -5661,6 +5826,25 @@ final class TiebaPureUITests: XCTestCase {
         }
         let didOpenDetail = app.buttons["更多"].waitForExistence(timeout: 8)
         XCTAssertTrue(didOpenDetail)
+    }
+
+    private func visibleThreadAuthorButton(in app: XCUIApplication) -> XCUIElement {
+        let predicate = NSPredicate(
+            format: "identifier == %@ OR identifier BEGINSWITH %@",
+            "thread-main-user-button",
+            "thread-user-button-"
+        )
+        let candidates = app.buttons.matching(predicate)
+        if candidates.firstMatch.waitForExistence(timeout: 3), candidates.firstMatch.isHittable {
+            return candidates.firstMatch
+        }
+        for _ in 0..<6 {
+            app.swipeDown()
+            if candidates.firstMatch.exists, candidates.firstMatch.isHittable {
+                return candidates.firstMatch
+            }
+        }
+        return candidates.firstMatch
     }
 
     private func middleSwipeRight(in app: XCUIApplication, y: CGFloat = 0.38) {


### PR DESCRIPTION
## 修改内容

- 将首页和“我的”的帖子、贴吧、用户深层导航统一收敛到根级 typed path，避免 iOS 18.3.1 在第二层页面入栈时触发 SwiftUI/AttributeGraph 递归布局。
- 子页面覆盖来源页时保留必要状态和任务，返回后仍按单层路径恢复。
- 调整帖子文字选择的触摸和手势处理，避免长按复制与用户链接导航互相竞争。
- iOS 16–25 继续使用系统边缘返回；iOS 26 保留系统 content-pop。

## 验证

- iOS 18.3.1：Issue #37 专项 UI 测试 8/8，路由与手势策略单测 11/11。
- iOS 26.5：专项 UI 回归 8/8。
- XcodeGen 重建后通用 iOS 模拟器构建通过。

Closes #37
