### PR TITLE
修复查看全部回复的进入动画

### DIFF
--- a/TiebaPure/Core/UI/InteractiveNavigationPop.swift
+++ b/TiebaPure/Core/UI/InteractiveNavigationPop.swift
@@ -61,24 +61,25 @@ private enum NavigationPopGestureDiagnostics {
 extension View {
     /// Keeps navigation system-owned while allowing a short, explicit critical
     /// section (such as a dispatched destructive write) to suspend both native
-    /// pop recognizers. The original enabled state is restored afterwards.
-    @ViewBuilder
+    /// pop recognizers. Keep the modifier's outer identity stable while this
+    /// flag changes: replacing the view that owns a system sheet interrupts its
+    /// presentation transition. The original enabled state is restored
+    /// afterwards.
     func fullScreenInteractiveNavigationPop(isEnabled: Bool = true) -> some View {
-        if NavigationPopGestureControlHostingPolicy.requiresController(
+        let hostsController = NavigationPopGestureControlHostingPolicy.requiresController(
             systemMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
             isEnabled: isEnabled
-        ) {
-            let exposesDiagnostics = NavigationPopGestureDiagnostics.isEnabled
-            background(
+        )
+        let exposesDiagnostics = NavigationPopGestureDiagnostics.isEnabled
+        return background {
+            if hostsController {
                 NativeNavigationPopGestureControl(isEnabled: isEnabled)
                     .frame(
                         width: exposesDiagnostics ? 1 : 0,
                         height: exposesDiagnostics ? 1 : 0
                     )
                     .accessibilityHidden(exposesDiagnostics == false)
-            )
-        } else {
-            self
+            }
         }
     }
 

--- a/TiebaPureTests/NavigationSourceLifecycleTests.swift
+++ b/TiebaPureTests/NavigationSourceLifecycleTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import SwiftUI
+import UIKit
 @testable import TiebaPure
 
 final class NavigationSourceLifecycleTests: XCTestCase {
@@ -48,6 +50,49 @@ final class NavigationSourceLifecycleTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testGestureControlStateChangeKeepsPresentedContentIdentity() async throws {
+        guard ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 else {
+            throw XCTSkip("iOS 26 才会在启用状态省略手势控制器")
+        }
+
+        let probe = NavigationGestureContentIdentityProbe()
+        let host = UIHostingController(
+            rootView: NavigationGestureContentIdentityHost(
+                isEnabled: true,
+                probe: probe
+            )
+        )
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        await waitForRenderCycle()
+
+        XCTAssertEqual(probe.makeCount, 1)
+        XCTAssertEqual(probe.dismantleCount, 0)
+
+        host.rootView = NavigationGestureContentIdentityHost(
+            isEnabled: false,
+            probe: probe
+        )
+        await waitForRenderCycle()
+
+        XCTAssertEqual(
+            probe.makeCount,
+            1,
+            "挂载手势控制器不能重建承载系统 sheet 的页面内容"
+        )
+        XCTAssertEqual(probe.dismantleCount, 0)
+
+        window.isHidden = true
+    }
+
+    @MainActor
+    private func waitForRenderCycle() async {
+        await Task.yield()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+
     func testMeHistoryThreadUserPathReturnsOneLevelAtATime() {
         let thread = ReaderSplitThreadRoute(threadID: 101, forumID: 7)
         let user = UserSummary(
@@ -81,5 +126,51 @@ final class NavigationSourceLifecycleTests: XCTestCase {
         path = MeNavigationPathPolicy.removingCurrent(.thread(thread), from: path)
 
         XCTAssertEqual(path, [.followedUsers, userRoute])
+    }
+}
+
+@MainActor
+private final class NavigationGestureContentIdentityProbe {
+    var makeCount = 0
+    var dismantleCount = 0
+}
+
+private struct NavigationGestureContentIdentityHost: View {
+    let isEnabled: Bool
+    let probe: NavigationGestureContentIdentityProbe
+
+    var body: some View {
+        NavigationGestureContentIdentityRepresentable(probe: probe)
+            .fullScreenInteractiveNavigationPop(isEnabled: isEnabled)
+    }
+}
+
+private struct NavigationGestureContentIdentityRepresentable: UIViewRepresentable {
+    let probe: NavigationGestureContentIdentityProbe
+
+    func makeUIView(context: Context) -> UIView {
+        probe.makeCount += 1
+        return NavigationGestureProbeView(probe: probe)
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: ()) {
+        (uiView as? NavigationGestureProbeView)?.probe.dismantleCount += 1
+    }
+}
+
+@MainActor
+private final class NavigationGestureProbeView: UIView {
+    let probe: NavigationGestureContentIdentityProbe
+
+    init(probe: NavigationGestureContentIdentityProbe) {
+        self.probe = probe
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -3777,7 +3777,10 @@ final class TiebaPureUITests: XCTestCase {
     }
 
     func testSubpostRightSwipeDismissesTheWholeSheet() {
-        let app = launchApp(scenario: "subpostReference")
+        let app = launchApp(
+            scenario: "subpostReference",
+            disableAnimations: false
+        )
         openFirstThread(in: app)
 
         XCTAssertTrue(waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 20))
@@ -3786,6 +3789,10 @@ final class TiebaPureUITests: XCTestCase {
         openAllButton.tap()
         let navigationBar = app.navigationBars["2楼的回复(4条)"]
         XCTAssertTrue(navigationBar.waitForExistence(timeout: 8))
+        XCTAssertTrue(
+            app.buttons["更多"].waitForExistence(timeout: 3),
+            "楼中楼呈现不能重建帖子页或破坏其导航状态"
+        )
         let sheetSurface = app.descendants(matching: .any)["subpost-sheet-surface"]
         XCTAssertTrue(sheetSurface.waitForExistence(timeout: 5))
         XCTAssertEqual(


### PR DESCRIPTION
## 修改内容

- 保持导航返回手势修饰器的外层视图身份稳定，避免打开楼中楼时重建承载系统 sheet 的帖子页
- 恢复“查看全部回复”的系统进入动画，同时保留 iOS 26 原生返回手势和旧系统边缘返回逻辑
- 增加视图身份回归测试，并让楼中楼 UI 用例在动画启用状态下连续验证 4 轮打开与退出

## 验证

- NavigationSourceLifecycleTests：6/6
- 楼中楼打开/右划退出与帖子页系统返回 UI 测试：2/2
- 旧实现 A/B：新增身份测试稳定失败；修复后通过