### PR TITLE
fix: 自动检测失效登录并退出账号

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		4AA30396C89848D6E874828A /* TiebaSubmissionChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFB1A84AD3090A9581D1DA7 /* TiebaSubmissionChallenge.swift */; };
 		4C637302510F02D057F7F18D /* AuthSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D258A9BF97B365AE98B663F /* AuthSessionTests.swift */; };
 		4CC783BD1274CE79745DE038 /* LoginWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F159C859125D33A23786365A /* LoginWebView.swift */; };
+		4D32AA19CAE1A40F2001E6D8 /* SessionExpirationMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A0FAAA54B2D05276E46330 /* SessionExpirationMonitorTests.swift */; };
 		4D7D3D4E33E7C375230D2F29 /* Post.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50FDF3AC3742333D5202EC /* Post.pb.swift */; };
 		4E2A3DFCCFD09D57BC62A04F /* FileOrderedCollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A20C49C14881A792297DFF2 /* FileOrderedCollectionPersistenceTests.swift */; };
 		4ED79FF1DB72B276E756EBF2 /* FixtureTiebaAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36421D36A7372F3886F8A1FA /* FixtureTiebaAPI.swift */; };
@@ -195,6 +196,7 @@
 		E4BC7D1B10FF88D762725986 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E2287E1195B4261B0B88E8 /* SettingsView.swift */; };
 		E6FCA5689969E1EE7020CF44 /* ReadingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432F97822473B7D42DB148EC /* ReadingSettingsView.swift */; };
 		EAADABB00751D25DB084C26D /* TiebaHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF65BFE5160CFC6F1F12CEF /* TiebaHTTPClient.swift */; };
+		EBD1AC0F607CBF4865A92A2A /* SessionExpirationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A578DF23FC437057492F4BE /* SessionExpirationMonitor.swift */; };
 		ECDE960EDA7E9E0E186B2D3C /* ExternalRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFA01B546626F59DF261F1 /* ExternalRoute.swift */; };
 		ED0AA7A2777C1AD628FF19AA /* TiebaContentFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CA90EA6BEF04EEA9AD1C3 /* TiebaContentFilter.swift */; };
 		ED3E9E7D0D3A425FBB4B9C05 /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = 2937FD9F177D6107E4AF3997 /* SwiftProtobuf */; };
@@ -255,6 +257,7 @@
 /* Begin PBXFileReference section */
 		00339148CB9511CB5F6A624F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0060EA54C03E209E46FB2C40 /* ForumThreadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumThreadsView.swift; sourceTree = "<group>"; };
+		00A0FAAA54B2D05276E46330 /* SessionExpirationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExpirationMonitorTests.swift; sourceTree = "<group>"; };
 		034D76B7DA1D80733B718828 /* MediaPreviewHeroAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewHeroAnimator.swift; sourceTree = "<group>"; };
 		06656E39A13E9DD402A3E9D7 /* CompatibleUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleUnavailableView.swift; sourceTree = "<group>"; };
 		06BFF7EDD31716056CE12B69 /* TiebaAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaAPI.swift; sourceTree = "<group>"; };
@@ -312,6 +315,7 @@
 		398BABD44302879D665A9AC3 /* VoicePlaybackControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlaybackControl.swift; sourceTree = "<group>"; };
 		3A20C49C14881A792297DFF2 /* FileOrderedCollectionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOrderedCollectionPersistenceTests.swift; sourceTree = "<group>"; };
 		3A38AD5D710823BA66CAE23C /* UserProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileTests.swift; sourceTree = "<group>"; };
+		3A578DF23FC437057492F4BE /* SessionExpirationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExpirationMonitor.swift; sourceTree = "<group>"; };
 		3ABAA8240FEE5D60D5C61349 /* VoicePlaybackControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePlaybackControlTests.swift; sourceTree = "<group>"; };
 		3BEB3F78F38EA8D24DAA64A4 /* Anti.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Anti.pb.swift; sourceTree = "<group>"; };
 		3C4F59298557DEA63197CAA5 /* OpenInTiebaPure.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = OpenInTiebaPure.js; sourceTree = "<group>"; };
@@ -751,6 +755,7 @@
 				481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */,
 				C60B7C87AF367770BAF70762 /* SearchAPITests.swift */,
 				594CFFAE35B27CDF27D9B903 /* SecurityRegressionTests.swift */,
+				00A0FAAA54B2D05276E46330 /* SessionExpirationMonitorTests.swift */,
 				72A829A6D2ABD0F1D55D90E6 /* SocialRelationshipStateTests.swift */,
 				8D5BFD4EFAD7D98BA703D36C /* StateRegressionTests.swift */,
 				8FBDD5BC8E767866E1874011 /* SwiftDataOrderedCollectionPersistenceTests.swift */,
@@ -905,6 +910,7 @@
 				DB22109F3B9CFD8850C4BEE0 /* AuthSession.swift */,
 				F159C859125D33A23786365A /* LoginWebView.swift */,
 				1D6B235101269A6DE9BEB53A /* LogoutCoordinator.swift */,
+				3A578DF23FC437057492F4BE /* SessionExpirationMonitor.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1208,6 +1214,7 @@
 				30D4D4D35FD01A12F8D58EAC /* SearchResultsView.swift in Sources */,
 				DEA70B990FBB4F0B3A27998B /* SearchRoute.swift in Sources */,
 				3FB07858552D194FD0AE222C /* SecureFilePersistence.swift in Sources */,
+				EBD1AC0F607CBF4865A92A2A /* SessionExpirationMonitor.swift in Sources */,
 				E4BC7D1B10FF88D762725986 /* SettingsView.swift in Sources */,
 				CDEA6D379FC8528CC2581C94 /* ShortPullRefresh.swift in Sources */,
 				50638626574849A4E23F01EA /* SimpleForum.pb.swift in Sources */,
@@ -1294,6 +1301,7 @@
 				9C4E81261CE11986A7FC94CA /* PersistenceBoundaryTests.swift in Sources */,
 				FA2D7EBC13B9CDAE43B9DAC0 /* SearchAPITests.swift in Sources */,
 				D3B0D1E46535FF84CB41BAB7 /* SecurityRegressionTests.swift in Sources */,
+				4D32AA19CAE1A40F2001E6D8 /* SessionExpirationMonitorTests.swift in Sources */,
 				6BF8CB32442EA2DD70E1BEE9 /* SocialRelationshipStateTests.swift in Sources */,
 				C52C1926A49DEF01D6460BB4 /* StateRegressionTests.swift in Sources */,
 				BC0174E4104B48F4D4A8B291 /* SwiftDataOrderedCollectionPersistenceTests.swift in Sources */,

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -6,6 +6,7 @@ final class AppEnvironment: ObservableObject {
     let accountStore: AccountStore
     let api: any TiebaAPIService
     let logoutCoordinator: LogoutCoordinator
+    let sessionExpirationMonitor: SessionExpirationMonitor
     let socialRelationshipState: SocialRelationshipState
     let socialMutationCoordinator: SocialMutationCoordinator
     let ownThreadMutationState: OwnThreadMutationState
@@ -19,6 +20,7 @@ final class AppEnvironment: ObservableObject {
         accountStore: AccountStore,
         api: any TiebaAPIService,
         logoutCoordinator: LogoutCoordinator,
+        sessionExpirationMonitor: SessionExpirationMonitor? = nil,
         socialRelationshipState: SocialRelationshipState? = nil,
         socialMutationCoordinator: SocialMutationCoordinator? = nil,
         ownThreadMutationState: OwnThreadMutationState? = nil,
@@ -28,9 +30,25 @@ final class AppEnvironment: ObservableObject {
         forumSignSettingsStore: ForumSignSettingsStore? = nil,
         forumSignCoordinator: ForumSignCoordinator? = nil
     ) {
+        let resolvedExpirationMonitor: SessionExpirationMonitor
+        let resolvedAPI: any TiebaAPIService
+        if let monitoredAPI = api as? SessionMonitoringTiebaAPI {
+            if let sessionExpirationMonitor {
+                precondition(sessionExpirationMonitor === monitoredAPI.monitor)
+                resolvedExpirationMonitor = sessionExpirationMonitor
+            } else {
+                resolvedExpirationMonitor = monitoredAPI.monitor
+            }
+            resolvedAPI = monitoredAPI
+        } else {
+            let monitor = sessionExpirationMonitor ?? SessionExpirationMonitor()
+            resolvedExpirationMonitor = monitor
+            resolvedAPI = SessionMonitoringTiebaAPI(base: api, monitor: monitor)
+        }
         self.accountStore = accountStore
-        self.api = api
+        self.api = resolvedAPI
         self.logoutCoordinator = logoutCoordinator
+        self.sessionExpirationMonitor = resolvedExpirationMonitor
         let resolvedSubmissionSettings = contentSubmissionSettingsStore
             ?? ContentSubmissionSettingsStore()
         self.contentSubmissionSettingsStore = resolvedSubmissionSettings
@@ -38,7 +56,7 @@ final class AppEnvironment: ObservableObject {
         self.socialRelationshipState = resolvedSocialState
         self.socialMutationCoordinator = socialMutationCoordinator
             ?? SocialMutationCoordinator(
-                api: api,
+                api: resolvedAPI,
                 state: resolvedSocialState,
                 allowsLikes: { resolvedSubmissionSettings.likesEnabled }
             )
@@ -46,13 +64,13 @@ final class AppEnvironment: ObservableObject {
         self.contentDraftStore = contentDraftStore ?? ContentDraftStore()
         self.contentSubmissionCoordinator = contentSubmissionCoordinator
             ?? ContentSubmissionCoordinator(
-                api: api,
+                api: resolvedAPI,
                 allowsSubmission: { resolvedSubmissionSettings.allowsSubmission(kind: $0) }
             )
         let resolvedSignSettings = forumSignSettingsStore ?? ForumSignSettingsStore()
         self.forumSignSettingsStore = resolvedSignSettings
         self.forumSignCoordinator = forumSignCoordinator
-            ?? ForumSignCoordinator(api: api, settings: resolvedSignSettings)
+            ?? ForumSignCoordinator(api: resolvedAPI, settings: resolvedSignSettings)
     }
 
     static func live() -> AppEnvironment {
@@ -186,10 +204,14 @@ final class AppEnvironment: ObservableObject {
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
         configuration.timeoutIntervalForRequest = 30
         configuration.timeoutIntervalForResource = 60
-        let api = TiebaAPI(client: TiebaHTTPClient(session: SecureRemoteURLSession.make(
-            configuration: configuration,
-            redirectScope: .baiduHTTPS
-        )))
+        let sessionExpirationMonitor = SessionExpirationMonitor()
+        let api = SessionMonitoringTiebaAPI(
+            base: TiebaAPI(client: TiebaHTTPClient(session: SecureRemoteURLSession.make(
+                configuration: configuration,
+                redirectScope: .baiduHTTPS
+            ))),
+            monitor: sessionExpirationMonitor
+        )
         let contentSubmissionSettingsStore = ContentSubmissionSettingsStore()
         let contentSubmissionCoordinator = ContentSubmissionCoordinator(
             api: api,
@@ -234,6 +256,7 @@ final class AppEnvironment: ObservableObject {
                     socialMutationCoordinator.endInvalidation()
                 }
             ),
+            sessionExpirationMonitor: sessionExpirationMonitor,
             socialRelationshipState: socialRelationshipState,
             socialMutationCoordinator: socialMutationCoordinator,
             contentSubmissionSettingsStore: contentSubmissionSettingsStore,
@@ -294,7 +317,11 @@ final class AppEnvironment: ObservableObject {
         }
         let service = MemoryAccountStoreService(data: accountData)
         let store = AccountStore(service: service)
-        let api = FixtureTiebaAPI(scenario: scenario, delayMilliseconds: delay)
+        let sessionExpirationMonitor = SessionExpirationMonitor()
+        let api = SessionMonitoringTiebaAPI(
+            base: FixtureTiebaAPI(scenario: scenario, delayMilliseconds: delay),
+            monitor: sessionExpirationMonitor
+        )
         let settingsSuite = "dev.infinityf4p.tiebapure.uitest.content-submission"
         let settingsDefaults = UserDefaults(suiteName: settingsSuite) ?? .standard
         if ProcessInfo.processInfo.arguments.contains(
@@ -358,6 +385,7 @@ final class AppEnvironment: ObservableObject {
                     socialMutationCoordinator.endInvalidation()
                 }
             ),
+            sessionExpirationMonitor: sessionExpirationMonitor,
             socialRelationshipState: socialRelationshipState,
             socialMutationCoordinator: socialMutationCoordinator,
             contentDraftStore: draftStore,

--- a/TiebaPure/App/RootView.swift
+++ b/TiebaPure/App/RootView.swift
@@ -10,6 +10,9 @@ struct RootView: View {
     @State private var externalRoute: ExternalRoute?
     @State private var accountTransitionTask: Task<Void, Never>?
     @State private var accountTransitionGeneration = 0
+    @State private var expiringSession: AccountSessionIdentity?
+    @State private var sessionExpirationTask: Task<Void, Never>?
+    @State private var sessionExpirationNotice: SessionExpirationNotice?
 
     var body: some View {
         Group {
@@ -49,6 +52,9 @@ struct RootView: View {
                 await signAutomaticallyIfNeeded()
             }
         }
+        .onReceive(environment.sessionExpirationMonitor.expiredSessions) { session in
+            handleSessionExpiration(session)
+        }
         .onReceive(NotificationCenter.default.publisher(
             for: UIApplication.didReceiveMemoryWarningNotification
         )) { _ in
@@ -67,10 +73,46 @@ struct RootView: View {
                 externalRoute = nil
             }
         }
+        .alert(item: $sessionExpirationNotice) { notice in
+            Alert(
+                title: Text(notice.title),
+                message: Text(notice.message),
+                dismissButton: .default(Text("知道了"))
+            )
+        }
     }
 
     private func signAutomaticallyIfNeeded() async {
         await environment.forumSignCoordinator.signAutomaticallyIfNeeded(account: account)
+    }
+
+    @MainActor
+    private func handleSessionExpiration(_ session: AccountSessionIdentity) {
+        guard SessionExpirationHandlingPolicy.shouldHandle(
+            reportedSession: session,
+            currentAccount: account,
+            expiringSession: expiringSession
+        ) else { return }
+
+        expiringSession = session
+        sessionExpirationNotice = .expired()
+        sessionExpirationTask = Task { @MainActor in
+            do {
+                try await environment.logoutCoordinator.logOut()
+            } catch is CancellationError {
+                if account?.sessionIdentity == session {
+                    expiringSession = nil
+                }
+            } catch {
+                if account?.sessionIdentity == session {
+                    expiringSession = nil
+                    sessionExpirationNotice = .logoutFailed(
+                        reason: ReaderErrorMessage.message(for: error)
+                    )
+                }
+            }
+            sessionExpirationTask = nil
+        }
     }
 
     @MainActor
@@ -152,6 +194,9 @@ struct RootView: View {
         guard Task.isCancelled == false,
               generation == accountTransitionGeneration else { return }
         account = newAccount
+        if newAccount?.sessionIdentity != expiringSession {
+            expiringSession = nil
+        }
         if AccountTransitionPolicy.shouldReleaseGlobalInvalidation(
             previous: previousAccount,
             next: newAccount
@@ -163,6 +208,26 @@ struct RootView: View {
             environment.socialMutationCoordinator.endInvalidation()
             environment.forumSignCoordinator.endInvalidation()
         }
+    }
+}
+
+private struct SessionExpirationNotice: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+
+    static func expired() -> SessionExpirationNotice {
+        SessionExpirationNotice(
+            title: "登录已失效",
+            message: "当前账号的登录状态已失效，应用将退出该账号，请重新登录。"
+        )
+    }
+
+    static func logoutFailed(reason: String) -> SessionExpirationNotice {
+        SessionExpirationNotice(
+            title: "自动退出失败",
+            message: "登录状态已失效，但未能清理本机账号数据。\(reason)"
+        )
     }
 }
 

--- a/TiebaPure/Core/Auth/SessionExpirationMonitor.swift
+++ b/TiebaPure/Core/Auth/SessionExpirationMonitor.swift
@@ -1,0 +1,294 @@
+import Combine
+import Foundation
+
+enum SessionExpirationErrorClassifier {
+    static func isSessionExpired(_ error: Error) -> Bool {
+        if let apiError = error as? TiebaAPIError,
+           case .sessionExpired = apiError {
+            return true
+        }
+        return (error as? ContentSubmissionError) == .sessionExpired
+    }
+}
+
+enum SessionExpirationHandlingPolicy {
+    static func shouldHandle(
+        reportedSession: AccountSessionIdentity,
+        currentAccount: Account?,
+        expiringSession: AccountSessionIdentity?
+    ) -> Bool {
+        guard expiringSession == nil else { return false }
+        return currentAccount?.sessionIdentity == reportedSession
+    }
+}
+
+@MainActor
+final class SessionExpirationMonitor {
+    private let subject = PassthroughSubject<AccountSessionIdentity, Never>()
+
+    var expiredSessions: AnyPublisher<AccountSessionIdentity, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func report(_ session: AccountSessionIdentity) {
+        subject.send(session)
+    }
+}
+
+struct SessionMonitoringTiebaAPI: TiebaAPIService {
+    let base: any TiebaAPIService
+    let monitor: SessionExpirationMonitor
+
+    func validateLogin(cookies: BaiduCookies) async throws -> Account {
+        try await base.validateLogin(cookies: cookies)
+    }
+
+    func personalizedThreads(
+        account: Account?,
+        page: Int,
+        loadType: Int
+    ) async throws -> [ThreadSummary] {
+        try await monitored(account: account) {
+            try await base.personalizedThreads(account: account, page: page, loadType: loadType)
+        }
+    }
+
+    func followedForums(account: Account) async throws -> [Forum] {
+        try await monitored(account: account) {
+            try await base.followedForums(account: account)
+        }
+    }
+
+    func forumThreads(
+        account: Account?,
+        forumName: String,
+        page: Int,
+        category: ForumThreadCategory
+    ) async throws -> [ThreadSummary] {
+        try await monitored(account: account) {
+            try await base.forumThreads(
+                account: account,
+                forumName: forumName,
+                page: page,
+                category: category
+            )
+        }
+    }
+
+    func searchThreads(
+        keyword: String,
+        page: Int,
+        sortType: Int,
+        filterType: Int,
+        forumName: String?,
+        pageSize: Int
+    ) async throws -> SearchResultsPage {
+        try await base.searchThreads(
+            keyword: keyword,
+            page: page,
+            sortType: sortType,
+            filterType: filterType,
+            forumName: forumName,
+            pageSize: pageSize
+        )
+    }
+
+    func resolveUser(named name: String) async throws -> UserSummary {
+        try await base.resolveUser(named: name)
+    }
+
+    func threadPage(
+        account: Account?,
+        threadID: Int64,
+        page: Int,
+        forumID: Int64?,
+        postID: UInt64?,
+        seeLz: Bool,
+        sortType: ThreadReplySort
+    ) async throws -> ThreadPage {
+        try await monitored(account: account) {
+            try await base.threadPage(
+                account: account,
+                threadID: threadID,
+                page: page,
+                forumID: forumID,
+                postID: postID,
+                seeLz: seeLz,
+                sortType: sortType
+            )
+        }
+    }
+
+    func subposts(
+        account: Account?,
+        threadID: Int64,
+        postID: UInt64,
+        forumID: Int64,
+        page: Int,
+        subpostID: UInt64
+    ) async throws -> [Subpost] {
+        try await monitored(account: account) {
+            try await base.subposts(
+                account: account,
+                threadID: threadID,
+                postID: postID,
+                forumID: forumID,
+                page: page,
+                subpostID: subpostID
+            )
+        }
+    }
+
+    func userProfile(account: Account?, user: UserSummary) async throws -> UserProfile {
+        try await monitored(account: account) {
+            try await base.userProfile(account: account, user: user)
+        }
+    }
+
+    func userThreads(
+        account: Account?,
+        userID: Int64,
+        page: Int
+    ) async throws -> UserThreadsPage {
+        try await monitored(account: account) {
+            try await base.userThreads(account: account, userID: userID, page: page)
+        }
+    }
+
+    func updateOwnProfile(account: Account, request: UserProfileEditRequest) async throws {
+        try await monitored(account: account) {
+            try await base.updateOwnProfile(account: account, request: request)
+        }
+    }
+
+    func deleteOwnThread(account: Account, target: OwnThreadDeletionTarget) async throws {
+        try await monitored(account: account) {
+            try await base.deleteOwnThread(account: account, target: target)
+        }
+    }
+
+    func setUserFollowed(
+        account: Account,
+        user: UserSummary,
+        followed: Bool
+    ) async throws {
+        try await monitored(account: account) {
+            try await base.setUserFollowed(account: account, user: user, followed: followed)
+        }
+    }
+
+    func userRelationships(
+        account: Account?,
+        userID: Int64,
+        kind: UserRelationshipKind,
+        page: Int
+    ) async throws -> UserRelationshipPage {
+        try await monitored(account: account) {
+            try await base.userRelationships(
+                account: account,
+                userID: userID,
+                kind: kind,
+                page: page
+            )
+        }
+    }
+
+    func forumMembership(account: Account, forum: Forum) async throws -> ForumMembership {
+        try await monitored(account: account) {
+            try await base.forumMembership(account: account, forum: forum)
+        }
+    }
+
+    func setForumFollowed(
+        account: Account,
+        forum: Forum,
+        followed: Bool
+    ) async throws -> ForumMembership {
+        try await monitored(account: account) {
+            try await base.setForumFollowed(account: account, forum: forum, followed: followed)
+        }
+    }
+
+    func signForum(account: Account, forum: Forum) async throws -> ForumSignResult {
+        try await monitored(account: account) {
+            try await base.signForum(account: account, forum: forum)
+        }
+    }
+
+    func accountThreadFavorites(
+        account: Account,
+        page: Int
+    ) async throws -> AccountThreadFavoritesPage {
+        try await monitored(account: account) {
+            try await base.accountThreadFavorites(account: account, page: page)
+        }
+    }
+
+    func setAccountThreadFavorite(
+        account: Account,
+        threadID: Int64,
+        postID: UInt64,
+        favorited: Bool
+    ) async throws {
+        try await monitored(account: account) {
+            try await base.setAccountThreadFavorite(
+                account: account,
+                threadID: threadID,
+                postID: postID,
+                favorited: favorited
+            )
+        }
+    }
+
+    func messages(
+        account: Account,
+        kind: MessageKind,
+        page: Int
+    ) async throws -> MessagesPage {
+        try await monitored(account: account) {
+            try await base.messages(account: account, kind: kind, page: page)
+        }
+    }
+
+    func setPostLiked(
+        account: Account,
+        threadID: Int64,
+        postID: UInt64,
+        objectType: TiebaLikeObjectType,
+        liked: Bool
+    ) async throws {
+        try await monitored(account: account) {
+            try await base.setPostLiked(
+                account: account,
+                threadID: threadID,
+                postID: postID,
+                objectType: objectType,
+                liked: liked
+            )
+        }
+    }
+
+    func submitContent(
+        account: Account,
+        request: ContentSubmissionRequest
+    ) async throws -> ContentSubmissionReceipt {
+        try await monitored(account: account) {
+            try await base.submitContent(account: account, request: request)
+        }
+    }
+
+    private func monitored<T>(
+        account: Account?,
+        operation: () async throws -> T
+    ) async throws -> T {
+        do {
+            return try await operation()
+        } catch {
+            if let account,
+               SessionExpirationErrorClassifier.isSessionExpired(error) {
+                await monitor.report(account.sessionIdentity)
+            }
+            throw error
+        }
+    }
+}

--- a/TiebaPureTests/SessionExpirationMonitorTests.swift
+++ b/TiebaPureTests/SessionExpirationMonitorTests.swift
@@ -1,0 +1,120 @@
+import Combine
+import XCTest
+@testable import TiebaPure
+
+@MainActor
+final class SessionExpirationMonitorTests: XCTestCase {
+    func testClassifierAcceptsOnlyExplicitSessionExpirationErrors() {
+        XCTAssertTrue(SessionExpirationErrorClassifier.isSessionExpired(
+            TiebaAPIError.sessionExpired(code: 110001, message: "登录已失效")
+        ))
+        XCTAssertTrue(SessionExpirationErrorClassifier.isSessionExpired(
+            ContentSubmissionError.sessionExpired
+        ))
+        XCTAssertFalse(SessionExpirationErrorClassifier.isSessionExpired(
+            TiebaAPIError.response(code: 4, message: "操作频繁")
+        ))
+        XCTAssertFalse(SessionExpirationErrorClassifier.isSessionExpired(
+            URLError(.notConnectedToInternet)
+        ))
+    }
+
+    func testHandlingPolicyRequiresCurrentSessionAndDeduplicates() {
+        let account = FixtureTiebaAPI.account
+        var replacement = account
+        replacement.stoken += "-replacement"
+
+        XCTAssertTrue(SessionExpirationHandlingPolicy.shouldHandle(
+            reportedSession: account.sessionIdentity,
+            currentAccount: account,
+            expiringSession: nil
+        ))
+        XCTAssertFalse(SessionExpirationHandlingPolicy.shouldHandle(
+            reportedSession: account.sessionIdentity,
+            currentAccount: replacement,
+            expiringSession: nil
+        ))
+        XCTAssertFalse(SessionExpirationHandlingPolicy.shouldHandle(
+            reportedSession: account.sessionIdentity,
+            currentAccount: account,
+            expiringSession: account.sessionIdentity
+        ))
+        XCTAssertFalse(SessionExpirationHandlingPolicy.shouldHandle(
+            reportedSession: account.sessionIdentity,
+            currentAccount: nil,
+            expiringSession: nil
+        ))
+    }
+
+    func testAuthenticatedExpirationIsReportedAndOriginalErrorIsPreserved() async {
+        let monitor = SessionExpirationMonitor()
+        let service = SessionMonitoringTiebaAPI(
+            base: FixtureTiebaAPI(scenario: .expired),
+            monitor: monitor
+        )
+        var reportedSessions: [AccountSessionIdentity] = []
+        let observation = monitor.expiredSessions.sink { reportedSessions.append($0) }
+        defer { observation.cancel() }
+
+        do {
+            _ = try await service.personalizedThreads(
+                account: FixtureTiebaAPI.account,
+                page: 1,
+                loadType: 0
+            )
+            XCTFail("Expected the fixture to report an expired session")
+        } catch {
+            XCTAssertEqual(
+                error as? TiebaAPIError,
+                .sessionExpired(code: 110001, message: "登录已失效")
+            )
+        }
+
+        XCTAssertEqual(reportedSessions, [FixtureTiebaAPI.account.sessionIdentity])
+    }
+
+    func testAnonymousExpirationAndLoginValidationDoNotReportActiveSession() async {
+        let monitor = SessionExpirationMonitor()
+        let service = SessionMonitoringTiebaAPI(
+            base: FixtureTiebaAPI(scenario: .expired),
+            monitor: monitor
+        )
+        var reportedSessions: [AccountSessionIdentity] = []
+        let observation = monitor.expiredSessions.sink { reportedSessions.append($0) }
+        defer { observation.cancel() }
+
+        do {
+            _ = try await service.personalizedThreads(account: nil, page: 1, loadType: 0)
+        } catch {}
+        do {
+            _ = try await service.validateLogin(cookies: BaiduCookies(
+                bduss: FixtureTiebaAPI.account.bduss,
+                stoken: FixtureTiebaAPI.account.stoken,
+                baiduID: FixtureTiebaAPI.account.baiduID
+            ))
+        } catch {}
+
+        XCTAssertTrue(reportedSessions.isEmpty)
+    }
+
+    func testOrdinaryNetworkFailureDoesNotReportExpiration() async {
+        let monitor = SessionExpirationMonitor()
+        let service = SessionMonitoringTiebaAPI(
+            base: FixtureTiebaAPI(scenario: .error),
+            monitor: monitor
+        )
+        var reportedSessions: [AccountSessionIdentity] = []
+        let observation = monitor.expiredSessions.sink { reportedSessions.append($0) }
+        defer { observation.cancel() }
+
+        do {
+            _ = try await service.personalizedThreads(
+                account: FixtureTiebaAPI.account,
+                page: 1,
+                loadType: 0
+            )
+        } catch {}
+
+        XCTAssertTrue(reportedSessions.isEmpty)
+    }
+}

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -359,6 +359,24 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertFalse(app.buttons["user-profile-follow-button"].exists)
     }
 
+    func testExpiredSessionShowsPromptAndAutomaticallyLogsOut() {
+        let app = launchApp(scenario: "expired", account: "loggedIn")
+
+        let alert = app.alerts["登录已失效"]
+        XCTAssertTrue(alert.waitForExistence(timeout: 8))
+        XCTAssertTrue(
+            alert.staticTexts["当前账号的登录状态已失效，应用将退出该账号，请重新登录。"].exists
+        )
+        alert.buttons["知道了"].tap()
+
+        let meTab = rootTab("我的", in: app)
+        XCTAssertTrue(meTab.waitForExistence(timeout: 5))
+        meTab.tap()
+        XCTAssertTrue(app.staticTexts["未登录也可以浏览公开帖子"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.buttons["手机号验证码登录"].exists)
+        XCTAssertFalse(app.buttons["me-user-profile-button"].exists)
+    }
+
     func testMessagesGuestPromptAndLoggedInFixtureJourney() {
         var app = launchApp()
         rootTab("我的", in: app).tap()


### PR DESCRIPTION
## 改动

- 在所有携带账号的 API 调用外统一检测明确的登录失效错误
- 当前会话失效时显示提示，并复用 LogoutCoordinator 自动清理登录态
- 校验会话身份并去重，避免旧请求、网络中断或操作频繁误触发退出

## 验证

- SessionExpirationMonitorTests：5 项通过
- 账号切换/退出相关定向回归：9 项通过
- 失效提示与自动退出 UI 测试：iOS 18.3.1、iOS 16.4 均通过
- Release iOS Simulator 构建通过
- 正常模拟器中的真实账号登录态单独确认，未用于失效夹具测试