### PR TITLE
fix: prevent text selection layout freeze

### DIFF
--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -556,6 +556,17 @@ final class InlineContentTextView: UITextView {
         plainTextTapRecognizer?.isEnabled = isEnabled
     }
 
+    private var hasActiveTextSelection: Bool {
+        allowsTextSelection && selectedRange.length > 0
+    }
+
+    func normalizeContentOffsetIfTextSelectionIsInactive() {
+        guard hasActiveTextSelection == false else { return }
+        if abs(contentOffset.x) > 0.01 || abs(contentOffset.y) > 0.01 {
+            setContentOffset(.zero, animated: false)
+        }
+    }
+
     /// Returns a view the lazy stack dropped to a blank state. Everything the
     /// representable configures in `makeUIView` is reapplied there, so this only
     /// has to drop the content, this app's own recognizer, and the metrics
@@ -584,7 +595,7 @@ final class InlineContentTextView: UITextView {
         cachedFittingLineBreakMode = .byWordWrapping
         cachedFittingDisplayScale = 0
         cachedFittingSize = .zero
-        setContentOffset(.zero, animated: false)
+        normalizeContentOffsetIfTextSelectionIsInactive()
     }
 
     func apply(
@@ -766,9 +777,10 @@ final class InlineContentTextView: UITextView {
         // which is the source of intermittent clipping during cell reuse.
         configureTextContainer(forViewWidth: bounds.width)
         super.layoutSubviews()
-        if abs(contentOffset.x) > 0.01 || abs(contentOffset.y) > 0.01 {
-            setContentOffset(.zero, animated: false)
-        }
+        // UIKit moves a selectable text view's internal viewport while it
+        // positions selection handles. Forcing that offset back to zero here
+        // makes UIKit request another layout, creating a main-thread loop.
+        normalizeContentOffsetIfTextSelectionIsInactive()
     }
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
@@ -1110,9 +1122,7 @@ struct InlineContentText: UIViewRepresentable {
         textView.allowsTextSelection = allowsTextSelection
         textView.setPlainTextTapEnabled(onPlainTextTap != nil)
         textView.panGestureRecognizer.isEnabled = false
-        if abs(textView.contentOffset.x) > 0.01 || abs(textView.contentOffset.y) > 0.01 {
-            textView.setContentOffset(.zero, animated: false)
-        }
+        textView.normalizeContentOffsetIfTextSelectionIsInactive()
         context.coordinator.onOpenUser = onOpenUser
         context.coordinator.onPlainTextTap = onPlainTextTap
         context.coordinator.observeArtwork(

--- a/TiebaPureTests/InlineTextReuseTests.swift
+++ b/TiebaPureTests/InlineTextReuseTests.swift
@@ -81,6 +81,34 @@ final class InlineTextReuseTests: XCTestCase {
     }
 
     @MainActor
+    func testLayoutPreservesUIKitOffsetWhileTextSelectionIsActive() {
+        let text = paragraph(String(repeating: "选择句柄调整可视区域时不能被布局拉回原点。", count: 12))
+        let view = InlineContentTextView()
+        view.frame = CGRect(x: 0, y: 0, width: 240, height: 44)
+        view.isSelectable = true
+        view.allowsTextSelection = true
+        view.apply(
+            attributedText: text,
+            maximumNumberOfLines: 0,
+            lineBreakMode: .byWordWrapping
+        )
+        view.layoutIfNeeded()
+        view.selectedRange = NSRange(location: 4, length: 8)
+        view.setContentOffset(CGPoint(x: 0, y: 24), animated: false)
+        XCTAssertEqual(view.contentOffset.y, 24, accuracy: 0.01)
+
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+
+        XCTAssertEqual(
+            view.contentOffset.y,
+            24,
+            accuracy: 0.01,
+            "UIKit 为选区句柄设置的偏移不能在同一布局周期内被强制归零"
+        )
+    }
+
+    @MainActor
     func testMeasurementCacheStaysBounded() {
         for index in 0..<(InlineContentTextMeasurementCache.capacity + 32) {
             InlineContentTextMeasurementCache.store(
@@ -115,6 +143,7 @@ final class InlineTextReuseTests: XCTestCase {
             maximumNumberOfLines: 2,
             lineBreakMode: .byTruncatingTail
         )
+        view.selectedRange = NSRange(location: 1, length: 3)
 
         InlineContentTextViewPool.recycle(view)
         await Task.yield()
@@ -126,6 +155,7 @@ final class InlineTextReuseTests: XCTestCase {
         XCTAssertEqual(reused.textStorage.string, "")
         XCTAssertNil(reused.accessibilityIdentifier)
         XCTAssertFalse(reused.allowsTextSelection)
+        XCTAssertEqual(reused.selectedRange, NSRange(location: 0, length: 0))
         XCTAssertEqual(reused.textContainer.maximumNumberOfLines, 0)
 
         // A fresh coordinator restarts render IDs at 1, so a recycled view must

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -3732,6 +3732,58 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(app.buttons["更多"].exists)
     }
 
+    func testIssue54IPadSubpostTextSelectionStaysResponsive() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            throw XCTSkip("仅在 iPad 设备矩阵中运行。")
+        }
+        let app = launchApp(scenario: "longContent", disableAnimations: false)
+        XCUIDevice.shared.orientation = .landscapeLeft
+        addTeardownBlock {
+            XCUIDevice.shared.orientation = .portrait
+        }
+        openFirstThread(in: app)
+
+        let previewText = app.descendants(matching: .any)
+            .matching(identifier: "thread-subpost-preview-text")
+            .firstMatch
+        let detailScrollView = app.scrollViews["thread-detail-scroll-view"]
+        XCTAssertTrue(detailScrollView.waitForExistence(timeout: 8))
+        for _ in 0..<20 where previewText.exists == false || previewText.isHittable == false {
+            detailScrollView.swipeUp()
+        }
+        XCTAssertTrue(previewText.exists && previewText.isHittable)
+
+        for iteration in 0..<5 {
+            previewText.coordinate(withNormalizedOffset: CGVector(dx: 0.55, dy: 0.5))
+                .press(forDuration: 1.2)
+
+            let copyControl = app.descendants(matching: .any)
+                .matching(NSPredicate(format: "label IN %@", ["复制", "拷贝", "Copy"]))
+                .firstMatch
+            XCTAssertTrue(
+                copyControl.waitForExistence(timeout: 5),
+                "第\(iteration + 1)次楼中楼文本选择后界面失去响应"
+            )
+            XCTAssertTrue(waitForHittable(copyControl, expected: true, timeout: 5))
+            copyControl.tap()
+            XCTAssertTrue(
+                app.buttons["更多"].waitForExistence(timeout: 5),
+                "第\(iteration + 1)次复制后帖子页失去响应"
+            )
+        }
+
+        let openAllButton = app.buttons["查看全部4条回复"]
+        for _ in 0..<8 where openAllButton.exists == false || openAllButton.isHittable == false {
+            detailScrollView.swipeUp()
+        }
+        XCTAssertTrue(openAllButton.exists && openAllButton.isHittable)
+        openAllButton.tap()
+        XCTAssertTrue(
+            app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8),
+            "反复选择楼中楼文字后仍应可以打开回复列表"
+        )
+    }
+
     func testIssue37RepeatedProfileNavigationAndTextSelectionStayResponsive() {
         let app = launchApp(
             scenario: "longContent",


### PR DESCRIPTION
## Summary
- preserve the UIKit-managed text viewport while an inline text selection is active
- keep zero-offset normalization for inactive and recycled text views
- add deterministic offset coverage and an iPad landscape repeated-selection UI regression

## Tests
- iOS 18.3.1 iPad: InlineTextReuseTests (7/7)
- iOS 18.3.1 iPad: issue #54 repeated selection UI test
- iOS 18.3.1 iPad: copy, wrapping, and reuse layout regressions
- iOS 16.4 iPhone: InlineTextReuseTests plus reuse layout smoke (8/8)

Fixes #54