### PR TITLE
fix: prevent thread pages from losing the main post

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		34511F43DA6B267EB2816388 /* FixtureDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4A700D0BB079E5CEC104C1 /* FixtureDecodingTests.swift */; };
 		35D97F8C9E055B516F478254 /* TiebaForumSignAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722158AB6808A4470B0BDE41 /* TiebaForumSignAPI.swift */; };
 		35DB68280B2FAF0F4C1493B9 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 37E6671F9A9A069EADCFAFB9 /* PrivacyInfo.xcprivacy */; };
+		3788E594CA3F66F7C738E184 /* ThreadPageMainPostPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D748C5A77D226EAD9A7EEB85 /* ThreadPageMainPostPolicyTests.swift */; };
 		388FED0A277CBB09D2C252F5 /* TiebaEmoticonRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9BED7F7A1BE8C617FE2F15 /* TiebaEmoticonRepository.swift */; };
 		3C76B30ACE505A1329C35516 /* SubpostSheetInteractiveDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BC2EF1ED11AC6A71B3CED6 /* SubpostSheetInteractiveDismiss.swift */; };
 		3D1A84D21D3BA0D4DF205924 /* SwiftData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 158DD0B24F8C6500639DB687 /* SwiftData.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -427,6 +428,7 @@
 		D6711EB46FB5BE95EF86ACB6 /* Personalized.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Personalized.pb.swift; sourceTree = "<group>"; };
 		D671D758CEF85777E7C7D8E4 /* MeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeView.swift; sourceTree = "<group>"; };
 		D675F69938E6B1281FC28A54 /* ContentDraftPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftPersistence.swift; sourceTree = "<group>"; };
+		D748C5A77D226EAD9A7EEB85 /* ThreadPageMainPostPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPageMainPostPolicyTests.swift; sourceTree = "<group>"; };
 		D9DDCEE2EB7CAB5604D83C90 /* SubPostList.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubPostList.pb.swift; sourceTree = "<group>"; };
 		DB22109F3B9CFD8850C4BEE0 /* AuthSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
 		DBA0A4653556BD11ACA8C0A3 /* AnonymousLiveSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousLiveSmokeTests.swift; sourceTree = "<group>"; };
@@ -753,6 +755,7 @@
 				8D5BFD4EFAD7D98BA703D36C /* StateRegressionTests.swift */,
 				8FBDD5BC8E767866E1874011 /* SwiftDataOrderedCollectionPersistenceTests.swift */,
 				5E7B54C9EC311DDB57FEBB4F /* ThreadAuthorBadgeTests.swift */,
+				D748C5A77D226EAD9A7EEB85 /* ThreadPageMainPostPolicyTests.swift */,
 				12A3703C41D45165012736BB /* TiebaFormSignerTests.swift */,
 				2792F6DFB423B6000542ADFB /* TiebaPostingBootstrapTests.swift */,
 				53A22DDA746D43724E44B7D2 /* TiebaPureSmokeTests.swift */,
@@ -1295,6 +1298,7 @@
 				C52C1926A49DEF01D6460BB4 /* StateRegressionTests.swift in Sources */,
 				BC0174E4104B48F4D4A8B291 /* SwiftDataOrderedCollectionPersistenceTests.swift in Sources */,
 				53DEA982CB662F838F26F9BC /* ThreadAuthorBadgeTests.swift in Sources */,
+				3788E594CA3F66F7C738E184 /* ThreadPageMainPostPolicyTests.swift in Sources */,
 				A9A2CC0EE649F6C31E920713 /* TiebaFormSignerTests.swift in Sources */,
 				85EFBF3494B6DBAE4707E464 /* TiebaPostingBootstrapTests.swift in Sources */,
 				C0E5134C9E23DDD474D84DDA /* TiebaPureSmokeTests.swift in Sources */,
@@ -1409,13 +1413,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 55;
+				CURRENT_PROJECT_VERSION = 56;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.11;
+				MARKETING_VERSION = 1.4.12;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1426,14 +1430,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 55;
+				CURRENT_PROJECT_VERSION = 56;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.11;
+				MARKETING_VERSION = 1.4.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1479,14 +1483,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CURRENT_PROJECT_VERSION = 55;
+				CURRENT_PROJECT_VERSION = 56;
 				INFOPLIST_FILE = TiebaPureOpenIn/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.11;
+				MARKETING_VERSION = 1.4.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.infinityf4p.tiebapure.open-in";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1499,13 +1503,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 55;
+				CURRENT_PROJECT_VERSION = 56;
 				INFOPLIST_FILE = TiebaPure/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.11;
+				MARKETING_VERSION = 1.4.12;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.infinityf4p.tiebapure;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -102,6 +102,9 @@ final class AppEnvironment: ObservableObject {
                 BlocklistStore.shared.clear(kind: $0)
             }
         }
+        if arguments.contains("UITEST_SEED_MAIN_POST_BLOCKLIST") {
+            BlocklistStore.shared.addKeyword("完全离线的合成帖子正文")
+        }
         if arguments.contains("UITEST_RESET_FORUM_THREAD_SORT") {
             ForumThreadSortPreferenceStore().reset()
         }

--- a/TiebaPure/Core/Network/FixtureTiebaAPI.swift
+++ b/TiebaPure/Core/Network/FixtureTiebaAPI.swift
@@ -27,6 +27,8 @@ enum FixtureScenario: String {
     case readingPosition
     case scrollPerformance
     case layoutPreview
+    case missingMainThenRecovery
+    case missingMain
     case submissionFailure
     case submissionVerification
     case submissionUnknown
@@ -235,7 +237,8 @@ struct FixtureTiebaAPI: TiebaAPIService {
         let usesLargeLikeCount = scenario == .largeLikeCount
         let usesVoicePlayback = scenario == .voicePlayback
         let threadPageOneRequestNumber: Int
-        if scenario == .refreshUpdate, page == 1 {
+        if [.refreshUpdate, .missingMainThenRecovery, .missingMain].contains(scenario),
+           page == 1 {
             threadPageOneRequestNumber = await state.nextThreadPageOneRequestNumber()
         } else {
             threadPageOneRequestNumber = 1
@@ -353,7 +356,11 @@ struct FixtureTiebaAPI: TiebaAPIService {
             replies = [reply]
         }
         let submittedPosts = await state.submittedPosts(threadID: threadID)
-        let posts = page == 1 ? [main] + replies + submittedPosts : []
+        let omitsMainPost = scenario == .missingMain
+            || scenario == .missingMainThenRecovery && threadPageOneRequestNumber == 1
+        let posts = page == 1
+            ? (omitsMainPost ? replies + submittedPosts : [main] + replies + submittedPosts)
+            : []
         var isCollected = false
         if let account {
             await seedCollectionIfNeeded(account: account)
@@ -362,7 +369,7 @@ struct FixtureTiebaAPI: TiebaAPIService {
         return ThreadPage(
             thread: thread,
             forum: Self.forum,
-            mainPost: main,
+            mainPost: omitsMainPost ? nil : main,
             posts: posts,
             currentPage: page,
             totalPage: 1,

--- a/TiebaPure/Core/Network/TiebaAPI.swift
+++ b/TiebaPure/Core/Network/TiebaAPI.swift
@@ -970,6 +970,7 @@ enum TiebaAPIError: Error, Equatable, CustomStringConvertible {
     case response(code: Int, message: String)
     case sessionExpired(code: Int, message: String)
     case emptyResponse
+    case missingMainPost
 
     private static let unambiguousSessionExpiredCodes: Set<Int> = [
         110001,
@@ -1014,6 +1015,8 @@ enum TiebaAPIError: Error, Equatable, CustomStringConvertible {
             return message.isEmpty ? "登录已失效（\(code)）" : message
         case .emptyResponse:
             return "服务器返回了空数据，请稍后重试。"
+        case .missingMainPost:
+            return "服务器未返回帖子主楼，请刷新后重试。"
         }
     }
 }

--- a/TiebaPure/Core/UI/ReaderSplitLayout.swift
+++ b/TiebaPure/Core/UI/ReaderSplitLayout.swift
@@ -12,19 +12,22 @@ struct ReaderSplitThreadRoute: Hashable {
     let initialPostID: UInt64?
     let initialDestination: ThreadDetailInitialDestination?
     let ownThreadDeletionTarget: OwnThreadDeletionTarget?
+    let mainPostFallback: ThreadMainPostFallback?
 
     init(
         threadID: Int64,
         forumID: Int64?,
         initialPostID: UInt64? = nil,
         initialDestination: ThreadDetailInitialDestination? = nil,
-        ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil
+        ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil,
+        mainPostFallback: ThreadMainPostFallback? = nil
     ) {
         self.threadID = threadID
         self.forumID = forumID
         self.initialPostID = initialPostID
         self.initialDestination = initialDestination
         self.ownThreadDeletionTarget = ownThreadDeletionTarget
+        self.mainPostFallback = mainPostFallback
     }
 }
 
@@ -150,7 +153,8 @@ struct ReaderSplitLayout<Route: Hashable, ListColumn: View, DetailRoot: View>: V
                             forumID: route.forumID,
                             initialPostID: route.initialPostID,
                             initialDestination: route.initialDestination,
-                            ownThreadDeletionTarget: route.ownThreadDeletionTarget
+                            ownThreadDeletionTarget: route.ownThreadDeletionTarget,
+                            mainPostFallback: route.mainPostFallback
                         )
                         // Replacing the selection must never reuse the
                         // previous thread's loaded state.

--- a/TiebaPure/Core/UI/ReaderStateView.swift
+++ b/TiebaPure/Core/UI/ReaderStateView.swift
@@ -252,6 +252,10 @@ enum ReaderErrorMessage {
             return "登录已失效，请重新登录。"
         }
 
+        if case .missingMainPost = error as? TiebaAPIError {
+            return "未能加载帖子主楼，请刷新后重试。"
+        }
+
         if let apiError = error as? TiebaAPIError,
            case let .response(_, message) = apiError,
            message.isEmpty == false {

--- a/TiebaPure/Domain/Filtering/TiebaContentFilter.swift
+++ b/TiebaPure/Domain/Filtering/TiebaContentFilter.swift
@@ -196,14 +196,20 @@ enum TiebaContentFilter {
         ) == false
     }
 
-    static func shouldKeep(post: Tieba_Post) -> Bool {
+    static func shouldMap(post: Tieba_Post) -> Bool {
         if post.hasAdvertisement { return false }
         if post.isFold != 0 { return false }
+        if post.content.contains(where: shouldKeep(content:)) { return true }
+        // A content-less floor with 楼中楼 still owns reachable text replies.
+        // Empty and invalid-voice-only floors otherwise have nothing to show.
+        return post.subPostNumber > 0
+            || post.subPostList.subPostList.isEmpty == false
+    }
+
+    static func shouldKeep(post: Tieba_Post) -> Bool {
+        guard shouldMap(post: post) else { return false }
         let blocklist = Self.blocklist
         if blocklist.isEmpty == false {
-            // Blocklist rejects run before the continuity keep-rules below:
-            // a floor kept only for its voice content or 楼中楼 still drops
-            // when its author is blocked or its text matches a keyword.
             if blocklist.blocksUser(
                 id: post.author.id > 0 ? post.author.id : post.authorID,
                 names: [post.author.nameShow, post.author.name]
@@ -212,11 +218,7 @@ enum TiebaContentFilter {
                 return false
             }
         }
-        if post.content.contains(where: shouldKeep(content:)) { return true }
-        // A content-less floor with 楼中楼 still owns reachable text replies.
-        // Empty and invalid-voice-only floors otherwise have nothing to show.
-        return post.subPostNumber > 0
-            || post.subPostList.subPostList.isEmpty == false
+        return true
     }
 
     static func shouldKeep(post: Post) -> Bool {
@@ -227,6 +229,12 @@ enum TiebaContentFilter {
             names: [post.author.displayName, post.author.name]
         ) { return false }
         return blocklist.containsKeyword(in: post.contentPreview) == false
+    }
+
+    /// A blocklist controls discovery and replies, but it must not remove the
+    /// structural first floor after the user has explicitly opened a thread.
+    static func shouldKeep(post: Post, asOpenedThreadMainPost isMainPost: Bool) -> Bool {
+        isMainPost || shouldKeep(post: post)
     }
 
     static func shouldKeep(subpost: Tieba_SubPostList) -> Bool {

--- a/TiebaPure/Domain/Mapping/PostMapper.swift
+++ b/TiebaPure/Domain/Mapping/PostMapper.swift
@@ -187,13 +187,22 @@ enum PostMapper {
 
         let forum = ForumMapper.fromProto(data.forum)
         let thread = ThreadMapper.fromThreadInfo(data.thread, usersByID: usersByID)
+        let rawMainPost = data.hasFirstFloorPost && data.firstFloorPost.id != 0
+            ? data.firstFloorPost
+            : data.postList.first {
+                $0.floor == 1
+                    && $0.id != 0
+            }
         let posts = data.postList
             .filter(TiebaContentFilter.shouldKeep(post:))
             .map { post(from: $0, usersByID: usersByID, threadID: data.thread.id) }
             .map { enrichIPIfNeeded($0, thread: thread) }
-        let mainPost = data.hasFirstFloorPost && data.firstFloorPost.id != 0
-            ? enrichIPIfNeeded(post(from: data.firstFloorPost, usersByID: usersByID, threadID: data.thread.id), thread: thread)
-            : posts.first { $0.floor == 1 }
+        let mainPost = rawMainPost.map {
+            enrichIPIfNeeded(
+                post(from: $0, usersByID: usersByID, threadID: data.thread.id),
+                thread: thread
+            )
+        }
 
         return ThreadPage(
             thread: thread,

--- a/TiebaPure/Domain/Models/Post.swift
+++ b/TiebaPure/Domain/Models/Post.swift
@@ -8,9 +8,102 @@ struct ThreadPage: Equatable, Sendable {
     var currentPage: Int
     var totalPage: Int
     var hasMore: Bool
+    /// The service omitted the complete first floor, so the main post shown
+    /// here comes from the already-visible list summary.
+    var mainPostIsSummaryFallback: Bool = false
     /// Whether the signed-in account has this thread collected, as reported by
     /// the thread page itself — the collection lives on the account only.
     var isCollected: Bool = false
+}
+
+struct ThreadMainPostFallback: Equatable, Hashable, Sendable {
+    let threadID: Int64
+    let postID: UInt64?
+    let author: UserSummary
+    let createdAt: Date?
+    let blocks: [ContentBlock]
+    let likeCount: Int
+    let isLiked: Bool
+
+    init?(thread: ThreadSummary) {
+        guard thread.blocks.isEmpty == false else { return nil }
+        threadID = thread.id
+        postID = thread.firstPostID
+        author = thread.author
+        createdAt = thread.createdAt
+        blocks = thread.blocks
+        likeCount = thread.likeCount
+        isLiked = thread.isLiked
+    }
+
+    func post(for requestedThreadID: Int64) -> Post? {
+        guard requestedThreadID == threadID, blocks.isEmpty == false else { return nil }
+        return Post(
+            id: postID ?? 0,
+            threadID: threadID,
+            floor: 1,
+            author: author,
+            ipAddress: author.ipAddress,
+            createdAt: createdAt,
+            blocks: blocks,
+            subpostCount: 0,
+            likeCount: likeCount,
+            isLiked: isLiked,
+            previewSubposts: []
+        )
+    }
+
+    func hash(into hasher: inout Hasher) {
+        // Route identity only needs stable source identity. Unequal summaries
+        // may share a hash; Equatable still compares their complete content.
+        hasher.combine(threadID)
+        hasher.combine(postID)
+        hasher.combine(author)
+        hasher.combine(createdAt)
+        hasher.combine(blocks.count)
+    }
+}
+
+enum ThreadPageMainPostPolicy {
+    static func mainPost(in page: ThreadPage) -> Post? {
+        page.mainPost ?? page.posts.first { $0.floor == 1 }
+    }
+
+    static func needsFirstPageRecovery(_ page: ThreadPage, requestedPage: Int) -> Bool {
+        requestedPage == 1
+            && mainPost(in: page) == nil
+    }
+
+    static func merging(
+        _ incoming: ThreadPage,
+        previousMainPost: Post?,
+        previousMainPostIsSummaryFallback: Bool = false,
+        requestedPage: Int
+    ) -> ThreadPage {
+        var merged = incoming
+        if let incomingMainPost = mainPost(in: incoming) {
+            merged.mainPost = incomingMainPost
+        } else if let previousMainPost {
+            // A refresh or pagination response must not erase a main post the
+            // reader has already displayed just because one response omits it.
+            merged.mainPost = previousMainPost
+            merged.mainPostIsSummaryFallback = previousMainPostIsSummaryFallback
+        }
+        return merged
+    }
+
+    static func applyingFallback(
+        _ fallback: ThreadMainPostFallback?,
+        to page: ThreadPage,
+        threadID: Int64
+    ) -> ThreadPage {
+        guard mainPost(in: page) == nil,
+              let fallbackPost = fallback?.post(for: threadID) else { return page }
+        var resolved = page
+        resolved.mainPost = fallbackPost
+        resolved.mainPostIsSummaryFallback = true
+        return resolved
+    }
 }
 
 enum ThreadReplySort: Int, CaseIterable, Identifiable, Sendable {

--- a/TiebaPure/Features/Home/HomeView.swift
+++ b/TiebaPure/Features/Home/HomeView.swift
@@ -113,6 +113,7 @@ struct HomeView: View {
                     initialPostID: threadRoute.initialPostID,
                     initialDestination: threadRoute.initialDestination,
                     ownThreadDeletionTarget: threadRoute.ownThreadDeletionTarget,
+                    mainPostFallback: threadRoute.mainPostFallback,
                     openUserInParent: { user in
                         openUser(user, sourceThreadID: threadRoute.threadID)
                     },
@@ -253,14 +254,14 @@ struct HomeView: View {
     }
 
     private func openThread(
-        threadID: Int64,
-        forumID: Int64?,
+        _ thread: ThreadSummary,
         initialDestination: ThreadDetailInitialDestination? = nil
     ) {
         let route = ReaderSplitThreadRoute(
-            threadID: threadID,
-            forumID: forumID,
-            initialDestination: initialDestination
+            threadID: thread.id,
+            forumID: thread.forumID,
+            initialDestination: initialDestination,
+            mainPostFallback: ThreadMainPostFallback(thread: thread)
         )
         if usesSplitDetailLayout {
             openThreadInSplitDetail(route)
@@ -351,7 +352,7 @@ struct HomeView: View {
                         thread: thread,
                         presentation: .homeFeed,
                         onOpenThread: {
-                            openThread(threadID: thread.id, forumID: thread.forumID)
+                            openThread(thread)
                         },
                         onOpenForum: { forum in
                             openForum(forum)
@@ -386,13 +387,12 @@ struct HomeView: View {
                                     )
                                 )
                             case .openThread:
-                                openThread(threadID: thread.id, forumID: thread.forumID)
+                                openThread(thread)
                             }
                         },
                         onOpenComments: {
                             openThread(
-                                threadID: thread.id,
-                                forumID: thread.forumID,
+                                thread,
                                 initialDestination: .replies
                             )
                         },

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -15,6 +15,7 @@ struct ThreadDetailView: View {
     let forumID: Int64?
     let initialPostID: UInt64?
     let initialDestination: ThreadDetailInitialDestination?
+    private let mainPostFallback: ThreadMainPostFallback?
     private let ownThreadDeletionTarget: OwnThreadDeletionTarget?
     private let onOwnThreadDeleted: ((Int64) -> Void)?
     private let onOwnThreadDeletionNeedsRefresh: (() -> Void)?
@@ -29,6 +30,7 @@ struct ThreadDetailView: View {
     @State private var isLoading = false
     @State private var didLoad = false
     @State private var didRecordBrowsingHistory = false
+    @State private var isMainPostBlocked = false
     @State private var errorMessage: String?
     @State private var seeLz = false
     @State private var sortType: ThreadReplySort = .hot
@@ -93,6 +95,7 @@ struct ThreadDetailView: View {
         initialPostID: UInt64? = nil,
         initialDestination: ThreadDetailInitialDestination? = nil,
         ownThreadDeletionTarget: OwnThreadDeletionTarget? = nil,
+        mainPostFallback: ThreadMainPostFallback? = nil,
         onOwnThreadDeleted: ((Int64) -> Void)? = nil,
         onOwnThreadDeletionNeedsRefresh: (() -> Void)? = nil,
         openSearchInParent: ((SearchScope) -> Void)? = nil,
@@ -104,6 +107,7 @@ struct ThreadDetailView: View {
         self.forumID = forumID
         self.initialPostID = initialPostID
         self.initialDestination = initialDestination
+        self.mainPostFallback = mainPostFallback
         self.ownThreadDeletionTarget = ownThreadDeletionTarget
         self.onOwnThreadDeleted = onOwnThreadDeleted
         self.onOwnThreadDeletionNeedsRefresh = onOwnThreadDeletionNeedsRefresh
@@ -353,6 +357,7 @@ struct ThreadDetailView: View {
         hasMore = true
         isLoading = false
         didLoad = false
+        isMainPostBlocked = false
         errorMessage = nil
         selectedSubpostPost = nil
         composerRoute = nil
@@ -384,10 +389,27 @@ struct ThreadDetailView: View {
     }
 
     private func applyCurrentBlocklist() {
-        posts = posts.compactMap(postApplyingCurrentBlocklist)
+        let currentMainPost = threadPage.flatMap(ThreadPageMainPostPolicy.mainPost(in:))
+            ?? posts.first { $0.floor == 1 }
+        isMainPostBlocked = currentMainPost.map {
+            TiebaContentFilter.shouldKeep(post: $0) == false
+        } ?? false
+        posts = posts.compactMap { post in
+            postApplyingCurrentBlocklist(
+                post,
+                isMainPost: post.id == currentMainPost?.id || post.floor == 1
+            )
+        }
         if var currentPage = threadPage {
-            currentPage.posts = currentPage.posts.compactMap(postApplyingCurrentBlocklist)
-            currentPage.mainPost = currentPage.mainPost.flatMap(postApplyingCurrentBlocklist)
+            currentPage.posts = currentPage.posts.compactMap { post in
+                postApplyingCurrentBlocklist(
+                    post,
+                    isMainPost: post.id == currentMainPost?.id || post.floor == 1
+                )
+            }
+            currentPage.mainPost = currentMainPost.flatMap {
+                postApplyingCurrentBlocklist($0, isMainPost: true)
+            }
             threadPage = currentPage
         }
         if let target = preciseScrollSession?.postID,
@@ -442,11 +464,18 @@ struct ThreadDetailView: View {
             ReaderStateView.loading(
                 isResumingReadingPosition ? "正在恢复上次阅读位置" : "正在加载帖子"
             )
-        } else if let errorMessage, posts.isEmpty {
+        } else if isMainPostBlocked {
+            ReaderStateScrollView(refresh: { await reload() }) {
+                ReaderStateView.empty(
+                    title: "帖子已被本机屏蔽",
+                    message: "主楼命中了当前的用户或关键词屏蔽规则。"
+                )
+            }
+        } else if let errorMessage, posts.isEmpty, mainPost == nil {
             ReaderStateScrollView(refresh: { await reload() }) {
                 ReaderStateView.error(message: errorMessage, action: requestReload)
             }
-        } else if posts.isEmpty {
+        } else if posts.isEmpty, mainPost == nil {
             ReaderStateScrollView(refresh: { await reload() }) {
                 ReaderStateView.empty(
                     title: "暂无内容",
@@ -477,28 +506,40 @@ struct ThreadDetailView: View {
     @ViewBuilder
     private var mainPostContent: some View {
         if let mainPost {
-            PostRowView(
-                post: mainPost,
-                threadTitle: threadPage?.thread.title,
-                threadAuthorID: threadAuthorID,
-                isMainPost: true,
-                onOpenSubposts: openSubpostsIfPossible,
-                onOpenUser: openUser,
-                isLikeUpdating: updatingPostLikeIDs.contains(mainPost.id),
-                onToggleLike: contentSubmissionSettingsStore.likesEnabled
-                    ? { toggleLike(for: mainPost, objectType: .thread) }
-                    : nil,
-                onReply: contentSubmissionSettingsStore.repliesEnabled
-                    ? { openReplyComposer(for: mainPost) }
-                    : nil
-            )
-            .equatable()
-            .padding(.bottom, TiebaPureTheme.Spacing.xs)
-            .threadPreciseScrollAnchor(
-                post: mainPost,
-                isEnabled: preciseScrollSession?.postID == mainPost.id
-            )
-            .id(mainPost.id)
+            VStack(spacing: 0) {
+                if threadPage?.mainPostIsSummaryFallback == true {
+                    Label("主楼完整内容暂不可用，以下为首页摘要。", systemImage: "info.circle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                        .padding(.vertical, TiebaPureTheme.Spacing.sm)
+                        .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+                        .accessibilityIdentifier("thread-main-summary-fallback-notice")
+                }
+                PostRowView(
+                    post: mainPost,
+                    threadTitle: threadPage?.thread.title,
+                    threadAuthorID: threadAuthorID,
+                    isMainPost: true,
+                    onOpenSubposts: openSubpostsIfPossible,
+                    onOpenUser: openUser,
+                    isLikeUpdating: updatingPostLikeIDs.contains(mainPost.id),
+                    onToggleLike: contentSubmissionSettingsStore.likesEnabled && mainPost.id > 0
+                        ? { toggleLike(for: mainPost, objectType: .thread) }
+                        : nil,
+                    onReply: contentSubmissionSettingsStore.repliesEnabled && mainPost.id > 0
+                        ? { openReplyComposer(for: mainPost) }
+                        : nil
+                )
+                .equatable()
+                .padding(.bottom, TiebaPureTheme.Spacing.xs)
+                .threadPreciseScrollAnchor(
+                    post: mainPost,
+                    isEnabled: preciseScrollSession?.postID == mainPost.id
+                )
+                .id(mainPost.id)
+            }
         }
     }
 
@@ -674,7 +715,7 @@ struct ThreadDetailView: View {
         Button(action: toggleCollection) {
             Image(systemName: isCollected ? "star.fill" : "star")
         }
-        .disabled(threadPage == nil || isUpdatingCollection)
+        .disabled(threadPage == nil || isUpdatingCollection || (mainPost?.id ?? 0) == 0)
         .accessibilityLabel(isCollected ? "取消收藏帖子" : "收藏帖子")
         .accessibilityValue(isCollected ? "已收藏" : "未收藏")
         .accessibilityHint(favoriteAccessibilityHint)
@@ -683,6 +724,9 @@ struct ThreadDetailView: View {
 
     private var favoriteAccessibilityHint: String {
         guard account != nil else { return "登录后可以收藏帖子" }
+        guard let mainPostID = mainPost?.id, mainPostID > 0 else {
+            return "主楼标识暂不可用，无法收藏"
+        }
         return isCollected ? "从贴吧账号的收藏中移除" : "收藏到贴吧账号"
     }
 
@@ -1688,6 +1732,8 @@ struct ThreadDetailView: View {
                       requestedSeeLz == seeLz,
                       requestedSort == sortType else { return }
             }
+            let previousMainPost = mainPost
+            let previousMainPostIsSummaryFallback = threadPage?.mainPostIsSummaryFallback ?? false
             let task = Task { try await environment.api.threadPage(
                 account: requestedAccount,
                 threadID: threadID,
@@ -1698,14 +1744,80 @@ struct ThreadDetailView: View {
                 sortType: requestedSort
             ) }
             loadTask = task
-            let loaded = try await task.value
+            var loaded = try await task.value
             guard generation == requestGeneration,
                   requestedSession == account?.sessionIdentity,
                   requestedSeeLz == seeLz,
                   requestedSort == sortType else { return }
-            var visiblePage = loaded
-            visiblePage.posts = loaded.posts.compactMap(postApplyingCurrentBlocklist)
-            visiblePage.mainPost = loaded.mainPost.flatMap(postApplyingCurrentBlocklist)
+            let availableMainPostFallback = mainPostFallback
+                ?? ThreadMainPostFallback(thread: loaded.thread)
+
+            if ThreadPageMainPostPolicy.needsFirstPageRecovery(
+                loaded,
+                requestedPage: requestedPage
+            ) {
+                do {
+                    let recoveryTask = Task { try await environment.api.threadPage(
+                        account: requestedAccount,
+                        threadID: threadID,
+                        page: 1,
+                        forumID: forumID,
+                        postID: nil,
+                        seeLz: false,
+                        sortType: .ascending
+                    ) }
+                    loadTask = recoveryTask
+                    let recoveryPage = try await recoveryTask.value
+                    guard generation == requestGeneration,
+                          requestedSession == account?.sessionIdentity,
+                          requestedSeeLz == seeLz,
+                          requestedSort == sortType else { return }
+                    if let recoveredMainPost = ThreadPageMainPostPolicy.mainPost(in: recoveryPage) {
+                        loaded.mainPost = recoveredMainPost
+                    }
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // The first request already loaded a valid thread and its
+                    // replies. If Home supplied a summary, a failed enrichment
+                    // request must not discard that deterministic fallback.
+                    guard availableMainPostFallback != nil else { throw error }
+                }
+            }
+
+            var mergedPage = ThreadPageMainPostPolicy.merging(
+                loaded,
+                previousMainPost: previousMainPost,
+                previousMainPostIsSummaryFallback: previousMainPostIsSummaryFallback,
+                requestedPage: requestedPage
+            )
+            if requestedPage == 1 {
+                mergedPage = ThreadPageMainPostPolicy.applyingFallback(
+                    availableMainPostFallback,
+                    to: mergedPage,
+                    threadID: threadID
+                )
+            }
+            if ThreadPageMainPostPolicy.needsFirstPageRecovery(
+                mergedPage,
+                requestedPage: requestedPage
+            ) {
+                throw TiebaAPIError.missingMainPost
+            }
+            let mergedMainPost = ThreadPageMainPostPolicy.mainPost(in: mergedPage)
+            isMainPostBlocked = mergedMainPost.map {
+                TiebaContentFilter.shouldKeep(post: $0) == false
+            } ?? false
+            var visiblePage = mergedPage
+            visiblePage.posts = mergedPage.posts.compactMap { post in
+                postApplyingCurrentBlocklist(
+                    post,
+                    isMainPost: post.id == mergedMainPost?.id || post.floor == 1
+                )
+            }
+            visiblePage.mainPost = mergedMainPost.flatMap {
+                postApplyingCurrentBlocklist($0, isMainPost: true)
+            }
             threadPage = visiblePage
             if requestedPage == 1 {
                 posts = visiblePage.posts
@@ -1894,8 +2006,14 @@ struct ThreadDetailView: View {
         post.likeCount = max(post.likeCount + (liked ? 1 : -1), 0)
     }
 
-    private func postApplyingCurrentBlocklist(_ candidate: Post) -> Post? {
-        guard TiebaContentFilter.shouldKeep(post: candidate) else { return nil }
+    private func postApplyingCurrentBlocklist(
+        _ candidate: Post,
+        isMainPost: Bool = false
+    ) -> Post? {
+        guard TiebaContentFilter.shouldKeep(
+            post: candidate,
+            asOpenedThreadMainPost: isMainPost
+        ) else { return nil }
         var filtered = candidate
         filtered.previewSubposts.removeAll {
             TiebaContentFilter.shouldKeep(subpost: $0) == false

--- a/TiebaPureTests/ContentFilterTests.swift
+++ b/TiebaPureTests/ContentFilterTests.swift
@@ -289,6 +289,19 @@ final class ContentFilterTests: XCTestCase {
         XCTAssertFalse(TiebaContentFilter.shouldKeep(post: ad))
     }
 
+    func testStructuralPostFilterKeepsBlocklistedFirstFloorForThreadDetail() {
+        TiebaContentFilter.updateBlocklist(BlocklistSnapshot(keywords: ["屏蔽主楼"]))
+        var post = Tieba_Post()
+        post.id = 1
+        post.floor = 1
+        var text = Tieba_PbContent()
+        text.text = "正文含屏蔽主楼"
+        post.content = [text]
+
+        XCTAssertTrue(TiebaContentFilter.shouldMap(post: post))
+        XCTAssertFalse(TiebaContentFilter.shouldKeep(post: post))
+    }
+
     func testBlocklistDropsPostsByAuthorEvenWhenKeptOnlyForSubposts() {
         TiebaContentFilter.updateBlocklist(BlocklistSnapshot(userIDs: [77]))
 
@@ -435,6 +448,87 @@ final class ContentFilterTests: XCTestCase {
         XCTAssertFalse(TiebaContentFilter.shouldKeep(post: post))
         XCTAssertFalse(TiebaContentFilter.shouldKeep(subpost: subpost))
         XCTAssertTrue(TiebaContentFilter.shouldKeep(user: cleanUser))
+    }
+
+    func testOpenedThreadMainPostIsStructuralEvenWhenItsBodyMatchesBlocklist() {
+        TiebaContentFilter.updateBlocklist(BlocklistSnapshot(keywords: ["剧透"]))
+        let post = Post(
+            id: 1,
+            threadID: 1,
+            floor: 1,
+            author: UserSummary(
+                id: 7,
+                name: "author",
+                displayName: "作者",
+                portrait: ""
+            ),
+            ipAddress: nil,
+            createdAt: nil,
+            blocks: [.text("主楼正文包含剧透")],
+            subpostCount: 0,
+            likeCount: 0,
+            previewSubposts: []
+        )
+
+        XCTAssertFalse(TiebaContentFilter.shouldKeep(post: post))
+        XCTAssertTrue(
+            TiebaContentFilter.shouldKeep(
+                post: post,
+                asOpenedThreadMainPost: true
+            )
+        )
+    }
+
+    func testThreadPageMapperRetainsBlockedFirstFloorAsStructuralMainPost() {
+        TiebaContentFilter.updateBlocklist(BlocklistSnapshot(keywords: ["隐藏主楼正文"]))
+
+        var author = Tieba_User()
+        author.id = 42
+        author.nameShow = "楼主"
+
+        var thread = Tieba_ThreadInfo()
+        thread.id = 123
+        thread.title = "摘要没有命中屏蔽词"
+        thread.author = author
+
+        var mainContent = Tieba_PbContent()
+        mainContent.type = 0
+        mainContent.text = "这段隐藏主楼正文只在完整内容中出现"
+
+        var firstFloor = Tieba_Post()
+        firstFloor.id = 11
+        firstFloor.tid = 123
+        firstFloor.floor = 1
+        firstFloor.author = author
+        firstFloor.content = [mainContent]
+
+        var replyContent = Tieba_PbContent()
+        replyContent.type = 0
+        replyContent.text = "普通回复"
+
+        var reply = Tieba_Post()
+        reply.id = 12
+        reply.tid = 123
+        reply.floor = 2
+        reply.author = author
+        reply.content = [replyContent]
+
+        var data = Tieba_PbPage_PbPageResponseData()
+        data.thread = thread
+        data.firstFloorPost = firstFloor
+        data.postList = [reply]
+        data.page.currentPage = 1
+        data.page.totalPage = 1
+
+        var response = Tieba_PbPage_PbPageResponse()
+        response.data = data
+
+        let page = PostMapper.threadPage(from: response)
+
+        XCTAssertEqual(page.mainPost?.id, 11)
+        XCTAssertEqual(page.mainPost?.contentPreview, mainContent.text)
+        XCTAssertEqual(page.posts.map(\.id), [12])
+        XCTAssertFalse(TiebaContentFilter.shouldKeep(post: firstFloor))
     }
 
     func testBlocklistFiltersMessagesByAuthorKeywordAndForum() {

--- a/TiebaPureTests/ThreadPageMainPostPolicyTests.swift
+++ b/TiebaPureTests/ThreadPageMainPostPolicyTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+@testable import TiebaPure
+
+final class ThreadPageMainPostPolicyTests: XCTestCase {
+    func testLaterPageKeepsAlreadyLoadedMainPost() {
+        let main = makePost(id: 100, floor: 1)
+        let reply = makePost(id: 201, floor: 16)
+        let page = makePage(mainPost: nil, posts: [reply], currentPage: 2)
+
+        let merged = ThreadPageMainPostPolicy.merging(
+            page,
+            previousMainPost: main,
+            requestedPage: 2
+        )
+
+        XCTAssertEqual(merged.mainPost, main)
+        XCTAssertEqual(merged.posts, [reply])
+    }
+
+    func testFirstPageRefreshKeepsAlreadyDisplayedMainPost() {
+        let main = makePost(id: 100, floor: 1)
+        let reply = makePost(id: 201, floor: 2)
+        let page = makePage(mainPost: nil, posts: [reply], currentPage: 1)
+
+        let merged = ThreadPageMainPostPolicy.merging(
+            page,
+            previousMainPost: main,
+            requestedPage: 1
+        )
+
+        XCTAssertEqual(merged.mainPost, main)
+    }
+
+    func testRefreshPreservesSummaryFallbackMarkerWithItsMainPost() {
+        let main = makePost(id: 100, floor: 1)
+        let page = makePage(
+            mainPost: nil,
+            posts: [makePost(id: 201, floor: 2)],
+            currentPage: 1
+        )
+
+        let merged = ThreadPageMainPostPolicy.merging(
+            page,
+            previousMainPost: main,
+            previousMainPostIsSummaryFallback: true,
+            requestedPage: 1
+        )
+
+        XCTAssertEqual(merged.mainPost, main)
+        XCTAssertTrue(merged.mainPostIsSummaryFallback)
+    }
+
+    func testReplyOnlyFirstPageRequiresRecovery() {
+        let reply = makePost(id: 201, floor: 2)
+        let page = makePage(mainPost: nil, posts: [reply], currentPage: 1)
+
+        XCTAssertTrue(
+            ThreadPageMainPostPolicy.needsFirstPageRecovery(page, requestedPage: 1)
+        )
+    }
+
+    func testFirstFloorInsidePostsResolvesWithoutRecovery() {
+        let main = makePost(id: 100, floor: 1)
+        let reply = makePost(id: 201, floor: 2)
+        let page = makePage(mainPost: nil, posts: [main, reply], currentPage: 1)
+
+        XCTAssertEqual(ThreadPageMainPostPolicy.mainPost(in: page), main)
+        XCTAssertFalse(
+            ThreadPageMainPostPolicy.needsFirstPageRecovery(page, requestedPage: 1)
+        )
+    }
+
+    func testEmptyFirstPageStillRequiresMainPostRecovery() {
+        let page = makePage(mainPost: nil, posts: [], currentPage: 1)
+
+        XCTAssertTrue(
+            ThreadPageMainPostPolicy.needsFirstPageRecovery(page, requestedPage: 1)
+        )
+    }
+
+    func testHomeSummaryFallbackResolvesReplyOnlyFirstPage() throws {
+        let reply = makePost(id: 201, floor: 2)
+        let page = makePage(mainPost: nil, posts: [reply], currentPage: 1)
+        let summary = ThreadSummary(
+            id: 1,
+            title: "主题",
+            author: makeUser(),
+            replyCount: 1,
+            viewCount: 10,
+            likeCount: 12,
+            firstPostID: 100,
+            blocks: [.text("首页已有的主楼摘要")]
+        )
+
+        let fallback = try XCTUnwrap(ThreadMainPostFallback(thread: summary))
+        let resolved = ThreadPageMainPostPolicy.applyingFallback(
+            fallback,
+            to: page,
+            threadID: 1
+        )
+
+        XCTAssertEqual(resolved.mainPost?.id, 100)
+        XCTAssertEqual(resolved.mainPost?.contentPreview, "首页已有的主楼摘要")
+        XCTAssertTrue(resolved.mainPostIsSummaryFallback)
+        XCTAssertFalse(
+            ThreadPageMainPostPolicy.needsFirstPageRecovery(resolved, requestedPage: 1)
+        )
+    }
+
+    func testFallbackCannotLeakIntoAnotherThread() throws {
+        let page = makePage(
+            mainPost: nil,
+            posts: [makePost(id: 201, floor: 2)],
+            currentPage: 1
+        )
+        let summary = ThreadSummary(
+            id: 99,
+            title: "其他主题",
+            author: makeUser(),
+            replyCount: 1,
+            viewCount: 10,
+            blocks: [.text("不应串入")]
+        )
+
+        let fallback = try XCTUnwrap(ThreadMainPostFallback(thread: summary))
+        let resolved = ThreadPageMainPostPolicy.applyingFallback(
+            fallback,
+            to: page,
+            threadID: 1
+        )
+
+        XCTAssertNil(resolved.mainPost)
+        XCTAssertFalse(resolved.mainPostIsSummaryFallback)
+    }
+
+    func testEmptyHomeSummaryDoesNotCreateFakeMainPost() {
+        let summary = ThreadSummary(
+            id: 1,
+            title: "空摘要",
+            author: makeUser(),
+            replyCount: 1,
+            viewCount: 10,
+            blocks: []
+        )
+
+        XCTAssertNil(ThreadMainPostFallback(thread: summary))
+    }
+
+    private func makePage(
+        mainPost: Post?,
+        posts: [Post],
+        currentPage: Int
+    ) -> ThreadPage {
+        ThreadPage(
+            thread: ThreadSummary(
+                id: 1,
+                title: "主题",
+                author: makeUser(),
+                replyCount: posts.count,
+                viewCount: 0,
+                blocks: []
+            ),
+            forum: Forum(
+                id: 1,
+                name: "测试",
+                displayName: "测试吧",
+                avatarURL: nil,
+                memberCount: 0,
+                threadCount: 0
+            ),
+            mainPost: mainPost,
+            posts: posts,
+            currentPage: currentPage,
+            totalPage: 2,
+            hasMore: currentPage < 2
+        )
+    }
+
+    private func makePost(id: UInt64, floor: Int) -> Post {
+        Post(
+            id: id,
+            threadID: 1,
+            floor: floor,
+            author: makeUser(),
+            ipAddress: nil,
+            createdAt: nil,
+            blocks: [.text("第\(floor)楼")],
+            subpostCount: 0,
+            likeCount: 0,
+            previewSubposts: []
+        )
+    }
+
+    private func makeUser() -> UserSummary {
+        UserSummary(id: 1, name: "author", displayName: "作者", portrait: "")
+    }
+}

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -49,6 +49,51 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
+    func testThreadMainPostBlocklistShowsExplicitBlockedStateInsteadOfReplies() {
+        let app = launchApp(
+            additionalArguments: ["UITEST_SEED_MAIN_POST_BLOCKLIST"]
+        )
+
+        openFirstThread(in: app)
+
+        XCTAssertTrue(
+            app.staticTexts["帖子已被本机屏蔽"].waitForExistence(timeout: 8)
+        )
+        XCTAssertFalse(app.buttons["thread-main-user-button"].exists)
+        XCTAssertFalse(app.descendants(matching: .any)["thread-reply-metadata"].exists)
+    }
+
+    func testThreadRecoversMainPostBeforeShowingReplies() {
+        let app = launchApp(scenario: "missingMainThenRecovery")
+
+        openFirstThread(in: app)
+
+        XCTAssertTrue(app.buttons["thread-main-user-button"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["thread-reply-metadata"].exists)
+        XCTAssertFalse(app.staticTexts["未能加载帖子主楼，请刷新后重试。"].exists)
+    }
+
+    func testThreadUsesExplicitHomeSummaryWhenFullMainPostRecoveryFails() {
+        let app = launchApp(scenario: "missingMain")
+
+        openFirstThread(in: app)
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["thread-main-summary-fallback-notice"]
+                .waitForExistence(timeout: 8)
+        )
+        XCTAssertTrue(app.buttons["thread-main-user-button"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["thread-main-text"].exists)
+        let threadScrollView = app.scrollViews.firstMatch
+        XCTAssertTrue(threadScrollView.waitForExistence(timeout: 5))
+        threadScrollView.swipeUp()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["thread-reply-metadata"]
+                .waitForExistence(timeout: 5)
+        )
+        XCTAssertFalse(app.staticTexts["未能加载帖子主楼，请刷新后重试。"].exists)
+    }
+
     func testVoiceSummaryRequiresDetailAndPlaybackStatesRemainAccessible() {
         let app = launchApp(scenario: "voicePlayback")
         let successIdentifier = "voice-playback-\(String(repeating: "a", count: 32))"

--- a/project.yml
+++ b/project.yml
@@ -36,8 +36,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.infinityf4p.tiebapure
         INFOPLIST_FILE: TiebaPure/Resources/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: 1.4.11
-        CURRENT_PROJECT_VERSION: 55
+        MARKETING_VERSION: 1.4.12
+        CURRENT_PROJECT_VERSION: 56
   TiebaPureOpenIn:
     type: app-extension
     platform: iOS
@@ -56,8 +56,8 @@ targets:
         INFOPLIST_FILE: TiebaPureOpenIn/Info.plist
         APPLICATION_EXTENSION_API_ONLY: YES
         SKIP_INSTALL: YES
-        MARKETING_VERSION: 1.4.11
-        CURRENT_PROJECT_VERSION: 55
+        MARKETING_VERSION: 1.4.12
+        CURRENT_PROJECT_VERSION: 56
   TiebaPureTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 修改内容

- 当帖子接口第一页遗漏主楼时，以正序第一页补取主楼；刷新和分页响应不再清除已显示的主楼。
- 补取仍失败时，从首页进入的帖子会显示带明确说明的首页摘要；没有可靠摘要时显示主楼加载错误，不再直接展示评论。
- 修复屏蔽规则命中主楼后只剩评论的问题，改为显示明确的本机屏蔽状态。
- 版本更新至 1.4.12 (56)。

## 验证

- 随机首页真实 UI 进入帖子 100 次，覆盖 53 个不同帖子并每 20 次冷启动：100/100 显示完整主楼，0 次仅显示评论。
- 随机首页接口请求 120 次：105 次成功响应全部满足主楼约束；15 次为贴吧 HTTP 429。
- 主楼策略与屏蔽规则单元测试：37/37。
- 主楼补取、摘要兜底和屏蔽状态 UI 测试：3/3。

Closes #47