### PR TITLE
Refine search and reply controls

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -1401,13 +1401,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 54;
+				CURRENT_PROJECT_VERSION = 55;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.10;
+				MARKETING_VERSION = 1.4.11;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1418,14 +1418,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 54;
+				CURRENT_PROJECT_VERSION = 55;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.10;
+				MARKETING_VERSION = 1.4.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1471,14 +1471,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 54;
+				CURRENT_PROJECT_VERSION = 55;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.10;
+				MARKETING_VERSION = 1.4.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1491,13 +1491,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 54;
+				CURRENT_PROJECT_VERSION = 55;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.10;
+				MARKETING_VERSION = 1.4.11;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -26,6 +26,7 @@ enum FixtureScenario: String {
     case signFailure
     case readingPosition
     case scrollPerformance
+    case layoutPreview
     case submissionFailure
     case submissionVerification
     case submissionUnknown
@@ -187,6 +188,21 @@ struct FixtureTiebaAPI: TiebaAPIService {
             blocks: [],
             isReplyMatch: true
         )
+        if scenario == .layoutPreview, page == 1 {
+            let results = (0..<8).map { index in
+                var item = result
+                item.threadID = index == 0 ? 1001 : Int64(1_100 + index)
+                item.postID = index == 0 ? 2_002 : UInt64(2_100 + index)
+                item.title = "\(keyword) 搜索结果 \(index + 1)"
+                item.content = index.isMultiple(of: 2)
+                    ? "用于检查筛选栏随结果自然滚动。"
+                    : "搜索框保持在页面顶部。"
+                item.replyCount = index + 1
+                item.likeCount = index * 3
+                return item
+            }
+            return SearchResultsPage(results: results, currentPage: page, hasMore: false)
+        }
         return SearchResultsPage(results: page == 1 ? [result] : [], currentPage: page, hasMore: false)
     }
 
@@ -264,6 +280,7 @@ struct FixtureTiebaAPI: TiebaAPIService {
         }
         if scenario != .textClipping,
            scenario != .readingPosition,
+           scenario != .layoutPreview,
            usesVoicePlayback == false,
            scenario != .scrollPerformance || ["mixed", "production"].contains(scrollVariant) {
             mainBlocks.append(.image(longImage))
@@ -330,6 +347,8 @@ struct FixtureTiebaAPI: TiebaAPIService {
             replies = Self.readingPositionReplyFixtures(threadID: threadID, author: replyAuthor)
         case .scrollPerformance:
             replies = Self.scrollPerformanceReplyFixtures(threadID: threadID, author: replyAuthor)
+        case .layoutPreview:
+            replies = Self.layoutPreviewReplyFixtures(threadID: threadID, author: replyAuthor)
         default:
             replies = [reply]
         }
@@ -1084,6 +1103,39 @@ struct FixtureTiebaAPI: TiebaAPIService {
                 previewSubposts: []
             )
         }
+    }
+
+    static func layoutPreviewReplyFixtures(
+        threadID: Int64,
+        author: UserSummary
+    ) -> [Post] {
+        let previewSubposts = Array(subpostFixtures.prefix(3))
+        return [
+            Post(
+                id: 2_002,
+                threadID: threadID,
+                floor: 2,
+                author: author,
+                ipAddress: "上海",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_200),
+                blocks: [.text("这个楼层没有楼中楼回复。")],
+                subpostCount: 0,
+                likeCount: 3,
+                previewSubposts: []
+            ),
+            Post(
+                id: 2_003,
+                threadID: threadID,
+                floor: 3,
+                author: author,
+                ipAddress: "广东",
+                createdAt: Date(timeIntervalSince1970: 1_700_000_260),
+                blocks: [.text("这个楼层下面还有几条回复。")],
+                subpostCount: previewSubposts.count,
+                likeCount: 5,
+                previewSubposts: previewSubposts
+            )
+        ]
     }
 
     static func scrollPerformanceReplyFixtures(

--- a/TiebaPure/Core/UI/ReaderCard.swift
+++ b/TiebaPure/Core/UI/ReaderCard.swift
@@ -3,17 +3,23 @@ import SwiftUI
 struct ReaderCard<Content: View>: View {
     private let showsDivider: Bool
     private let cornerRadius: CGFloat
+    private let contentTopPadding: CGFloat
+    private let contentBottomPadding: CGFloat
     private let action: (() -> Void)?
     private let content: Content
 
     init(
         showsDivider: Bool = true,
         cornerRadius: CGFloat = 0,
+        contentTopPadding: CGFloat = TiebaPureTheme.Spacing.sm,
+        contentBottomPadding: CGFloat = TiebaPureTheme.Spacing.sm,
         action: (() -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.showsDivider = showsDivider
         self.cornerRadius = cornerRadius
+        self.contentTopPadding = contentTopPadding
+        self.contentBottomPadding = contentBottomPadding
         self.action = action
         self.content = content()
     }
@@ -36,7 +42,8 @@ struct ReaderCard<Content: View>: View {
             content
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, TiebaPureTheme.Spacing.md)
-                .padding(.vertical, TiebaPureTheme.Spacing.sm)
+                .padding(.top, contentTopPadding)
+                .padding(.bottom, contentBottomPadding)
                 .contentShape(Rectangle())
 
             if showsDivider {

--- a/TiebaPure/Features/Search/SearchResultsView.swift
+++ b/TiebaPure/Features/Search/SearchResultsView.swift
@@ -201,7 +201,7 @@ struct SearchResultsView: View {
                 .fill(TiebaPureTheme.ColorToken.readerSecondarySurface)
         )
         .padding(.horizontal, TiebaPureTheme.Spacing.md)
-        .padding(.vertical, TiebaPureTheme.Spacing.xs)
+        .padding(.vertical, SearchResultsControlsLayout.searchFieldVerticalPadding)
     }
 
     private var searchHistory: some View {
@@ -283,74 +283,34 @@ struct SearchResultsView: View {
     }
 
     private var searchResults: some View {
-        VStack(spacing: 0) {
-            controls
-                .readableWidth()
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 0) {
+                    controls
 
-            Group {
-                if isLoading && didLoad == false {
-                    ReaderStateView.loading("正在搜索")
-                } else if let errorMessage, results.isEmpty {
-                    ReaderStateScrollView(refresh: { await reload() }) {
-                        ReaderStateView.error(message: errorMessage) {
-                            Task { await reload() }
-                        }
-                    }
-                } else if results.isEmpty {
-                    ReaderStateScrollView(refresh: { await reload() }) {
-                        ReaderStateView.empty(
-                            title: "没有结果",
-                            message: "可调整范围或排序后重试。",
-                            actionTitle: hasMore && didLoad ? "继续加载" : nil,
-                            action: hasMore && didLoad ? { Task { await loadMore() } } : nil
-                        )
-                    }
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: TiebaPureTheme.Spacing.sm) {
-                            ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
-                                let thread = result.threadSummary
-                                ForumThreadRow(
-                                    thread: thread,
-                                    presentation: .homeFeed,
-                                    highlightKeyword: submittedKeyword,
-                                    onOpenThread: {
-                                        openThread(
-                                            SearchThreadRoute(
-                                                threadID: result.threadID,
-                                                forumID: result.forumID,
-                                                postID: result.postID
-                                            )
-                                        )
-                                    },
-                                    onOpenForum: { forum in
-                                        RecentForumStore.shared.save(forum)
-                                        openForum(forum)
-                                    },
-                                    onOpenUser: openUser,
-                                    onOpenMedia: { item, mediaItems, sourceFrame, sourceImage, sourceAnchor in
-                                        switch HomeMediaActionPolicy.action(for: item, in: mediaItems) {
-                                        case let .previewImages(images, index):
-                                            ImagePreviewCoordinator.shared.present(
-                                                ImagePreviewSession(
-                                                    images: images,
-                                                    initialIndex: index,
-                                                    sourceFrame: sourceFrame,
-                                                    sourceImage: sourceImage,
-                                                    sourceAnchor: sourceAnchor,
-                                                    prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
-                                                )
-                                            )
-                                        case let .playVideo(video):
-                                            VideoPreviewCoordinator.shared.present(
-                                                VideoPreviewSession(
-                                                    video: video,
-                                                    sourceFrame: sourceFrame,
-                                                    sourceImage: sourceImage,
-                                                    sourceAnchor: sourceAnchor
-                                                )
-                                            )
-                                        case .openThread:
+                    Group {
+                        if isLoading && didLoad == false {
+                            ReaderStateView.loading("正在搜索")
+                        } else if let errorMessage, results.isEmpty {
+                            ReaderStateView.error(message: errorMessage) {
+                                Task { await reload() }
+                            }
+                        } else if results.isEmpty {
+                            ReaderStateView.empty(
+                                title: "没有结果",
+                                message: "可调整范围或排序后重试。",
+                                actionTitle: hasMore && didLoad ? "继续加载" : nil,
+                                action: hasMore && didLoad ? { Task { await loadMore() } } : nil
+                            )
+                        } else {
+                            LazyVStack(spacing: TiebaPureTheme.Spacing.sm) {
+                                ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
+                                    let thread = result.threadSummary
+                                    ForumThreadRow(
+                                        thread: thread,
+                                        presentation: .homeFeed,
+                                        highlightKeyword: submittedKeyword,
+                                        onOpenThread: {
                                             openThread(
                                                 SearchThreadRoute(
                                                     threadID: result.threadID,
@@ -358,64 +318,110 @@ struct SearchResultsView: View {
                                                     postID: result.postID
                                                 )
                                             )
+                                        },
+                                        onOpenForum: { forum in
+                                            RecentForumStore.shared.save(forum)
+                                            openForum(forum)
+                                        },
+                                        onOpenUser: openUser,
+                                        onOpenMedia: { item, mediaItems, sourceFrame, sourceImage, sourceAnchor in
+                                            switch HomeMediaActionPolicy.action(for: item, in: mediaItems) {
+                                            case let .previewImages(images, index):
+                                                ImagePreviewCoordinator.shared.present(
+                                                    ImagePreviewSession(
+                                                        images: images,
+                                                        initialIndex: index,
+                                                        sourceFrame: sourceFrame,
+                                                        sourceImage: sourceImage,
+                                                        sourceAnchor: sourceAnchor,
+                                                        prefetchesAdjacentPages: readingPreferences.mediaLoading != .manual
+                                                    )
+                                                )
+                                            case let .playVideo(video):
+                                                VideoPreviewCoordinator.shared.present(
+                                                    VideoPreviewSession(
+                                                        video: video,
+                                                        sourceFrame: sourceFrame,
+                                                        sourceImage: sourceImage,
+                                                        sourceAnchor: sourceAnchor
+                                                    )
+                                                )
+                                            case .openThread:
+                                                openThread(
+                                                    SearchThreadRoute(
+                                                        threadID: result.threadID,
+                                                        forumID: result.forumID,
+                                                        postID: result.postID
+                                                    )
+                                                )
+                                            }
+                                        }
+                                    )
+                                    .onAppear {
+                                        guard PaginationPrefetchPolicy.shouldLoadMore(
+                                            currentIndex: index,
+                                            totalCount: results.count
+                                        ) else { return }
+                                        Task { await loadMore() }
+                                    }
+                                    .accessibilityElement(children: .contain)
+                                    .accessibilityIdentifier("thread-row")
+                                }
+
+                                if isLoading, didLoad {
+                                    ProgressView()
+                                        .padding(TiebaPureTheme.Spacing.md)
+                                        .accessibilityLabel("正在加载更多搜索结果")
+                                }
+
+                                if let errorMessage {
+                                    InlineLoadErrorView(message: errorMessage) {
+                                        Task {
+                                            if page <= 1 { await reload() } else { await loadMore() }
                                         }
                                     }
-                                )
-                                .onAppear {
-                                    guard PaginationPrefetchPolicy.shouldLoadMore(
-                                        currentIndex: index,
-                                        totalCount: results.count
-                                    ) else { return }
-                                    Task { await loadMore() }
-                                }
-                                .accessibilityElement(children: .contain)
-                                .accessibilityIdentifier("thread-row")
-                            }
-
-                            if isLoading, didLoad {
-                                ProgressView()
-                                    .padding(TiebaPureTheme.Spacing.md)
-                                    .accessibilityLabel("正在加载更多搜索结果")
-                            }
-
-                            if let errorMessage {
-                                InlineLoadErrorView(message: errorMessage) {
-                                    Task {
-                                        if page <= 1 { await reload() } else { await loadMore() }
+                                } else if hasMore, isLoading == false, didLoad {
+                                    Button {
+                                        Task { await loadMore() }
+                                    } label: {
+                                        Label("加载更多搜索结果", systemImage: "arrow.down.circle")
+                                            .frame(maxWidth: .infinity)
                                     }
+                                    .buttonStyle(.bordered)
+                                    .minTouchTarget()
+                                    .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                                    .accessibilityIdentifier("search-results-load-more")
                                 }
-                            } else if hasMore, isLoading == false, didLoad {
-                                Button {
-                                    Task { await loadMore() }
-                                } label: {
-                                    Label("加载更多搜索结果", systemImage: "arrow.down.circle")
-                                        .frame(maxWidth: .infinity)
-                                }
-                                .buttonStyle(.bordered)
-                                .minTouchTarget()
-                                .padding(.horizontal, TiebaPureTheme.Spacing.md)
-                                .accessibilityIdentifier("search-results-load-more")
-                            }
 
-                            Color.clear
-                                .frame(height: 48)
-                                .accessibilityHidden(true)
+                                Color.clear
+                                    .frame(height: 48)
+                                    .accessibilityHidden(true)
+                            }
+                            .padding(.horizontal, TiebaPureTheme.Spacing.sm)
+                            .padding(.top, SearchResultsControlsLayout.resultsTopPadding)
+                            .padding(.bottom, TiebaPureTheme.Spacing.sm)
                         }
-                        .padding(.horizontal, TiebaPureTheme.Spacing.sm)
-                        .padding(.vertical, TiebaPureTheme.Spacing.sm)
-                        .readableWidth()
                     }
-                    .shortPullRefresh(
-                        isEnabled: didLoad && isLoading == false,
-                        surface: .grouped,
-                        accessibilityIdentifier: "search-refresh-animation"
-                    ) {
-                        await reload()
-                    }
-                    .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+                    .frame(
+                        maxWidth: .infinity,
+                        minHeight: SearchResultsControlsLayout.minimumContentHeight(
+                            viewportHeight: proxy.size.height
+                        )
+                    )
                 }
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: max(proxy.size.height + 1, 1), alignment: .top)
+                .readableWidth()
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("search-results-scroll-view")
+            .shortPullRefresh(
+                isEnabled: didLoad && isLoading == false,
+                surface: .grouped,
+                accessibilityIdentifier: "search-refresh-animation"
+            ) {
+                await reload()
+            }
+            .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
         }
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
     }
@@ -477,18 +483,27 @@ struct SearchResultsView: View {
 
     private var controls: some View {
         ViewThatFits(in: .horizontal) {
-            HStack(spacing: TiebaPureTheme.Spacing.sm) {
+            HStack(alignment: .center, spacing: TiebaPureTheme.Spacing.sm) {
                 filterPicker
+                Spacer(minLength: TiebaPureTheme.Spacing.sm)
                 sortMenu
             }
+            .frame(
+                maxWidth: .infinity,
+                minHeight: SearchResultsControlsLayout.controlHeight,
+                maxHeight: SearchResultsControlsLayout.controlHeight,
+                alignment: .center
+            )
             VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xs) {
                 filterPicker
                 sortMenu
             }
         }
         .padding(.horizontal, TiebaPureTheme.Spacing.md)
-        .padding(.vertical, TiebaPureTheme.Spacing.sm)
+        .padding(.vertical, SearchResultsControlsLayout.controlVerticalPadding)
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("search-result-controls")
     }
 
     private var filterPicker: some View {
@@ -498,7 +513,7 @@ struct SearchResultsView: View {
             }
             .pickerStyle(.segmented)
             .frame(maxWidth: 220)
-            .frame(minHeight: 44)
+            .frame(height: SearchResultsControlsLayout.controlHeight, alignment: .center)
             .contentShape(Rectangle())
             .onChange(of: filterType) { _ in
                 Task { await reload() }
@@ -514,7 +529,7 @@ struct SearchResultsView: View {
                 Label(sortTitle, systemImage: "arrow.up.arrow.down")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(.secondary)
-                    .frame(minHeight: 44)
+                    .frame(height: SearchResultsControlsLayout.controlHeight, alignment: .center)
                     .fixedSize(horizontal: true, vertical: false)
             }
             .accessibilityLabel("排序：\(sortTitle)")
@@ -677,6 +692,21 @@ struct SearchResultsView: View {
             sortType: sortType,
             page: page
         )
+    }
+}
+
+enum SearchResultsControlsLayout {
+    static let searchFieldVerticalPadding: CGFloat = TiebaPureTheme.Spacing.xxs
+    static let controlVerticalPadding: CGFloat = 0
+    static let controlHeight: CGFloat = 40
+    static let resultsTopPadding: CGFloat = TiebaPureTheme.Spacing.xxs
+
+    static var compactHeight: CGFloat {
+        controlHeight + controlVerticalPadding * 2
+    }
+
+    static func minimumContentHeight(viewportHeight: CGFloat) -> CGFloat {
+        max(viewportHeight - compactHeight + 1, 1)
     }
 }
 

--- a/TiebaPure/Features/Thread/PostRowView.swift
+++ b/TiebaPure/Features/Thread/PostRowView.swift
@@ -36,7 +36,14 @@ struct PostRowView: View {
     }
 
     var body: some View {
-        ReaderCard(showsDivider: isMainPost == false) {
+        let metadataPlacement = ThreadPostMetadataPlacement.resolve(
+            isMainPost: isMainPost,
+            hasPreviewSubposts: post.previewSubposts.isEmpty == false
+        )
+        ReaderCard(
+            showsDivider: isMainPost == false,
+            contentBottomPadding: metadataPlacement.cardBottomPadding
+        ) {
             VStack(
                 alignment: .leading,
                 spacing: isMainPost ? TiebaPureTheme.Spacing.md : ThreadReplyLayout.headerContentSpacing
@@ -87,7 +94,8 @@ struct PostRowView: View {
                             : "thread-reply-metadata",
                         replyAccessibilityLabel: "回复第\(post.floor)楼",
                         replyAccessibilityIdentifier: "thread-reply-button-\(post.id)",
-                        onReply: onReply
+                        onReply: onReply,
+                        placement: metadataPlacement
                     )
 
                     if post.previewSubposts.isEmpty == false {
@@ -300,13 +308,54 @@ enum ThreadReplyLayout {
     static let bodyLeadingInset = ThreadAuthorIdentityLayout.replyAvatarSize + TiebaPureTheme.Spacing.sm
     static let headerContentSpacing: CGFloat = TiebaPureTheme.Spacing.xxs
     static let bodyStackSpacing: CGFloat = 0
-    static let metadataTopSpacing: CGFloat = TiebaPureTheme.Spacing.xxs
-    static let metadataVisualHeight: CGFloat = 28
     static let metadataHitHeight: CGFloat = 44
-    static let metadataHitExpansion = (metadataHitHeight - metadataVisualHeight) / 2
     static let sectionSeparatorHeight: CGFloat = TiebaPureTheme.Spacing.xs
     static let previewTopPadding: CGFloat = TiebaPureTheme.Spacing.sm
     static let previewBottomPadding: CGFloat = TiebaPureTheme.Spacing.xxs
+}
+
+enum ThreadPostMetadataPlacement: Equatable {
+    case mainPost
+    case standaloneReply
+    case beforeSubpostPreview
+
+    static func resolve(isMainPost: Bool, hasPreviewSubposts: Bool) -> ThreadPostMetadataPlacement {
+        if isMainPost { return .mainPost }
+        return hasPreviewSubposts ? .beforeSubpostPreview : .standaloneReply
+    }
+
+    var visualHeight: CGFloat {
+        self == .mainPost ? 28 : 20
+    }
+
+    var topSpacing: CGFloat {
+        switch self {
+        case .mainPost:
+            return TiebaPureTheme.Spacing.xxs
+        case .standaloneReply, .beforeSubpostPreview:
+            return 6
+        }
+    }
+
+    var bottomSpacing: CGFloat {
+        self == .beforeSubpostPreview ? 6 : 0
+    }
+
+    var totalVerticalSpace: CGFloat {
+        topSpacing + visualHeight + bottomSpacing
+    }
+
+    var hitExpansion: CGFloat {
+        max((ThreadReplyLayout.metadataHitHeight - visualHeight) / 2, 0)
+    }
+
+    var cardBottomPadding: CGFloat {
+        self == .standaloneReply ? topSpacing : TiebaPureTheme.Spacing.sm
+    }
+
+    var totalSpaceToFollowingContent: CGFloat {
+        totalVerticalSpace + (self == .standaloneReply ? cardBottomPadding : 0)
+    }
 }
 
 enum ThreadPostMetadataText {
@@ -351,6 +400,7 @@ struct ThreadPostMetadataView: View {
     var replyAccessibilityLabel: String? = nil
     var replyAccessibilityIdentifier: String? = nil
     var onReply: (() -> Void)? = nil
+    var placement: ThreadPostMetadataPlacement = .standaloneReply
 
     var body: some View {
         let displayText = ThreadPostMetadataText.text(createdAt: createdAt, ipAddress: ipAddress)
@@ -378,7 +428,7 @@ struct ThreadPostMetadataView: View {
                             .fixedSize(horizontal: true, vertical: false)
                             .frame(
                                 minWidth: 56,
-                                minHeight: ThreadReplyLayout.metadataVisualHeight,
+                                minHeight: placement.visualHeight,
                                 alignment: .trailing
                             )
                             .contentShape(Rectangle())
@@ -386,7 +436,7 @@ struct ThreadPostMetadataView: View {
                     .buttonStyle(.plain)
                     .contentShape(
                         .interaction,
-                        Rectangle().inset(by: -ThreadReplyLayout.metadataHitExpansion)
+                        Rectangle().inset(by: -placement.hitExpansion)
                     )
                     .accessibilityLabel(replyAccessibilityLabel ?? "回复")
                     .accessibilityHint("打开回复编辑器")
@@ -395,10 +445,11 @@ struct ThreadPostMetadataView: View {
             }
             .frame(
                 maxWidth: .infinity,
-                minHeight: ThreadReplyLayout.metadataVisualHeight,
+                minHeight: placement.visualHeight,
                 alignment: .leading
             )
-            .padding(.top, ThreadReplyLayout.metadataTopSpacing)
+            .padding(.top, placement.topSpacing)
+            .padding(.bottom, placement.bottomSpacing)
         }
     }
 }

--- a/TiebaPure/Features/Thread/SubpostPreviewView.swift
+++ b/TiebaPure/Features/Thread/SubpostPreviewView.swift
@@ -68,6 +68,8 @@ struct SubpostPreviewView: View {
                 RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.media, style: .continuous)
                     .fill(TiebaPureTheme.ColorToken.readerTertiarySurface)
             )
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("thread-subpost-preview")
         }
     }
 }

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -2264,6 +2264,9 @@ private struct ForumToolbarTitle: View {
 }
 
 private struct ReplyControlBar: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let seeLz: Bool
     let sortType: ThreadReplySort
     let onSeeLzChange: (Bool) -> Void
@@ -2282,8 +2285,17 @@ private struct ReplyControlBar: View {
             }
         }
         .padding(.horizontal, TiebaPureTheme.Spacing.md)
-        .padding(.vertical, TiebaPureTheme.Spacing.xs)
+        .frame(minHeight: controlHeight, alignment: .center)
         .background(.regularMaterial)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("thread-reply-control-bar")
+    }
+
+    private var controlHeight: CGFloat {
+        ReplyControlBarLayout.controlHeight(
+            readerFontSize: readingPreferences.fontSize,
+            dynamicTypeSize: dynamicTypeSize
+        )
     }
 
     private var filterControls: some View {
@@ -2316,7 +2328,7 @@ private struct ReplyControlBar: View {
                     sortButton(item)
                 }
             }
-            .padding(3)
+            .frame(height: controlHeight, alignment: .center)
             .background(
                 Capsule(style: .continuous)
                     .fill(TiebaPureTheme.ColorToken.readerGroupedBackground)
@@ -2326,7 +2338,6 @@ private struct ReplyControlBar: View {
                     sortButton(item)
                 }
             }
-            .padding(3)
             .background(
                 RoundedRectangle(cornerRadius: TiebaPureTheme.Radius.chip, style: .continuous)
                     .fill(TiebaPureTheme.ColorToken.readerGroupedBackground)
@@ -2339,16 +2350,21 @@ private struct ReplyControlBar: View {
             onSortChange(item)
         } label: {
             Text(item.title)
-                .font(.subheadline.weight(sortType == item ? .semibold : .regular))
+                .font(Font(ReplyControlBarTypography.font(
+                    textStyle: .subheadline,
+                    isEmphasized: sortType == item,
+                    readerFontSize: readingPreferences.fontSize,
+                    dynamicTypeSize: dynamicTypeSize
+                )))
                 .foregroundStyle(sortType == item ? Color.primary : Color.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-                .frame(minWidth: 48)
-                .padding(.vertical, 7)
-                .padding(.horizontal, 4)
+                .frame(minWidth: 48, minHeight: controlHeight, alignment: .center)
+                .offset(y: ReplyControlBarLayout.opticalTextOffset)
                 .background(
                     Capsule(style: .continuous)
                         .fill(sortType == item ? Color(uiColor: .systemBackground) : Color.clear)
+                        .padding(3)
                 )
         }
         .buttonStyle(.plain)
@@ -2362,12 +2378,78 @@ private struct ReplyControlBar: View {
     private func filterButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(title)
-                .font(.body.weight(isSelected ? .semibold : .regular))
+                .font(Font(ReplyControlBarTypography.font(
+                    textStyle: .body,
+                    isEmphasized: isSelected,
+                    readerFontSize: readingPreferences.fontSize,
+                    dynamicTypeSize: dynamicTypeSize
+                )))
                 .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+                .frame(minHeight: controlHeight, alignment: .center)
+                .offset(y: ReplyControlBarLayout.opticalTextOffset)
         }
         .buttonStyle(.plain)
-        .minTouchTarget()
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}
+
+enum ReplyControlBarLayout {
+    static let minimumHeight: CGFloat = 44
+    static let opticalTextOffset: CGFloat = -1
+
+    static func controlHeight(
+        readerFontSize: ReaderFontSize,
+        dynamicTypeSize: DynamicTypeSize
+    ) -> CGFloat {
+        let bodyFont = ReplyControlBarTypography.font(
+            textStyle: .body,
+            isEmphasized: true,
+            readerFontSize: readerFontSize,
+            dynamicTypeSize: dynamicTypeSize
+        )
+        let sortFont = ReplyControlBarTypography.font(
+            textStyle: .subheadline,
+            isEmphasized: true,
+            readerFontSize: readerFontSize,
+            dynamicTypeSize: dynamicTypeSize
+        )
+        return ceil(max(minimumHeight, max(bodyFont.lineHeight, sortFont.lineHeight) + 12))
+    }
+}
+
+enum ReplyControlBarTypography {
+    static func font(
+        textStyle: UIFont.TextStyle,
+        isEmphasized: Bool,
+        readerFontSize: ReaderFontSize,
+        dynamicTypeSize: DynamicTypeSize = .large
+    ) -> UIFont {
+        ReaderTypographyPolicy.font(
+            textStyle: textStyle,
+            weight: isEmphasized ? .semibold : .regular,
+            fontSize: readerFontSize,
+            compatibleWith: UITraitCollection(
+                preferredContentSizeCategory: contentSizeCategory(for: dynamicTypeSize)
+            )
+        )
+    }
+
+    private static func contentSizeCategory(for dynamicTypeSize: DynamicTypeSize) -> UIContentSizeCategory {
+        switch dynamicTypeSize {
+        case .xSmall: return .extraSmall
+        case .small: return .small
+        case .medium: return .medium
+        case .large: return .large
+        case .xLarge: return .extraLarge
+        case .xxLarge: return .extraExtraLarge
+        case .xxxLarge: return .extraExtraExtraLarge
+        case .accessibility1: return .accessibilityMedium
+        case .accessibility2: return .accessibilityLarge
+        case .accessibility3: return .accessibilityExtraLarge
+        case .accessibility4: return .accessibilityExtraExtraLarge
+        case .accessibility5: return .accessibilityExtraExtraExtraLarge
+        @unknown default: return .large
+        }
     }
 }
 
@@ -2453,7 +2535,10 @@ private struct SubpostListSheet: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 0) {
-                            ReaderCard(showsDivider: false) {
+                            ReaderCard(
+                                showsDivider: false,
+                                contentBottomPadding: ThreadPostMetadataPlacement.standaloneReply.cardBottomPadding
+                            ) {
                                 VStack(alignment: .leading, spacing: ThreadReplyLayout.headerContentSpacing) {
                                     UserHeaderView(
                                         author: post.author,
@@ -2980,7 +3065,9 @@ private struct SubpostRowView: View {
     let onReply: (() -> Void)?
 
     var body: some View {
-        ReaderCard {
+        ReaderCard(
+            contentBottomPadding: ThreadPostMetadataPlacement.standaloneReply.cardBottomPadding
+        ) {
             VStack(alignment: .leading, spacing: ThreadReplyLayout.headerContentSpacing) {
                 UserHeaderView(
                     author: subpost.author,

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -3156,12 +3156,75 @@ final class TiebaPureSmokeTests: XCTestCase {
 
     func testThreadReplyMetadataMatchesCompactFooterStyle() throws {
         XCTAssertEqual(ThreadReplyLayout.bodyStackSpacing, 0)
-        XCTAssertEqual(ThreadReplyLayout.metadataTopSpacing, 4)
-        XCTAssertEqual(ThreadReplyLayout.metadataVisualHeight, 28)
         XCTAssertEqual(ThreadReplyLayout.metadataHitHeight, 44)
+
+        let main = ThreadPostMetadataPlacement.mainPost
+        let standalone = ThreadPostMetadataPlacement.standaloneReply
+        let beforePreview = ThreadPostMetadataPlacement.beforeSubpostPreview
+
+        XCTAssertEqual(main.visualHeight, 28)
+        XCTAssertEqual(main.totalVerticalSpace, 32)
+        XCTAssertEqual(standalone.visualHeight, 20)
+        XCTAssertEqual(standalone.totalVerticalSpace, 26)
+        XCTAssertLessThan(standalone.totalVerticalSpace, main.totalVerticalSpace)
+        XCTAssertEqual(standalone.cardBottomPadding, standalone.topSpacing)
+        XCTAssertEqual(beforePreview.topSpacing, beforePreview.bottomSpacing)
+        XCTAssertEqual(beforePreview.totalVerticalSpace, main.totalVerticalSpace)
         XCTAssertEqual(
-            ThreadReplyLayout.metadataVisualHeight + ThreadReplyLayout.metadataHitExpansion * 2,
-            ThreadReplyLayout.metadataHitHeight
+            standalone.totalSpaceToFollowingContent,
+            beforePreview.totalSpaceToFollowingContent
+        )
+        XCTAssertEqual(
+            ThreadPostMetadataPlacement.resolve(isMainPost: true, hasPreviewSubposts: true),
+            .mainPost
+        )
+        XCTAssertEqual(
+            ThreadPostMetadataPlacement.resolve(isMainPost: false, hasPreviewSubposts: false),
+            .standaloneReply
+        )
+        XCTAssertEqual(
+            ThreadPostMetadataPlacement.resolve(isMainPost: false, hasPreviewSubposts: true),
+            .beforeSubpostPreview
+        )
+
+        for placement in [main, standalone, beforePreview] {
+            XCTAssertEqual(
+                placement.visualHeight + placement.hitExpansion * 2,
+                ThreadReplyLayout.metadataHitHeight
+            )
+        }
+
+        XCTAssertEqual(SearchResultsControlsLayout.searchFieldVerticalPadding, 4)
+        XCTAssertEqual(SearchResultsControlsLayout.controlVerticalPadding, 0)
+        XCTAssertEqual(SearchResultsControlsLayout.compactHeight, 40)
+        XCTAssertEqual(SearchResultsControlsLayout.minimumContentHeight(viewportHeight: 600), 561)
+        XCTAssertEqual(ReplyControlBarLayout.minimumHeight, 44)
+        XCTAssertEqual(ReplyControlBarLayout.opticalTextOffset, -1)
+        XCTAssertEqual(
+            ReplyControlBarLayout.controlHeight(
+                readerFontSize: .standard,
+                dynamicTypeSize: .large
+            ),
+            44
+        )
+        XCTAssertGreaterThan(
+            ReplyControlBarLayout.controlHeight(
+                readerFontSize: .extraLarge,
+                dynamicTypeSize: .accessibility5
+            ),
+            44
+        )
+        XCTAssertGreaterThan(
+            ReplyControlBarTypography.font(
+                textStyle: .body,
+                isEmphasized: false,
+                readerFontSize: .extraLarge
+            ).pointSize,
+            ReplyControlBarTypography.font(
+                textStyle: .body,
+                isEmphasized: false,
+                readerFontSize: .standard
+            ).pointSize
         )
 
         var calendar = Calendar(identifier: .gregorian)

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -4228,7 +4228,7 @@ final class TiebaPureUITests: XCTestCase {
     }
 
     func testSyntheticScreenshotMatrix() {
-        let app = launchApp()
+        let app = launchApp(scenario: "layoutPreview")
         XCTAssertTrue(threadRows(in: app).firstMatch.waitForExistence(timeout: 8))
         attachScreenshot(named: "fixture-home")
 
@@ -4236,7 +4236,36 @@ final class TiebaPureUITests: XCTestCase {
         searchField.typeText("合成测试")
         searchField.typeText("\n")
         XCTAssertTrue(threadRows(in: app).firstMatch.waitForExistence(timeout: 8))
-        attachScreenshot(named: "fixture-search-controls")
+        let searchScroll = app.scrollViews["search-results-scroll-view"]
+        let searchSegmentedControl = app.segmentedControls.firstMatch
+        let allFilter = app.segmentedControls.buttons["全部"]
+        let searchControlBar = app.descendants(matching: .any)["search-result-controls"]
+        let searchSortButton = app.buttons["排序：最新"]
+        XCTAssertTrue(searchScroll.waitForExistence(timeout: 5))
+        XCTAssertTrue(searchSegmentedControl.waitForExistence(timeout: 5))
+        XCTAssertTrue(allFilter.waitForExistence(timeout: 5))
+        XCTAssertTrue(searchControlBar.waitForExistence(timeout: 5))
+        XCTAssertTrue(searchSortButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForHittable(allFilter, expected: true, timeout: 5))
+        XCTAssertEqual(searchControlBar.frame.height, 40, accuracy: 1)
+        XCTAssertEqual(allFilter.frame.midY, searchControlBar.frame.midY, accuracy: 1)
+        XCTAssertEqual(searchSortButton.frame.midY, searchControlBar.frame.midY, accuracy: 1)
+        XCTAssertLessThan(searchSegmentedControl.frame.midX, searchControlBar.frame.midX)
+        XCTAssertGreaterThan(searchSortButton.frame.midX, searchControlBar.frame.midX)
+        let fixedSearchFieldY = searchField.frame.minY
+        attachScreenshot(named: "issue43-search-compact")
+
+        searchScroll.swipeUp()
+        if allFilter.isHittable {
+            searchScroll.swipeUp()
+        }
+        XCTAssertEqual(searchField.frame.minY, fixedSearchFieldY, accuracy: 1)
+        XCTAssertTrue(searchField.isHittable)
+        XCTAssertFalse(allFilter.isHittable)
+        attachScreenshot(named: "issue43-search-field-fixed")
+
+        searchScroll.swipeDown()
+        searchScroll.swipeDown()
 
         let openArea = app.descendants(matching: .any)
             .matching(identifier: "thread-open-area")
@@ -4245,8 +4274,19 @@ final class TiebaPureUITests: XCTestCase {
         openArea.tap()
         XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 8))
         XCTAssertTrue(waitForElement(named: "全部回复", in: app, maxSwipes: 30))
-        app.swipeUp()
-        attachScreenshot(named: "fixture-thread-controls")
+        let replyControlBar = app.descendants(matching: .any)["thread-reply-control-bar"]
+        let allRepliesButton = app.buttons["thread-reply-controls"]
+        let ascendingSortButton = app.buttons["thread-reply-sort-0"]
+        XCTAssertTrue(replyControlBar.waitForExistence(timeout: 5))
+        XCTAssertTrue(allRepliesButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(ascendingSortButton.waitForExistence(timeout: 5))
+        XCTAssertEqual(replyControlBar.frame.height, 44, accuracy: 1)
+        XCTAssertEqual(allRepliesButton.frame.midY, replyControlBar.frame.midY, accuracy: 1)
+        XCTAssertEqual(ascendingSortButton.frame.midY, replyControlBar.frame.midY, accuracy: 1)
+        attachScreenshot(named: "issue43-thread-controls-compact")
+
+        XCTAssertTrue(waitForLabelContaining("这个楼层没有楼中楼回复", in: app, maxSwipes: 4))
+        attachScreenshot(named: "issue43-thread-metadata-spacing")
     }
 
     func testLandscapeHomeAndSearchLayout() {

--- a/project.yml
+++ b/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.10
-        CURRENT_PROJECT_VERSION: 54
+        MARKETING_VERSION: 1.4.11
+        CURRENT_PROJECT_VERSION: 55
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -56,8 +56,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.10
-        CURRENT_PROJECT_VERSION: 54
+        MARKETING_VERSION: 1.4.11
+        CURRENT_PROJECT_VERSION: 55
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容

- 搜索框固定在滚动区外，筛选栏随结果滚动，并将范围筛选与排序分别放在左右两侧。
- 压缩搜索与帖子回复筛选栏的竖向空间，回复筛选字体跟随阅读字号和系统动态字体。
- 统一有无楼中楼时楼层时间、IP 与后续内容之间的竖向间距。
- 版本更新至 1.4.11 (55)。

## 验证

- `TiebaPureSmokeTests/testThreadReplyMetadataMatchesCompactFooterStyle`
- `TiebaPureUITests/testSyntheticScreenshotMatrix`

Closes #43
