### PR TITLE
修复图片、倒序回复与楼中楼交互

### DIFF
--- a/TiebaPure/Core/UI/AvatarView.swift
+++ b/TiebaPure/Core/UI/AvatarView.swift
@@ -119,6 +119,27 @@ enum TiebaImageDecodePolicy {
     }
 }
 
+enum TiebaAnimatedImageDecodePolicy {
+    static let maximumFrameCount = 120
+    static let maximumDecodedPixels = 24_000_000
+    static let defaultFrameDuration = 0.1
+    static let minimumFrameDuration = 0.02
+    static let maximumFrameDuration = 10.0
+
+    static func frameDuration(properties: [CFString: Any]) -> TimeInterval {
+        guard let gifProperties = properties[kCGImagePropertyGIFDictionary]
+                as? [CFString: Any] else {
+            return defaultFrameDuration
+        }
+        let rawDuration = (gifProperties[kCGImagePropertyGIFUnclampedDelayTime]
+            as? NSNumber)?.doubleValue
+            ?? (gifProperties[kCGImagePropertyGIFDelayTime] as? NSNumber)?.doubleValue
+            ?? defaultFrameDuration
+        guard rawDuration.isFinite else { return defaultFrameDuration }
+        return min(max(rawDuration, minimumFrameDuration), maximumFrameDuration)
+    }
+}
+
 private enum TiebaImagePipelineError: Error {
     case invalidURL
     case invalidResponse
@@ -289,7 +310,7 @@ actor TiebaImagePipeline {
                 ))
             }
             let image = Self.syntheticFixtureImage(for: url)
-            let cost = Int(image.size.width * image.size.height * image.scale * image.scale * 4)
+            let cost = Self.decodedImageCost(image)
             memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
             return image
         }
@@ -301,7 +322,7 @@ actor TiebaImagePipeline {
                 onProgress: onProgress
             )
             try Task.checkCancellation()
-            let cost = Int(image.size.width * image.size.height * image.scale * image.scale * 4)
+            let cost = Self.decodedImageCost(image)
             memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
             return image
         }
@@ -405,7 +426,7 @@ actor TiebaImagePipeline {
 
         switch result {
         case let .success(image):
-            let cost = Int(image.size.width * image.size.height * image.scale * image.scale * 4)
+            let cost = Self.decodedImageCost(image)
             memoryCache.setObject(image, forKey: request.cacheKey, cost: cost)
             requestState.waiters.values.forEach { $0.resume(returning: image) }
         case let .failure(error):
@@ -471,7 +492,9 @@ actor TiebaImagePipeline {
 
 #if DEBUG
     private static func syntheticFixtureImage(for url: URL) -> UIImage {
-        let size = CGSize(width: 120, height: 480)
+        let size = url.lastPathComponent.contains("lowres-thumbnail")
+            ? CGSize(width: 80, height: 320)
+            : CGSize(width: 320, height: 1_280)
         // Thumbnail/original fixture URLs represent the same underlying
         // picture. Seeding them independently made the hero animation morph
         // between unrelated colors and could either mimic or conceal a real
@@ -513,13 +536,19 @@ actor TiebaImagePipeline {
     }
 #endif
 
-    private static func decodedImage(from data: Data, targetPixelSize: Int) -> UIImage? {
+    static func decodedImage(from data: Data, targetPixelSize: Int) -> UIImage? {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil),
               let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
               let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
               let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
               TiebaImageDecodePolicy.allows(width: width, height: height) else {
             return nil
+        }
+        if let animatedImage = decodedAnimatedImage(
+            source: source,
+            targetPixelSize: targetPixelSize
+        ) {
+            return animatedImage
         }
         let options: [CFString: Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
@@ -529,6 +558,96 @@ actor TiebaImagePipeline {
         ]
         guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else { return nil }
         return UIImage(cgImage: image)
+    }
+
+    static func decodedImageCost(_ image: UIImage) -> Int {
+        let frames = image.images ?? [image]
+        return frames.reduce(into: 0) { total, frame in
+            let width = frame.cgImage?.width ?? Int(frame.size.width * frame.scale)
+            let height = frame.cgImage?.height ?? Int(frame.size.height * frame.scale)
+            let (pixels, pixelOverflow) = width.multipliedReportingOverflow(by: height)
+            let (bytes, byteOverflow) = pixels.multipliedReportingOverflow(by: 4)
+            guard pixelOverflow == false, byteOverflow == false,
+                  total <= Int.max - bytes else {
+                total = Int.max
+                return
+            }
+            total += bytes
+        }
+    }
+
+    private static func decodedAnimatedImage(
+        source: CGImageSource,
+        targetPixelSize: Int
+    ) -> UIImage? {
+        let frameCount = CGImageSourceGetCount(source)
+        guard frameCount > 1,
+              frameCount <= TiebaAnimatedImageDecodePolicy.maximumFrameCount else {
+            return nil
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: TiebaImageDecodePolicy.decodeTargetPixelSize(
+                targetPixelSize
+            ),
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+        var frames: [UIImage] = []
+        frames.reserveCapacity(frameCount)
+        var duration: TimeInterval = 0
+        var decodedPixels = 0
+
+        for index in 0..<frameCount {
+            guard let properties = CGImageSourceCopyPropertiesAtIndex(
+                source,
+                index,
+                nil
+            ) as? [CFString: Any],
+                  let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+                  let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+                  TiebaImageDecodePolicy.allows(width: width, height: height),
+                  let cgImage = CGImageSourceCreateThumbnailAtIndex(
+                    source,
+                    index,
+                    options as CFDictionary
+                  ) else {
+                return nil
+            }
+            let (framePixels, overflow) = cgImage.width.multipliedReportingOverflow(
+                by: cgImage.height
+            )
+            guard overflow == false,
+                  framePixels <= TiebaAnimatedImageDecodePolicy.maximumDecodedPixels - decodedPixels else {
+                return nil
+            }
+            decodedPixels += framePixels
+            duration += TiebaAnimatedImageDecodePolicy.frameDuration(properties: properties)
+            frames.append(UIImage(cgImage: cgImage))
+        }
+        return UIImage.animatedImage(with: frames, duration: duration)
+    }
+}
+
+private struct TiebaAnimatedUIImageView: UIViewRepresentable {
+    let image: UIImage
+    let contentMode: ContentMode
+
+    func makeUIView(context: Context) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.clipsToBounds = true
+        return imageView
+    }
+
+    func updateUIView(_ imageView: UIImageView, context: Context) {
+        imageView.contentMode = contentMode == .fill ? .scaleAspectFill : .scaleAspectFit
+        imageView.image = image
+        imageView.startAnimating()
+    }
+
+    static func dismantleUIView(_ imageView: UIImageView, coordinator: Void) {
+        imageView.stopAnimating()
+        imageView.image = nil
     }
 }
 
@@ -728,9 +847,18 @@ struct TiebaRemoteImage: View {
             case let .success(image):
                 if model.represents(urls: urls, targetPixelSize: targetPixelSize) {
                     if showsResolvedImage {
-                        Image(uiImage: image)
-                            .resizable()
-                            .aspectRatio(contentMode: contentMode)
+                        Group {
+                            if image.images?.isEmpty == false {
+                                TiebaAnimatedUIImageView(
+                                    image: image,
+                                    contentMode: contentMode
+                                )
+                            } else {
+                                Image(uiImage: image)
+                                    .resizable()
+                                    .aspectRatio(contentMode: contentMode)
+                            }
+                        }
                             .background {
                                 if onImageLayoutResolved != nil || activeDebugImageObserver != nil {
                                     TiebaResolvedImageFrameReader(

--- a/TiebaPure/Domain/Models/Post.swift
+++ b/TiebaPure/Domain/Models/Post.swift
@@ -125,6 +125,25 @@ enum ThreadReplySort: Int, CaseIterable, Identifiable, Sendable {
     }
 }
 
+enum ThreadDescendingPaginationPolicy {
+    static func serverPage(logicalPage: Int, totalPage: Int) -> Int {
+        guard totalPage > 0 else { return 1 }
+        return max(totalPage - max(logicalPage, 1) + 1, 1)
+    }
+
+    static func normalized(_ page: ThreadPage, logicalPage: Int) -> ThreadPage {
+        var result = page
+        result.posts = displayOrder(page.posts)
+        result.currentPage = max(logicalPage, 1)
+        result.hasMore = result.currentPage < max(result.totalPage, 1)
+        return result
+    }
+
+    static func displayOrder<Element>(_ elements: [Element]) -> [Element] {
+        Array(elements.reversed())
+    }
+}
+
 struct Post: Identifiable, Equatable, Sendable {
     var id: UInt64
     var threadID: Int64

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -2411,10 +2411,9 @@ enum FullScreenImageSourcePolicy {
         )
     }
 
-    /// Automatic full-screen image-body loading stays on the preview tier. A
-    /// distinct original image body is reserved for the explicit original and
-    /// download actions; the visible page may still issue a body-free HEAD
-    /// request so the control can display its file size.
+    /// The initial full-screen request stays on the preview tier. After that
+    /// request resolves, the visible page may upgrade an objectively undersized
+    /// preview; adjacent pages never touch their original URLs speculatively.
     static func automaticPreviewURLs(
         primary: URL?,
         fallback: URL?,
@@ -2574,6 +2573,34 @@ enum FullScreenImageDecodePolicy {
     }
 }
 
+enum FullScreenImageResolutionUpgradePolicy {
+    static let minimumPreviewTargetFraction: CGFloat = 0.8
+
+    static func shouldUpgrade(
+        previewPixelSize: CGSize,
+        targetPixelSize: Int,
+        pageIndex: Int,
+        currentIndex: Int,
+        didFinishPresentation: Bool,
+        previewURL: URL?,
+        originalURL: URL?,
+        originalState: FullScreenOriginalImageLoadState
+    ) -> Bool {
+        guard didFinishPresentation,
+              pageIndex == currentIndex,
+              originalState == .available,
+              let previewURL,
+              let originalURL,
+              previewURL != originalURL,
+              targetPixelSize > 0 else {
+            return false
+        }
+        let longestEdge = max(previewPixelSize.width, previewPixelSize.height)
+        guard longestEdge.isFinite, longestEdge > 0 else { return true }
+        return longestEdge < CGFloat(targetPixelSize) * minimumPreviewTargetFraction
+    }
+}
+
 enum FullScreenImagePlaceholderPolicy {
     static func canReuseAsPreview(
         placeholderSize: CGSize?,
@@ -2696,6 +2723,7 @@ private final class FullScreenZoomImageController: UIViewController,
     private var presentationCancellable: AnyCancellable?
     private var currentIndexCancellable: AnyCancellable?
     private var didRevealResolvedImage = false
+    private var didResolveAutomaticPreview = false
     private var lastReportedZoomed = false
     private var lastAccessibilityPercentage = 100
     private var zoomGestureStartTime: CFTimeInterval?
@@ -3150,6 +3178,7 @@ private final class FullScreenZoomImageController: UIViewController,
         }
         startOriginalMetadataLoadingIfEligible()
         startLoading()
+        startAutomaticResolutionUpgradeIfNeeded()
     }
 
     private func updatePageResidency() {
@@ -3183,6 +3212,7 @@ private final class FullScreenZoomImageController: UIViewController,
 
         resolvedImage = nil
         transitionImage = nil
+        didResolveAutomaticPreview = false
         resolvedImageView.image = nil
         didRevealResolvedImage = false
         resolvedImageView.alpha = 0
@@ -3229,7 +3259,7 @@ private final class FullScreenZoomImageController: UIViewController,
     }
 
     private func startLoading(force: Bool = false) {
-        if force == false, resolvedImage != nil || loadTask != nil { return }
+        if force == false, didResolveAutomaticPreview || loadTask != nil { return }
         loadTask?.cancel()
         retryButton.isHidden = true
         if placeholderImage == nil {
@@ -3256,6 +3286,7 @@ private final class FullScreenZoomImageController: UIViewController,
                     return
                 }
                 let loadedAfterPresentation = self.transitionState.didFinishPresentation
+                self.didResolveAutomaticPreview = true
                 self.resolvedImage = image
                 self.transitionImage = image
                 // Committing a full-screen bitmap to the layer tree mid-hero
@@ -3273,6 +3304,7 @@ private final class FullScreenZoomImageController: UIViewController,
                     )
                 )
                 self.reportResolvedImageLayoutIfPossible()
+                self.startAutomaticResolutionUpgradeIfNeeded()
             } catch is CancellationError {
                 return
             } catch {
@@ -3351,6 +3383,25 @@ private final class FullScreenZoomImageController: UIViewController,
                 }
             }
         }
+    }
+
+    private func startAutomaticResolutionUpgradeIfNeeded() {
+        guard didResolveAutomaticPreview, let image = resolvedImage else { return }
+        let pixelSize = CGSize(
+            width: image.cgImage.map { CGFloat($0.width) } ?? image.size.width * image.scale,
+            height: image.cgImage.map { CGFloat($0.height) } ?? image.size.height * image.scale
+        )
+        guard FullScreenImageResolutionUpgradePolicy.shouldUpgrade(
+            previewPixelSize: pixelSize,
+            targetPixelSize: FullScreenImageDecodePolicy.initialTargetPixelSize,
+            pageIndex: imageIndex,
+            currentIndex: transitionState.currentIndex,
+            didFinishPresentation: transitionState.didFinishPresentation,
+            previewURL: primaryURL,
+            originalURL: originalURL,
+            originalState: originalLoadState
+        ) else { return }
+        startOriginalImageLoading()
     }
 
     private func receiveOriginalLoadProgress(_ progress: BoundedURLSessionProgress) {
@@ -4275,13 +4326,20 @@ struct ImageViewerUITestHost: View {
     )
     @State private var didPresent = false
 
-    private let fixtureImage = ImageContent(
-        thumbnailURL: URL(string: "https://fixture-success.invalid/viewer-thumbnail.png"),
-        originalURL: URL(string: "https://fixture-success.invalid/viewer-original.png"),
-        width: 120,
-        height: 480,
-        showOriginalButton: true
-    )
+    private var fixtureImage: ImageContent {
+        let usesLowResolutionPreview = ProcessInfo.processInfo.arguments.contains(
+            "UITEST_IMAGE_VIEWER_LOW_RESOLUTION_PREVIEW"
+        )
+        return ImageContent(
+            thumbnailURL: URL(string: usesLowResolutionPreview
+                ? "https://fixture-success.invalid/viewer-lowres-thumbnail.png"
+                : "https://fixture-success.invalid/viewer-thumbnail.png"),
+            originalURL: URL(string: "https://fixture-success.invalid/viewer-original.png"),
+            width: 120,
+            height: 480,
+            showOriginalButton: true
+        )
+    }
     private let secondFixtureImage = ImageContent(
         thumbnailURL: URL(string: "https://fixture-success.invalid/viewer-second-thumbnail.png"),
         originalURL: URL(string: "https://fixture-success.invalid/viewer-second-original.png"),

--- a/TiebaPure/Features/Thread/SubpostSheetInteractiveDismiss.swift
+++ b/TiebaPure/Features/Thread/SubpostSheetInteractiveDismiss.swift
@@ -8,6 +8,23 @@ enum SubpostSheetDismissPhase: String, Equatable {
     case dismissing
 }
 
+enum SubpostSheetDismissAxis: Equatable {
+    case rightSwipe
+    case pullDown
+}
+
+enum SubpostSheetScrollCoordinateSpace {
+    static let name = "subpost-sheet-scroll"
+}
+
+struct SubpostSheetScrollTopPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat?
+
+    static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+        value = nextValue() ?? value
+    }
+}
+
 private enum SubpostLegacyAnimationCompletion {
     case dismiss
     case restore
@@ -57,6 +74,47 @@ private extension EnvironmentValues {
     }
 }
 
+private struct SubpostSheetLegacyScrollTelemetryAction {
+    let onSnapshot: (LegacyScrollTelemetrySnapshot) -> Void
+    let onPanChange: (LegacyScrollPanEvent) -> Void
+}
+
+private struct SubpostSheetLegacyScrollTelemetryActionKey: EnvironmentKey {
+    static let defaultValue = SubpostSheetLegacyScrollTelemetryAction(
+        onSnapshot: { _ in },
+        onPanChange: { _ in }
+    )
+}
+
+private extension EnvironmentValues {
+    var subpostSheetLegacyScrollTelemetryAction: SubpostSheetLegacyScrollTelemetryAction {
+        get { self[SubpostSheetLegacyScrollTelemetryActionKey.self] }
+        set { self[SubpostSheetLegacyScrollTelemetryActionKey.self] = newValue }
+    }
+}
+
+private struct SubpostSheetLegacyScrollTelemetryModifier: ViewModifier {
+    @Environment(\.subpostSheetLegacyScrollTelemetryAction) private var action
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+        } else {
+            content.legacyScrollTelemetry(
+                onPanChange: action.onPanChange,
+                action.onSnapshot
+            )
+        }
+    }
+}
+
+extension View {
+    func subpostSheetLegacyScrollTelemetry() -> some View {
+        modifier(SubpostSheetLegacyScrollTelemetryModifier())
+    }
+}
+
 struct SubpostSheetDismissButton: View {
     @Environment(\.subpostSheetDismissAction) private var dismissAction
 
@@ -85,6 +143,11 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
     @State private var phase = SubpostSheetDismissPhase.idle
     @State private var verticalOffset: CGFloat = 0
     @State private var rejectedCurrentGesture = false
+    @State private var activeDismissAxis: SubpostSheetDismissAxis?
+    @State private var isContentAtTop = false
+    @State private var contentTopBaseline: CGFloat?
+    @State private var legacyPullDownStartedAtTop = false
+    @State private var legacyPullDownRejected = false
     @State private var legacyAnimationGeneration: UInt = 0
     @State private var legacyAnimationTarget: CGFloat?
     @State private var legacyAnimationCompletion: SubpostLegacyAnimationCompletion?
@@ -133,6 +196,18 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
                         finishDismissal(containerHeight: containerSize.height)
                     }
                 )
+                .environment(
+                    \.subpostSheetLegacyScrollTelemetryAction,
+                    SubpostSheetLegacyScrollTelemetryAction(
+                        onSnapshot: handleLegacyScrollSnapshot,
+                        onPanChange: { event in
+                            handleLegacyScrollPan(
+                                event,
+                                containerSize: containerSize
+                            )
+                        }
+                    )
+                )
                 .simultaneousGesture(
                     dismissGesture(containerSize: containerSize),
                     isEnabled: isEnabled && phase != .dismissing
@@ -174,6 +249,12 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
         .compatibleOnChange(of: isEnabled) { _, enabled in
             guard enabled == false, phase == .tracking else { return }
             restore()
+        }
+        .onPreferenceChange(SubpostSheetScrollTopPreferenceKey.self) { contentTop in
+            guard let contentTop, contentTop.isFinite else { return }
+            let baseline = max(contentTopBaseline ?? contentTop, contentTop)
+            contentTopBaseline = baseline
+            isContentAtTop = contentTop >= baseline - 1
         }
         .compatibleOnChange(of: scenePhase) { _, newPhase in
             guard newPhase != .active else { return }
@@ -238,9 +319,14 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
         }
 
         if phase == .idle {
-            guard SubpostRightSwipeDismissPolicy.shouldBegin(
-                translation: translation
-            ) else {
+            if SubpostRightSwipeDismissPolicy.shouldBegin(translation: translation) {
+                activeDismissAxis = .rightSwipe
+            } else if SubpostPullDownDismissPolicy.shouldBegin(
+                translation: translation,
+                isContentAtTop: isContentAtTop
+            ) {
+                activeDismissAxis = .pullDown
+            } else {
                 rejectedCurrentGesture = true
                 return
             }
@@ -248,10 +334,20 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
         }
 
         guard phase == .tracking else { return }
-        verticalOffset = SubpostRightSwipeDismissPolicy.verticalOffset(
-            translationX: translation.width,
-            containerHeight: containerHeight
-        )
+        switch activeDismissAxis {
+        case .rightSwipe:
+            verticalOffset = SubpostRightSwipeDismissPolicy.verticalOffset(
+                translationX: translation.width,
+                containerHeight: containerHeight
+            )
+        case .pullDown:
+            verticalOffset = SubpostPullDownDismissPolicy.verticalOffset(
+                translationY: translation.height,
+                containerHeight: containerHeight
+            )
+        case nil:
+            verticalOffset = 0
+        }
     }
 
     private func handleDragEnded(
@@ -259,7 +355,10 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
         predictedTranslation: CGSize,
         containerSize: CGSize
     ) {
-        defer { rejectedCurrentGesture = false }
+        defer {
+            rejectedCurrentGesture = false
+            activeDismissAxis = nil
+        }
         guard phase == .tracking else {
             if phase == .idle {
                 verticalOffset = 0
@@ -267,16 +366,102 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
             return
         }
 
-        let shouldDismiss = SubpostRightSwipeDismissPolicy.shouldFinish(
-            translationX: translation.width,
-            predictedTranslationX: predictedTranslation.width,
-            containerWidth: containerSize.width
-        )
+        let shouldDismiss: Bool
+        switch activeDismissAxis {
+        case .rightSwipe:
+            shouldDismiss = SubpostRightSwipeDismissPolicy.shouldFinish(
+                translationX: translation.width,
+                predictedTranslationX: predictedTranslation.width,
+                containerWidth: containerSize.width
+            )
+        case .pullDown:
+            shouldDismiss = SubpostPullDownDismissPolicy.shouldFinish(
+                translationY: translation.height,
+                predictedTranslationY: predictedTranslation.height,
+                containerHeight: containerSize.height
+            )
+        case nil:
+            shouldDismiss = false
+        }
         if shouldDismiss {
             finishDismissal(containerHeight: containerSize.height)
         } else {
             restore()
         }
+    }
+
+    private func handleLegacyScrollSnapshot(_ snapshot: LegacyScrollTelemetrySnapshot) {
+        if #available(iOS 17.0, *) { return }
+        isContentAtTop = snapshot.distanceFromTop <= 1
+    }
+
+    private func handleLegacyScrollPan(
+        _ event: LegacyScrollPanEvent,
+        containerSize: CGSize
+    ) {
+        if #available(iOS 17.0, *) { return }
+
+        switch event.state {
+        case .began:
+            legacyPullDownStartedAtTop = isContentAtTop
+            legacyPullDownRejected = false
+        case .changed:
+            guard isEnabled,
+                  phase != .dismissing,
+                  phase != .restoring,
+                  legacyPullDownRejected == false else {
+                return
+            }
+            if phase == .idle {
+                let distance = hypot(event.translation.width, event.translation.height)
+                guard distance >= SubpostRightSwipeDismissPolicy.minimumTrackingDistance else {
+                    return
+                }
+                guard SubpostPullDownDismissPolicy.shouldBegin(
+                    translation: event.translation,
+                    isContentAtTop: legacyPullDownStartedAtTop
+                ) else {
+                    legacyPullDownRejected = true
+                    return
+                }
+                activeDismissAxis = .pullDown
+                phase = .tracking
+            }
+            guard phase == .tracking, activeDismissAxis == .pullDown else { return }
+            verticalOffset = SubpostPullDownDismissPolicy.verticalOffset(
+                translationY: event.translation.height,
+                containerHeight: containerSize.height
+            )
+        case .ended:
+            defer { resetLegacyPullDownGesture() }
+            guard phase == .tracking, activeDismissAxis == .pullDown else { return }
+            if SubpostPullDownDismissPolicy.shouldFinish(
+                translationY: event.translation.height,
+                predictedTranslationY: event.translation.height,
+                containerHeight: containerSize.height
+            ) {
+                finishDismissal(containerHeight: containerSize.height)
+            } else {
+                restore()
+            }
+        case .cancelled, .failed:
+            defer { resetLegacyPullDownGesture() }
+            if phase == .tracking, activeDismissAxis == .pullDown {
+                restore()
+            }
+        case .possible:
+            break
+        @unknown default:
+            defer { resetLegacyPullDownGesture() }
+            if phase == .tracking, activeDismissAxis == .pullDown {
+                restore()
+            }
+        }
+    }
+
+    private func resetLegacyPullDownGesture() {
+        legacyPullDownStartedAtTop = false
+        legacyPullDownRejected = false
     }
 
     private func finishDismissal(containerHeight: CGFloat) {
@@ -320,6 +505,7 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
                 verticalOffset = 0
             } completion: {
                 guard phase == .restoring else { return }
+                activeDismissAxis = nil
                 phase = .idle
             }
         } else {
@@ -354,6 +540,7 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
             onDismiss()
         case .restore:
             guard phase == .restoring else { return }
+            activeDismissAxis = nil
             phase = .idle
         }
     }
@@ -375,6 +562,8 @@ struct SubpostSheetInteractiveDismissSurface<Content: View>: View {
         phase = .idle
         verticalOffset = 0
         rejectedCurrentGesture = false
+        activeDismissAxis = nil
+        resetLegacyPullDownGesture()
     }
 }
 
@@ -513,5 +702,35 @@ enum SubpostRightSwipeDismissPolicy {
         return translationX >= completionDistance
             || translationX / containerWidth >= completionProgress
             || predictedTranslationX >= predictedCompletionDistance
+    }
+}
+
+enum SubpostPullDownDismissPolicy {
+    static let verticalDominance: CGFloat = 1.15
+    static let completionProgress: CGFloat = 0.18
+    static let completionDistance: CGFloat = 120
+    static let predictedCompletionDistance: CGFloat = 240
+    static let maximumInteractiveOffsetFraction: CGFloat = 0.72
+
+    static func shouldBegin(translation: CGSize, isContentAtTop: Bool) -> Bool {
+        isContentAtTop
+            && translation.height > 0
+            && translation.height > abs(translation.width) * verticalDominance
+    }
+
+    static func verticalOffset(translationY: CGFloat, containerHeight: CGFloat) -> CGFloat {
+        guard containerHeight > 0 else { return 0 }
+        return min(max(translationY, 0), containerHeight * maximumInteractiveOffsetFraction)
+    }
+
+    static func shouldFinish(
+        translationY: CGFloat,
+        predictedTranslationY: CGFloat,
+        containerHeight: CGFloat
+    ) -> Bool {
+        guard containerHeight > 0 else { return false }
+        return translationY >= completionDistance
+            || translationY / containerHeight >= completionProgress
+            || predictedTranslationY >= predictedCompletionDistance
     }
 }

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -27,6 +27,7 @@ struct ThreadDetailView: View {
     @State private var posts: [Post] = []
     @State private var nextPage = 1
     @State private var hasMore = true
+    @State private var descendingTotalPage: Int?
     @State private var isLoading = false
     @State private var didLoad = false
     @State private var didRecordBrowsingHistory = false
@@ -355,6 +356,7 @@ struct ThreadDetailView: View {
         posts = []
         nextPage = 1
         hasMore = true
+        descendingTotalPage = nil
         isLoading = false
         didLoad = false
         isMainPostBlocked = false
@@ -1686,6 +1688,9 @@ struct ThreadDetailView: View {
         isLoading = false
         nextPage = 1
         hasMore = true
+        // Refreshes and filter changes can alter the server's page count.
+        // Descending order must rediscover the latest page for each page-1 load.
+        descendingTotalPage = nil
         errorMessage = nil
         resolveAutoRestoreIfNeeded()
         // Explicit page-1 rebuilds (refresh, sort toggles) drop the saved
@@ -1734,17 +1739,75 @@ struct ThreadDetailView: View {
             }
             let previousMainPost = mainPost
             let previousMainPostIsSummaryFallback = threadPage?.mainPostIsSummaryFallback ?? false
-            let task = Task { try await environment.api.threadPage(
-                account: requestedAccount,
-                threadID: threadID,
-                page: requestedPage,
-                forumID: forumID,
-                postID: requestedPostID,
-                seeLz: requestedSeeLz,
-                sortType: requestedSort
-            ) }
-            loadTask = task
-            var loaded = try await task.value
+            var loaded: ThreadPage
+            if requestedSort == .descending {
+                var discoveryPage: ThreadPage?
+                let totalPage: Int
+                if requestedPage > 1, let descendingTotalPage {
+                    totalPage = descendingTotalPage
+                } else {
+                    let discoveryTask = Task { try await environment.api.threadPage(
+                        account: requestedAccount,
+                        threadID: threadID,
+                        page: 1,
+                        forumID: forumID,
+                        postID: nil,
+                        seeLz: requestedSeeLz,
+                        sortType: .ascending
+                    ) }
+                    loadTask = discoveryTask
+                    let page = try await discoveryTask.value
+                    guard generation == requestGeneration,
+                          requestedSession == account?.sessionIdentity,
+                          requestedSeeLz == seeLz,
+                          requestedSort == sortType else { return }
+                    discoveryPage = page
+                    totalPage = max(page.totalPage, 1)
+                    descendingTotalPage = totalPage
+                }
+
+                let serverPage = ThreadDescendingPaginationPolicy.serverPage(
+                    logicalPage: requestedPage,
+                    totalPage: totalPage
+                )
+                if serverPage == 1, let discoveryPage {
+                    loaded = discoveryPage
+                } else {
+                    let pageTask = Task { try await environment.api.threadPage(
+                        account: requestedAccount,
+                        threadID: threadID,
+                        page: serverPage,
+                        forumID: forumID,
+                        postID: nil,
+                        seeLz: requestedSeeLz,
+                        sortType: .ascending
+                    ) }
+                    loadTask = pageTask
+                    loaded = try await pageTask.value
+                }
+                if loaded.mainPost == nil,
+                   let discoveryMainPost = discoveryPage.flatMap(
+                    ThreadPageMainPostPolicy.mainPost(in:)
+                   ) {
+                    loaded.mainPost = discoveryMainPost
+                }
+                loaded = ThreadDescendingPaginationPolicy.normalized(
+                    loaded,
+                    logicalPage: requestedPage
+                )
+            } else {
+                let task = Task { try await environment.api.threadPage(
+                    account: requestedAccount,
+                    threadID: threadID,
+                    page: requestedPage,
+                    forumID: forumID,
+                    postID: requestedPostID,
+                    seeLz: requestedSeeLz,
+                    sortType: requestedSort
+                ) }
+                loadTask = task
+                loaded = try await task.value
+            }
             guard generation == requestGeneration,
                   requestedSession == account?.sessionIdentity,
                   requestedSeeLz == seeLz,
@@ -2678,6 +2741,17 @@ private struct SubpostListSheet: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 0) {
+                            GeometryReader { proxy in
+                                Color.clear.preference(
+                                    key: SubpostSheetScrollTopPreferenceKey.self,
+                                    value: Optional(proxy.frame(
+                                        in: .named(SubpostSheetScrollCoordinateSpace.name)
+                                    ).minY)
+                                )
+                            }
+                            .frame(height: 0)
+                            .accessibilityHidden(true)
+
                             ReaderCard(
                                 showsDivider: false,
                                 contentBottomPadding: ThreadPostMetadataPlacement.standaloneReply.cardBottomPadding
@@ -2783,6 +2857,8 @@ private struct SubpostListSheet: View {
                         }
                         .readableWidth()
                     }
+                    .coordinateSpace(name: SubpostSheetScrollCoordinateSpace.name)
+                    .subpostSheetLegacyScrollTelemetry()
                     .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
                 }
                 }

--- a/TiebaPureTests/AnonymousLiveSmokeTests.swift
+++ b/TiebaPureTests/AnonymousLiveSmokeTests.swift
@@ -7,6 +7,65 @@ import XCTest
 /// CI deliberately skips this test because the deterministic fixture suite is the
 /// source of truth there. Run it explicitly with `RUN_ANONYMOUS_LIVE_SMOKE=1`.
 final class AnonymousLiveSmokeTests: XCTestCase {
+    func testAnonymousDescendingRepliesStartFromLatestPage() async throws {
+        guard ProcessInfo.processInfo.environment["RUN_ANONYMOUS_LIVE_SMOKE"] == "1" else {
+            throw XCTSkip("发布前按需运行；日常与 CI 测试不访问贴吧线上服务。")
+        }
+
+        let session = SecureRemoteURLSession.make(
+            configuration: Self.sessionConfiguration(),
+            redirectScope: .baiduHTTPS
+        )
+        defer { session.invalidateAndCancel() }
+        let api = TiebaAPI(client: TiebaHTTPClient(session: session))
+        let threads = try await api.forumThreads(
+            account: nil,
+            forumName: "iphone",
+            page: 1,
+            category: .replyTime
+        )
+        let thread = try XCTUnwrap(
+            threads.first(where: { $0.replyCount >= 30 }),
+            "公开吧页应提供一个至少 30 条回复的帖子用于倒序契约验证"
+        )
+        let ascending = try await api.threadPage(
+            account: nil,
+            threadID: thread.id,
+            page: 1,
+            forumID: thread.forumID,
+            postID: nil,
+            seeLz: false,
+            sortType: .ascending
+        )
+        let latestServerPage = ThreadDescendingPaginationPolicy.serverPage(
+            logicalPage: 1,
+            totalPage: ascending.totalPage
+        )
+        let latest = try await api.threadPage(
+            account: nil,
+            threadID: thread.id,
+            page: latestServerPage,
+            forumID: thread.forumID,
+            postID: nil,
+            seeLz: false,
+            sortType: .ascending
+        )
+        let descending = ThreadDescendingPaginationPolicy.normalized(
+            latest,
+            logicalPage: 1
+        )
+        let ascendingFloors = ascending.posts.map(\.floor).filter { $0 > 1 }
+        let descendingFloors = descending.posts.map(\.floor).filter { $0 > 1 }
+
+        XCTAssertFalse(ascendingFloors.isEmpty)
+        XCTAssertFalse(descendingFloors.isEmpty)
+        XCTAssertGreaterThan(
+            descendingFloors.max() ?? 0,
+            ascendingFloors.max() ?? 0,
+            "倒序第一页必须从最新楼层开始，而不是只反转正序第一页"
+        )
+    }
+
     func testAnonymousHomeForumSearchThreadAndMediaJourney() async throws {
         guard ProcessInfo.processInfo.environment["RUN_ANONYMOUS_LIVE_SMOKE"] == "1" else {
             throw XCTSkip("发布前按需运行；日常与 CI 测试不访问贴吧线上服务。")

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -1,5 +1,6 @@
 import Security
 import SwiftUI
+import ImageIO
 import XCTest
 @testable import TiebaPure
 
@@ -1334,6 +1335,52 @@ final class TiebaPureSmokeTests: XCTestCase {
         XCTAssertFalse(TiebaImageRequestPolicy.shouldRetry(statusCode: 503, attempt: 2))
     }
 
+    func testTiebaImagePipelineDecodesAnimatedGIFAndAccountsForEveryFrame() throws {
+        let data = NSMutableData()
+        let destination = try XCTUnwrap(CGImageDestinationCreateWithData(
+            data,
+            "com.compuserve.gif" as CFString,
+            2,
+            nil
+        ))
+        for color in [UIColor.systemBlue, UIColor.systemOrange] {
+            let image = UIGraphicsImageRenderer(size: CGSize(width: 20, height: 12)).image {
+                color.setFill()
+                $0.fill(CGRect(x: 0, y: 0, width: 20, height: 12))
+            }
+            CGImageDestinationAddImage(
+                destination,
+                try XCTUnwrap(image.cgImage),
+                [
+                    kCGImagePropertyGIFDictionary: [
+                        kCGImagePropertyGIFDelayTime: 0.08
+                    ]
+                ] as CFDictionary
+            )
+        }
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+
+        let image = try XCTUnwrap(TiebaImagePipeline.decodedImage(
+            from: data as Data,
+            targetPixelSize: 128
+        ))
+        XCTAssertEqual(image.images?.count, 2)
+        XCTAssertEqual(image.duration, 0.16, accuracy: 0.01)
+        let expectedCost = try XCTUnwrap(image.images).reduce(into: 0) { total, frame in
+            let cgImage = try XCTUnwrap(frame.cgImage)
+            total += cgImage.width * cgImage.height * 4
+        }
+        XCTAssertEqual(
+            TiebaImagePipeline.decodedImageCost(image),
+            expectedCost
+        )
+        XCTAssertGreaterThan(
+            TiebaImagePipeline.decodedImageCost(image),
+            expectedCost / 2,
+            "动画缓存成本必须覆盖全部帧，而不是只计算首帧"
+        )
+    }
+
     func testTiebaImageSourcePolicyKeepsThumbnailThenOriginalWithoutDuplicates() throws {
         let thumbnail = try XCTUnwrap(URL(string: "https://tiebapic.baidu.com/thumb.jpg"))
         let original = try XCTUnwrap(URL(string: "https://tiebapic.baidu.com/original.jpg"))
@@ -1453,6 +1500,55 @@ final class TiebaPureSmokeTests: XCTestCase {
             FullScreenImageDecodePolicy.maximumPreviewDecodedPixelSize
         )
         XCTAssertEqual(TiebaImageDecodePolicy.maximumDecodedPixelSize, 4_096)
+    }
+
+    func testFullScreenImageAutomaticallyUpgradesOnlyVisibleInsufficientPreview() throws {
+        let preview = try XCTUnwrap(URL(
+            string: "https://tiebapic.baidu.com/forum/pic/item/preview.jpg"
+        ))
+        let original = try XCTUnwrap(URL(
+            string: "https://tiebapic.baidu.com/forum/pic/item/original.jpg"
+        ))
+        XCTAssertTrue(FullScreenImageResolutionUpgradePolicy.shouldUpgrade(
+            previewPixelSize: CGSize(width: 320, height: 960),
+            targetPixelSize: 3_072,
+            pageIndex: 0,
+            currentIndex: 0,
+            didFinishPresentation: true,
+            previewURL: preview,
+            originalURL: original,
+            originalState: .available
+        ))
+        XCTAssertFalse(FullScreenImageResolutionUpgradePolicy.shouldUpgrade(
+            previewPixelSize: CGSize(width: 768, height: 3_072),
+            targetPixelSize: 3_072,
+            pageIndex: 0,
+            currentIndex: 0,
+            didFinishPresentation: true,
+            previewURL: preview,
+            originalURL: original,
+            originalState: .available
+        ))
+        XCTAssertFalse(FullScreenImageResolutionUpgradePolicy.shouldUpgrade(
+            previewPixelSize: CGSize(width: 320, height: 960),
+            targetPixelSize: 3_072,
+            pageIndex: 1,
+            currentIndex: 0,
+            didFinishPresentation: true,
+            previewURL: preview,
+            originalURL: original,
+            originalState: .available
+        ))
+        XCTAssertFalse(FullScreenImageResolutionUpgradePolicy.shouldUpgrade(
+            previewPixelSize: CGSize(width: 320, height: 960),
+            targetPixelSize: 3_072,
+            pageIndex: 0,
+            currentIndex: 0,
+            didFinishPresentation: true,
+            previewURL: original,
+            originalURL: original,
+            originalState: .available
+        ))
     }
 
     func testOriginalImageOnlyLoadsFromAnExplicitAvailableOrRetryState() {
@@ -3334,6 +3430,71 @@ final class TiebaPureSmokeTests: XCTestCase {
             predictedTranslationX: 100,
             containerWidth: 390
         ))
+    }
+
+    func testSubpostPullDownDismissRequiresContentToStartAtTop() {
+        XCTAssertTrue(SubpostPullDownDismissPolicy.shouldBegin(
+            translation: CGSize(width: 8, height: 40),
+            isContentAtTop: true
+        ))
+        XCTAssertFalse(SubpostPullDownDismissPolicy.shouldBegin(
+            translation: CGSize(width: 8, height: 40),
+            isContentAtTop: false
+        ))
+        XCTAssertFalse(SubpostPullDownDismissPolicy.shouldBegin(
+            translation: CGSize(width: 40, height: 20),
+            isContentAtTop: true
+        ))
+        XCTAssertEqual(
+            SubpostPullDownDismissPolicy.verticalOffset(
+                translationY: 160,
+                containerHeight: 800
+            ),
+            160
+        )
+        XCTAssertTrue(SubpostPullDownDismissPolicy.shouldFinish(
+            translationY: 160,
+            predictedTranslationY: 160,
+            containerHeight: 800
+        ))
+        XCTAssertTrue(SubpostPullDownDismissPolicy.shouldFinish(
+            translationY: 48,
+            predictedTranslationY: 260,
+            containerHeight: 800
+        ))
+        XCTAssertFalse(SubpostPullDownDismissPolicy.shouldFinish(
+            translationY: 48,
+            predictedTranslationY: 100,
+            containerHeight: 800
+        ))
+    }
+
+    func testDescendingReplyPaginationStartsAtLastServerPage() {
+        XCTAssertEqual(
+            ThreadDescendingPaginationPolicy.serverPage(logicalPage: 1, totalPage: 8),
+            8
+        )
+        XCTAssertEqual(
+            ThreadDescendingPaginationPolicy.serverPage(logicalPage: 2, totalPage: 8),
+            7
+        )
+        XCTAssertEqual(
+            ThreadDescendingPaginationPolicy.serverPage(logicalPage: 8, totalPage: 8),
+            1
+        )
+        XCTAssertEqual(
+            ThreadDescendingPaginationPolicy.serverPage(logicalPage: 99, totalPage: 8),
+            1
+        )
+        XCTAssertEqual(
+            ThreadDescendingPaginationPolicy.serverPage(logicalPage: 1, totalPage: 3),
+            3,
+            "刷新后应使用重新发现的总页数定位最新回复"
+        )
+        XCTAssertEqual(
+            ThreadDescendingPaginationPolicy.displayOrder([37, 38, 39]),
+            [39, 38, 37]
+        )
     }
 
     func testNavigationBackGesturePolicyUsesNativeContentPopOnlyOnIOS26() {

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -3786,6 +3786,7 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 20))
         let openAllButton = app.buttons["查看全部4条回复"]
         XCTAssertEqual(openAllButton.frame.height, 36, accuracy: 1)
+        let sourceFrameBeforePresentation = openAllButton.frame
         openAllButton.tap()
         let navigationBar = app.navigationBars["2楼的回复(4条)"]
         XCTAssertTrue(navigationBar.waitForExistence(timeout: 8))
@@ -3803,12 +3804,18 @@ final class TiebaPureUITests: XCTestCase {
         )
         attachScreenshot(named: "fixture-subpost-reference-layout")
 
-        let downwardStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.32))
-        let downwardEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.72))
-        downwardStart.press(forDuration: 0.05, thenDragTo: downwardEnd)
-        XCTAssertTrue(navigationBar.exists, "楼中楼下滑只能滚动内容，不应退出")
-
         let restingFrame = navigationBar.frame
+        let shortPullStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.32))
+        let shortPullEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.39))
+        shortPullStart.press(
+            forDuration: 0.05,
+            thenDragTo: shortPullEnd,
+            withVelocity: 40,
+            thenHoldForDuration: 0.25
+        )
+        XCTAssertTrue(navigationBar.waitForExistence(timeout: 3))
+        XCTAssertEqual(navigationBar.frame.minY, restingFrame.minY, accuracy: 2)
+
         let parentMetadata = app.descendants(matching: .any)["thread-subpost-parent-metadata"]
         XCTAssertTrue(parentMetadata.waitForExistence(timeout: 5))
         let partialSwipeStart = parentMetadata.coordinate(
@@ -3825,14 +3832,33 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertEqual(navigationBar.frame.minY, restingFrame.minY, accuracy: 2)
         XCTAssertEqual(navigationBar.frame.minX, restingFrame.minX, accuracy: 2)
 
-        for cycle in 0..<4 {
-            if cycle > 0 {
-                XCTAssertTrue(
-                    waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 5)
-                )
-                app.buttons["查看全部4条回复"].tap()
-                XCTAssertTrue(navigationBar.waitForExistence(timeout: 8))
-            }
+        let pullStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.30))
+        let pullEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.72))
+        pullStart.press(
+            forDuration: 0.05,
+            thenDragTo: pullEnd,
+            withVelocity: 300,
+            thenHoldForDuration: 0.3
+        )
+        let pullDismissed = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: navigationBar
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [pullDismissed], timeout: 5), .completed)
+        XCTAssertTrue(waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 2))
+        XCTAssertEqual(
+            app.buttons["查看全部4条回复"].frame.minY,
+            sourceFrameBeforePresentation.minY,
+            accuracy: 3,
+            "下拉关闭后帖子阅读位置不能跳回主楼"
+        )
+
+        for cycle in 0..<3 {
+            XCTAssertTrue(
+                waitForElement(named: "查看全部4条回复", in: app, maxSwipes: 2)
+            )
+            app.buttons["查看全部4条回复"].tap()
+            XCTAssertTrue(navigationBar.waitForExistence(timeout: 8))
 
             XCTAssertEqual(
                 app.navigationBars.matching(identifier: "2楼的回复(4条)").count,
@@ -4053,6 +4079,29 @@ final class TiebaPureUITests: XCTestCase {
             object: sourceImage
         )
         XCTAssertEqual(XCTWaiter.wait(for: [sourceIsHittableAgain], timeout: 5), .completed)
+    }
+
+    func testFirstFullScreenImageUpgradesLowResolutionPreviewWithoutPagingAway() {
+        let app = launchApp(additionalArguments: [
+            "UITEST_IMAGE_VIEWER",
+            "UITEST_IMAGE_VIEWER_LOW_RESOLUTION_PREVIEW"
+        ])
+
+        let originalButton = app.buttons["view-original-image"]
+        XCTAssertTrue(originalButton.waitForExistence(timeout: 8))
+        let loaded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", "原图已加载"),
+            object: originalButton
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [loaded], timeout: 8),
+            .completed,
+            "第一张低清预览应在当前页直接升级，不应要求先切换到其他图片"
+        )
+        XCTAssertFalse(
+            app.staticTexts["image-page-indicator"].exists,
+            "单图查看器不应显示分页指示器"
+        )
     }
 
     func testFullScreenImageControlsFitAtAccessibilityXXXL() {


### PR DESCRIPTION
## 修改内容

- 修复多图帖子第一张放大后停留在低清过渡图的问题：当前页会加载实际预览，并在分辨率不足时自动升级原图，不需要切换图片触发刷新。
- 增加受内存和帧数限制的 GIF 动画解码与显示。
- 修复回复倒序只反转当前已加载页的问题：先发现总页数，从最新服务端页面开始，并向前分页；刷新和切换只看楼主会重新发现页数。
- 楼中楼增加从顶部下拉退出，短距离手势回弹；保留右滑退出和“完成”按钮，并避免列表中部滚动误触退出。
- 加强楼中楼退出后的阅读位置回归覆盖，确保返回原楼层而不是主楼。

## 验证

- iOS 26.5：图片与楼中楼 UI 回归 3/3 通过。
- iOS 16.4：楼中楼 UI 回归 1/1、相关策略测试 4/4 通过。
- 匿名线上只读契约：确认倒序第一页来自最新服务端页面。
- `git diff --check` 通过。

Fixes #50
Fixes #51
