### PR TITLE
Add local thread snapshots

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1B38ECEBD8AB77434B402F8A /* ForumThreadsRequestKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A1242A6C7E6C6F3740D3E6 /* ForumThreadsRequestKey.swift */; };
 		1C53CA119B8A4874452D2F6B /* ContentDraftFilePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE6592A34B15BF182198BFA /* ContentDraftFilePersistenceTests.swift */; };
 		1D73C1F9246A5740B5D63601 /* LogoutCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6B235101269A6DE9BEB53A /* LogoutCoordinator.swift */; };
+		1E84B72ACDF13678A6BE6CB8 /* SavedThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB03A9A81B77E7ECBD00B30 /* SavedThread.swift */; };
 		215E174D28331CD22F134EE6 /* TiebaAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BFF7EDD31716056CE12B69 /* TiebaAPI.swift */; };
 		221CEAF5C48D697203C0FC6B /* SwiftData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 158DD0B24F8C6500639DB687 /* SwiftData.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		22C326EADD75278D51629E56 /* ReaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431A697F330BBEC18E2252D0 /* ReaderCard.swift */; };
@@ -120,6 +121,7 @@
 		90A1EF7B8679DC1058702486 /* ForumListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944D4064677A9BAB7CD156BC /* ForumListView.swift */; };
 		94463A90FFDE1A58359C61B0 /* ContentDraftMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB122673DB1880647B37AE8 /* ContentDraftMigrationTests.swift */; };
 		96E558670B2758520F748005 /* ContentComposerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C0F8A37BD6F0E4EA09BFCD /* ContentComposerPolicyTests.swift */; };
+		985218E469AF18B5378E8549 /* SavedThreadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B960AF4A983D18E1496538 /* SavedThreadsView.swift */; };
 		9B869CC8E0EE590D0B003B40 /* FollowedUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBDB720D1FCC2A3138B0CC /* FollowedUsersView.swift */; };
 		9C4E81261CE11986A7FC94CA /* PersistenceBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */; };
 		9E782527D741226479B50A92 /* TiebaContentSubmissionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C158046155BBD6748519CF /* TiebaContentSubmissionAPI.swift */; };
@@ -205,6 +207,7 @@
 		F0FF2290BC0E84D98B000FF3 /* Anti.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEB3F78F38EA8D24DAA64A4 /* Anti.pb.swift */; };
 		F24BAE224091125E43EAC298 /* ForumSignSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4CFA3390403419B8C3E890 /* ForumSignSettings.swift */; };
 		F2FE7D83BA305985F7A5600D /* User.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D98C38DD4DF0A6BBAEE14B /* User.pb.swift */; };
+		F5B1D066296990A96D69CC0C /* SavedThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460C7E1E4622409127D0F888 /* SavedThreadTests.swift */; };
 		F60F13E9F3CF7AA790EE1C4A /* MessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C6EE1B24CFBA1308B81FD41 /* MessagesView.swift */; };
 		F81A17ADFC8827935D28CB43 /* Forum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E92E90BB801373B85685DDD /* Forum.swift */; };
 		F91AF0FEAF078DC66EA3C184 /* AppPosInfo.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3312A539F9532E1B21FD622 /* AppPosInfo.pb.swift */; };
@@ -267,6 +270,7 @@
 		094A7B97C027D43346675B29 /* TiebaPureProfile_UserProfile.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaPureProfile_UserProfile.pb.swift; sourceTree = "<group>"; };
 		094DB1CB5AD5C781A07443AB /* VideoDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoDownloadService.swift; sourceTree = "<group>"; };
 		0CE52F261111609A3D8E1D30 /* ContentDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDraftTests.swift; sourceTree = "<group>"; };
+		0DB03A9A81B77E7ECBD00B30 /* SavedThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedThread.swift; sourceTree = "<group>"; };
 		0E50CC9DC6A0FEE9D095B963 /* PbPage_PbPageResponse.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PbPage_PbPageResponse.pb.swift; sourceTree = "<group>"; };
 		0F167B1D47EFED83CEE70F2D /* SimpleForum.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleForum.pb.swift; sourceTree = "<group>"; };
 		10B4550B620AEBC6B7EA4F46 /* ContentBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockView.swift; sourceTree = "<group>"; };
@@ -326,6 +330,7 @@
 		431A697F330BBEC18E2252D0 /* ReaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCard.swift; sourceTree = "<group>"; };
 		432F97822473B7D42DB148EC /* ReadingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSettingsView.swift; sourceTree = "<group>"; };
 		44C549F603F6A8B5988B0B31 /* BrowsingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingHistory.swift; sourceTree = "<group>"; };
+		460C7E1E4622409127D0F888 /* SavedThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedThreadTests.swift; sourceTree = "<group>"; };
 		475452DA26606C9EEF2982D2 /* ReaderStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderStateView.swift; sourceTree = "<group>"; };
 		47A8570B3E26BDD92BF4524C /* TiebaMessageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaMessageAPI.swift; sourceTree = "<group>"; };
 		481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceBoundaryTests.swift; sourceTree = "<group>"; };
@@ -407,6 +412,7 @@
 		AEC5695CD74141BB65787AB6 /* TiebaAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaAPIService.swift; sourceTree = "<group>"; };
 		AF02A66EF1B9089518F9ED99 /* ImageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewer.swift; sourceTree = "<group>"; };
 		AFF65BFE5160CFC6F1F12CEF /* TiebaHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaHTTPClient.swift; sourceTree = "<group>"; };
+		B0B960AF4A983D18E1496538 /* SavedThreadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedThreadsView.swift; sourceTree = "<group>"; };
 		B3312A539F9532E1B21FD622 /* AppPosInfo.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPosInfo.pb.swift; sourceTree = "<group>"; };
 		B55649E6AEA1AD2EF4813452 /* TiebaUserProfileAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiebaUserProfileAPI.swift; sourceTree = "<group>"; };
 		B571B662CFFFF46F507E2FC5 /* TiebaPureOpenIn.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = TiebaPureOpenIn.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -630,6 +636,7 @@
 				CD2C30123EFF90A5F9BEE7C2 /* Post.swift */,
 				638DEF254549D0D4DE625487 /* ReadingPreferences.swift */,
 				FDE02417BF13C2E0A1D7824E /* RecentForum.swift */,
+				0DB03A9A81B77E7ECBD00B30 /* SavedThread.swift */,
 				24D4BAC59CD64A3B8F236258 /* SearchHistory.swift */,
 				16DDB351392A69BC42810B9E /* SearchResult.swift */,
 				6BBA032F531024778CFC5C0A /* SecureFilePersistence.swift */,
@@ -753,6 +760,7 @@
 				2758D17C77814946EB5560DA /* MultipartFormDataTests.swift */,
 				BA707FB3466F64C9B7BB74F3 /* NavigationSourceLifecycleTests.swift */,
 				481EB2A4D9C019B333364901 /* PersistenceBoundaryTests.swift */,
+				460C7E1E4622409127D0F888 /* SavedThreadTests.swift */,
 				C60B7C87AF367770BAF70762 /* SearchAPITests.swift */,
 				594CFFAE35B27CDF27D9B903 /* SecurityRegressionTests.swift */,
 				00A0FAAA54B2D05276E46330 /* SessionExpirationMonitorTests.swift */,
@@ -890,6 +898,7 @@
 			children = (
 				582A83F679EC3456CD6D08E4 /* BlocklistSettingsView.swift */,
 				432F97822473B7D42DB148EC /* ReadingSettingsView.swift */,
+				B0B960AF4A983D18E1496538 /* SavedThreadsView.swift */,
 				10E2287E1195B4261B0B88E8 /* SettingsView.swift */,
 			);
 			path = Settings;
@@ -1209,6 +1218,8 @@
 				D0EB13806B12EBFE42C8D71B /* RecentForum.swift in Sources */,
 				A4FCD6601BAA005BF0F264D0 /* RootView.swift in Sources */,
 				C02D20CEC3FEDED464983D96 /* SafariActionPayload.swift in Sources */,
+				1E84B72ACDF13678A6BE6CB8 /* SavedThread.swift in Sources */,
+				985218E469AF18B5378E8549 /* SavedThreadsView.swift in Sources */,
 				CAA7C941E2D8AAA65B342CBA /* SearchHistory.swift in Sources */,
 				8028A9708BDE36C7BB815CEF /* SearchResult.swift in Sources */,
 				30D4D4D35FD01A12F8D58EAC /* SearchResultsView.swift in Sources */,
@@ -1299,6 +1310,7 @@
 				D92FF26A20CE55595F45B81F /* MultipartFormDataTests.swift in Sources */,
 				BE37D589510658CE415782CD /* NavigationSourceLifecycleTests.swift in Sources */,
 				9C4E81261CE11986A7FC94CA /* PersistenceBoundaryTests.swift in Sources */,
+				F5B1D066296990A96D69CC0C /* SavedThreadTests.swift in Sources */,
 				FA2D7EBC13B9CDAE43B9DAC0 /* SearchAPITests.swift in Sources */,
 				D3B0D1E46535FF84CB41BAB7 /* SecurityRegressionTests.swift in Sources */,
 				4D32AA19CAE1A40F2001E6D8 /* SessionExpirationMonitorTests.swift in Sources */,

--- a/TiebaPure/App/AppEnvironment.swift
+++ b/TiebaPure/App/AppEnvironment.swift
@@ -115,6 +115,13 @@ final class AppEnvironment: ObservableObject {
                 operation: "清空本机帖子记录"
             )
         }
+        if arguments.contains("UITEST_RESET_SAVED_THREADS") {
+            do {
+                try SavedThreadStore.shared.clear()
+            } catch {
+                assertionFailure("UI fixture 清空本地保存失败：\(error)")
+            }
+        }
         if arguments.contains("UITEST_RESET_BLOCKLIST") {
             BlocklistEntryKind.allCases.forEach {
                 BlocklistStore.shared.clear(kind: $0)

--- a/TiebaPure/Domain/Models/ContentBlock.swift
+++ b/TiebaPure/Domain/Models/ContentBlock.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ContentBlock: Equatable, Sendable {
+enum ContentBlock: Equatable, Codable, Sendable {
     case text(String)
     case link(title: String, url: URL?)
     case mention(userID: Int64?, text: String)
@@ -8,6 +8,83 @@ enum ContentBlock: Equatable, Sendable {
     case image(ImageContent)
     case video(VideoContent)
     case voice(VoiceContent)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case text
+        case title
+        case url
+        case userID
+        case code
+        case image
+        case video
+        case voice
+    }
+
+    private enum Kind: String, Codable {
+        case text
+        case link
+        case mention
+        case emoticon
+        case image
+        case video
+        case voice
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .text:
+            self = .text(try container.decode(String.self, forKey: .text))
+        case .link:
+            self = .link(
+                title: try container.decode(String.self, forKey: .title),
+                url: try container.decodeIfPresent(URL.self, forKey: .url)
+            )
+        case .mention:
+            self = .mention(
+                userID: try container.decodeIfPresent(Int64.self, forKey: .userID),
+                text: try container.decode(String.self, forKey: .text)
+            )
+        case .emoticon:
+            self = .emoticon(code: try container.decode(String.self, forKey: .code))
+        case .image:
+            self = .image(try container.decode(ImageContent.self, forKey: .image))
+        case .video:
+            self = .video(try container.decode(VideoContent.self, forKey: .video))
+        case .voice:
+            self = .voice(try container.decode(VoiceContent.self, forKey: .voice))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .text(text):
+            try container.encode(Kind.text, forKey: .kind)
+            try container.encode(text, forKey: .text)
+        case let .link(title, url):
+            try container.encode(Kind.link, forKey: .kind)
+            try container.encode(title, forKey: .title)
+            try container.encodeIfPresent(url, forKey: .url)
+        case let .mention(userID, text):
+            try container.encode(Kind.mention, forKey: .kind)
+            try container.encodeIfPresent(userID, forKey: .userID)
+            try container.encode(text, forKey: .text)
+        case let .emoticon(code):
+            try container.encode(Kind.emoticon, forKey: .kind)
+            try container.encode(code, forKey: .code)
+        case let .image(image):
+            try container.encode(Kind.image, forKey: .kind)
+            try container.encode(image, forKey: .image)
+        case let .video(video):
+            try container.encode(Kind.video, forKey: .kind)
+            try container.encode(video, forKey: .video)
+        case let .voice(voice):
+            try container.encode(Kind.voice, forKey: .kind)
+            try container.encode(voice, forKey: .voice)
+        }
+    }
 
     var plainText: String? {
         switch self {
@@ -27,7 +104,7 @@ enum ContentBlock: Equatable, Sendable {
     }
 }
 
-struct VoiceContent: Equatable, Sendable {
+struct VoiceContent: Equatable, Codable, Sendable {
     let md5: String
     let durationMilliseconds: Int
 
@@ -49,7 +126,7 @@ struct VoiceContent: Equatable, Sendable {
     }
 }
 
-struct ImageContent: Equatable, Sendable {
+struct ImageContent: Equatable, Codable, Sendable {
     var thumbnailURL: URL?
     var originalURL: URL?
     var width: Int
@@ -62,7 +139,7 @@ struct ImageContent: Equatable, Sendable {
     }
 }
 
-struct VideoContent: Equatable, Sendable {
+struct VideoContent: Equatable, Codable, Sendable {
     var videoURL: URL?
     var coverURL: URL?
     var webURL: URL?

--- a/TiebaPure/Domain/Models/Forum.swift
+++ b/TiebaPure/Domain/Models/Forum.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Forum: Identifiable, Equatable, Sendable {
+struct Forum: Identifiable, Equatable, Codable, Sendable {
     var id: Int64
     var name: String
     var displayName: String

--- a/TiebaPure/Domain/Models/Post.swift
+++ b/TiebaPure/Domain/Models/Post.swift
@@ -144,7 +144,7 @@ enum ThreadDescendingPaginationPolicy {
     }
 }
 
-struct Post: Identifiable, Equatable, Sendable {
+struct Post: Identifiable, Equatable, Codable, Sendable {
     var id: UInt64
     var threadID: Int64
     var floor: Int
@@ -162,7 +162,7 @@ struct Post: Identifiable, Equatable, Sendable {
     }
 }
 
-struct Subpost: Identifiable, Equatable, Sendable {
+struct Subpost: Identifiable, Equatable, Codable, Sendable {
     var id: UInt64
     var floor: Int
     var author: UserSummary

--- a/TiebaPure/Domain/Models/SavedThread.swift
+++ b/TiebaPure/Domain/Models/SavedThread.swift
@@ -1,0 +1,306 @@
+import Foundation
+
+struct SavedThreadPost: Identifiable, Equatable, Codable, Sendable {
+    var post: Post
+    var subposts: [Subpost]
+
+    var id: UInt64 { post.id }
+
+    var displayPost: Post {
+        var value = post
+        value.subpostCount = subposts.count
+        value.previewSubposts = Array(subposts.prefix(3))
+        return value
+    }
+}
+
+struct SavedThreadSnapshot: Identifiable, Equatable, Codable, Sendable {
+    static let currentFormatVersion = 1
+
+    var formatVersion: Int = currentFormatVersion
+    var thread: ThreadSummary
+    var forum: Forum
+    var posts: [SavedThreadPost]
+    var savedAt: Date
+
+    var id: Int64 { thread.id }
+    var mainPost: SavedThreadPost? { posts.first { $0.post.floor == 1 } }
+    var replyCount: Int { posts.reduce(0) { $0 + ($1.post.floor == 1 ? 0 : 1) } }
+    var subpostCount: Int { posts.reduce(0) { $0 + $1.subposts.count } }
+
+    func validated() throws -> SavedThreadSnapshot {
+        guard formatVersion == Self.currentFormatVersion else {
+            throw SavedThreadError.unsupportedFormat
+        }
+        guard thread.id > 0,
+              forum.id > 0,
+              let mainPost,
+              mainPost.post.id > 0,
+              mainPost.post.threadID == thread.id,
+              posts.allSatisfy({ $0.post.id > 0 && $0.post.threadID == thread.id }) else {
+            throw SavedThreadError.incompleteThread
+        }
+        let postIDs = posts.map(\.post.id)
+        guard Set(postIDs).count == postIDs.count else {
+            throw SavedThreadError.inconsistentPagination
+        }
+        return self
+    }
+}
+
+enum SavedThreadError: LocalizedError, Equatable {
+    case persistenceUnavailable
+    case incompleteThread
+    case inconsistentPagination
+    case tooManyPages
+    case unsupportedFormat
+
+    var errorDescription: String? {
+        switch self {
+        case .persistenceUnavailable:
+            return "本机保存空间暂不可用。"
+        case .incompleteThread:
+            return "没有拿到完整主楼，未写入本地保存。"
+        case .inconsistentPagination:
+            return "帖子分页在保存期间发生变化，请稍后重试。"
+        case .tooManyPages:
+            return "帖子页数超出本机保存上限。"
+        case .unsupportedFormat:
+            return "本地保存的数据版本无法读取。"
+        }
+    }
+}
+
+enum SavedThreadPolicy {
+    static let maximumSavedThreads = 100
+    static let maximumThreadPages = 10_000
+    static let maximumSubpostPages = 10_000
+    static let subpostPageSize = 10
+    static let maximumStorageByteCount = 128 * 1_024 * 1_024
+}
+
+@MainActor
+final class SavedThreadStore: ObservableObject {
+    static let shared = SavedThreadStore()
+
+    @Published private(set) var entries: [SavedThreadSnapshot] = []
+    @Published private(set) var persistenceError: String?
+
+    private var file: SecureCodableFile<[SavedThreadSnapshot]>?
+
+    init(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        do {
+            let location = try SecurePersistenceLocation.applicationSupport(
+                fileManager: fileManager,
+                baseDirectoryURL: baseDirectoryURL
+            )
+            let file = try SecureCodableFile<[SavedThreadSnapshot]>(
+                directoryURL: location.directoryURL,
+                fileName: "saved-threads.json",
+                fileManager: fileManager,
+                maximumByteCount: SavedThreadPolicy.maximumStorageByteCount
+            )
+            self.file = file
+            entries = try Self.normalized(file.load() ?? [])
+        } catch {
+            file = nil
+            persistenceError = error.localizedDescription
+        }
+    }
+
+    func contains(threadID: Int64) -> Bool {
+        entries.contains { $0.id == threadID }
+    }
+
+    func snapshot(threadID: Int64) -> SavedThreadSnapshot? {
+        entries.first { $0.id == threadID }
+    }
+
+    func save(_ snapshot: SavedThreadSnapshot) throws {
+        guard let file else { throw SavedThreadError.persistenceUnavailable }
+        let validated = try snapshot.validated()
+        entries = try file.update(default: []) { values in
+            values.removeAll { $0.id == validated.id }
+            values.insert(validated, at: 0)
+            values = Array(try Self.normalized(values).prefix(SavedThreadPolicy.maximumSavedThreads))
+        }
+        persistenceError = nil
+    }
+
+    func remove(threadID: Int64) throws {
+        guard let file else { throw SavedThreadError.persistenceUnavailable }
+        entries = try file.update(default: []) { values in
+            values.removeAll { $0.id == threadID }
+            values = try Self.normalized(values)
+        }
+        persistenceError = nil
+    }
+
+    func clear() throws {
+        guard let file else { throw SavedThreadError.persistenceUnavailable }
+        try file.replace([])
+        entries = []
+        persistenceError = nil
+    }
+
+    private static func normalized(_ values: [SavedThreadSnapshot]) throws -> [SavedThreadSnapshot] {
+        var knownIDs = Set<Int64>()
+        return try values
+            .map { try $0.validated() }
+            .sorted { $0.savedAt > $1.savedAt }
+            .filter { knownIDs.insert($0.id).inserted }
+    }
+}
+
+struct SavedThreadCaptureService {
+    let api: any TiebaAPIService
+
+    func capture(
+        account: Account?,
+        threadID: Int64,
+        forumID: Int64? = nil,
+        savedAt: Date = Date()
+    ) async throws -> SavedThreadSnapshot {
+        try Task.checkCancellation()
+        var firstPage = try await loadThreadPage(
+            account: account,
+            threadID: threadID,
+            page: 1,
+            forumID: forumID
+        )
+        if ThreadPageMainPostPolicy.mainPost(in: firstPage) == nil {
+            firstPage = try await loadThreadPage(
+                account: account,
+                threadID: threadID,
+                page: 1,
+                forumID: forumID
+            )
+        }
+        guard firstPage.thread.id == threadID,
+              firstPage.totalPage > 0,
+              firstPage.totalPage <= SavedThreadPolicy.maximumThreadPages,
+              let mainPost = ThreadPageMainPostPolicy.mainPost(in: firstPage),
+              mainPost.id > 0,
+              firstPage.forum.id > 0 else {
+            throw SavedThreadError.incompleteThread
+        }
+
+        var orderedPosts = [mainPost]
+        var knownPostIDs = Set([mainPost.id])
+        appendUnique(firstPage.posts, to: &orderedPosts, knownIDs: &knownPostIDs)
+
+        if firstPage.totalPage > 1 {
+            for pageNumber in 2...firstPage.totalPage {
+                try Task.checkCancellation()
+                let page = try await loadThreadPage(
+                    account: account,
+                    threadID: threadID,
+                    page: pageNumber,
+                    forumID: firstPage.forum.id
+                )
+                guard page.thread.id == threadID,
+                      page.currentPage == pageNumber,
+                      page.totalPage == firstPage.totalPage else {
+                    throw SavedThreadError.inconsistentPagination
+                }
+                appendUnique(page.posts, to: &orderedPosts, knownIDs: &knownPostIDs)
+            }
+        }
+
+        orderedPosts.sort {
+            if $0.floor == $1.floor { return $0.id < $1.id }
+            return $0.floor < $1.floor
+        }
+        guard orderedPosts.first?.id == mainPost.id else {
+            throw SavedThreadError.incompleteThread
+        }
+
+        var savedPosts: [SavedThreadPost] = []
+        savedPosts.reserveCapacity(orderedPosts.count)
+        for post in orderedPosts {
+            try Task.checkCancellation()
+            let subposts = try await loadAllSubposts(
+                account: account,
+                threadID: threadID,
+                forumID: firstPage.forum.id,
+                post: post
+            )
+            savedPosts.append(SavedThreadPost(post: post, subposts: subposts))
+        }
+
+        return try SavedThreadSnapshot(
+            thread: firstPage.thread,
+            forum: firstPage.forum,
+            posts: savedPosts,
+            savedAt: savedAt
+        ).validated()
+    }
+
+    private func loadThreadPage(
+        account: Account?,
+        threadID: Int64,
+        page: Int,
+        forumID: Int64?
+    ) async throws -> ThreadPage {
+        try await api.threadPage(
+            account: account,
+            threadID: threadID,
+            page: page,
+            forumID: forumID,
+            postID: nil,
+            seeLz: false,
+            sortType: .ascending
+        )
+    }
+
+    private func loadAllSubposts(
+        account: Account?,
+        threadID: Int64,
+        forumID: Int64,
+        post: Post
+    ) async throws -> [Subpost] {
+        guard post.subpostCount > 0 || post.previewSubposts.isEmpty == false else { return [] }
+        var result: [Subpost] = []
+        var knownIDs = Set<UInt64>()
+
+        for page in 1...SavedThreadPolicy.maximumSubpostPages {
+            try Task.checkCancellation()
+            let loaded = try await api.subposts(
+                account: account,
+                threadID: threadID,
+                postID: post.id,
+                forumID: forumID,
+                page: page,
+                subpostID: 0
+            )
+            let previousCount = result.count
+            appendUnique(loaded, to: &result, knownIDs: &knownIDs)
+            if loaded.count < SavedThreadPolicy.subpostPageSize {
+                guard result.count >= max(post.subpostCount, post.previewSubposts.count) else {
+                    throw SavedThreadError.incompleteThread
+                }
+                return result.sorted {
+                    if $0.floor == $1.floor { return $0.id < $1.id }
+                    return $0.floor < $1.floor
+                }
+            }
+            guard result.count > previousCount else {
+                throw SavedThreadError.inconsistentPagination
+            }
+        }
+        throw SavedThreadError.tooManyPages
+    }
+
+    private func appendUnique<Element: Identifiable>(
+        _ values: [Element],
+        to result: inout [Element],
+        knownIDs: inout Set<Element.ID>
+    ) where Element.ID: Hashable {
+        for value in values where knownIDs.insert(value.id).inserted {
+            result.append(value)
+        }
+    }
+}

--- a/TiebaPure/Domain/Models/ThreadSummary.swift
+++ b/TiebaPure/Domain/Models/ThreadSummary.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ThreadSummary: Identifiable, Equatable, Sendable {
+struct ThreadSummary: Identifiable, Equatable, Codable, Sendable {
     var id: Int64
     var forumID: Int64?
     var title: String
@@ -99,7 +99,7 @@ struct ThreadSummary: Identifiable, Equatable, Sendable {
     }
 }
 
-struct UserSummary: Identifiable, Equatable, Hashable, Sendable {
+struct UserSummary: Identifiable, Equatable, Hashable, Codable, Sendable {
     var id: Int64
     var name: String
     var displayName: String

--- a/TiebaPure/Features/Settings/SavedThreadsView.swift
+++ b/TiebaPure/Features/Settings/SavedThreadsView.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+
+struct SavedThreadsView: View {
+    @ObservedObject private var store = SavedThreadStore.shared
+    @State private var searchText = ""
+    @State private var errorMessage: String?
+
+    private var visibleEntries: [SavedThreadSnapshot] {
+        let keyword = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard keyword.isEmpty == false else { return store.entries }
+        return store.entries.filter {
+            $0.thread.title.localizedCaseInsensitiveContains(keyword)
+                || $0.thread.author.displayNameResolved.localizedCaseInsensitiveContains(keyword)
+                || $0.forum.displayName.localizedCaseInsensitiveContains(keyword)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if store.entries.isEmpty {
+                ReaderStateView.empty(
+                    title: "还没有本地保存",
+                    message: "在帖子页右上角的更多菜单中选择“保存到本地”。"
+                )
+            } else if visibleEntries.isEmpty {
+                ReaderStateView.empty(
+                    title: "没有匹配的帖子",
+                    message: "换个标题、作者或贴吧名称搜索。"
+                )
+            } else {
+                List {
+                    Section {
+                        ForEach(visibleEntries) { snapshot in
+                            NavigationLink {
+                                SavedThreadDetailView(snapshot: snapshot)
+                            } label: {
+                                SavedThreadRow(snapshot: snapshot)
+                            }
+                            .accessibilityIdentifier("saved-thread-\(snapshot.id)")
+                            .swipeActions(edge: .trailing) {
+                                Button("删除", role: .destructive) {
+                                    remove(snapshot.id)
+                                }
+                            }
+                        }
+                    } footer: {
+                        Text("正文和楼层结构保存在本机；图片、视频和语音仍需通过保存时的原地址联网加载。最多保存\(SavedThreadPolicy.maximumSavedThreads)个帖子。")
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle("本地保存的帖子")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $searchText, prompt: "搜索标题、作者或贴吧")
+        .alert("无法删除", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if $0 == false { errorMessage = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .fullScreenInteractiveNavigationPop()
+    }
+
+    private func remove(_ threadID: Int64) {
+        do {
+            try store.remove(threadID: threadID)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct SavedThreadRow: View {
+    let snapshot: SavedThreadSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xs) {
+            Text(snapshot.thread.title.isEmpty ? snapshot.thread.textPreview : snapshot.thread.title)
+                .font(.body.weight(.semibold))
+                .lineLimit(2)
+            Text("\(snapshot.forum.displayName) · \(snapshot.thread.author.displayNameResolved)")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text("\(snapshot.replyCount)层回复 · \(snapshot.subpostCount)条楼中楼 · \(snapshot.savedAt.formatted(date: .abbreviated, time: .shortened))")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+        .padding(.vertical, TiebaPureTheme.Spacing.xxs)
+    }
+}
+
+struct SavedThreadDetailView: View {
+    let snapshot: SavedThreadSnapshot
+    @State private var selectedPost: SavedThreadPost?
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                Label(
+                    "保存于 \(snapshot.savedAt.formatted(date: .abbreviated, time: .shortened))；媒体需联网加载",
+                    systemImage: "internaldrive"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                .padding(.vertical, TiebaPureTheme.Spacing.sm)
+
+                ForEach(snapshot.posts) { savedPost in
+                    VStack(spacing: 0) {
+                        PostRowView(
+                            post: savedPost.displayPost,
+                            threadTitle: savedPost.post.floor == 1 ? snapshot.thread.title : nil,
+                            threadAuthorID: snapshot.thread.author.id,
+                            isMainPost: savedPost.post.floor == 1
+                        )
+                        .equatable()
+
+                        if savedPost.subposts.isEmpty == false {
+                            Button {
+                                selectedPost = savedPost
+                            } label: {
+                                HStack(spacing: TiebaPureTheme.Spacing.xxs) {
+                                    Text("查看已保存的\(savedPost.subposts.count)条楼中楼")
+                                    Image(systemName: "chevron.right")
+                                }
+                                .font(.footnote.weight(.medium))
+                                .foregroundStyle(TiebaPureTheme.ColorToken.primaryAccent)
+                                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                                .padding(.horizontal, TiebaPureTheme.Spacing.md)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("saved-thread-subposts-\(savedPost.id)")
+                        }
+                    }
+                }
+            }
+            .readableWidth()
+        }
+        .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+        .navigationTitle(snapshot.forum.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ShareLink(item: threadURL) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel("分享帖子")
+            }
+        }
+        .sheet(item: $selectedPost) { savedPost in
+            SavedSubpostsView(
+                post: savedPost.post,
+                subposts: savedPost.subposts,
+                threadAuthorID: snapshot.thread.author.id
+            )
+        }
+        .fullScreenInteractiveNavigationPop()
+    }
+
+    private var threadURL: URL {
+        URL(string: "https://tieba.baidu.com/p/\(snapshot.id)")!
+    }
+}
+
+private struct SavedSubpostsView: View {
+    @Environment(\.dismiss) private var dismiss
+    let post: Post
+    let subposts: [Subpost]
+    let threadAuthorID: Int64?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(subposts) { subpost in
+                        SavedSubpostRow(subpost: subpost, threadAuthorID: threadAuthorID)
+                    }
+                }
+                .readableWidth()
+            }
+            .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+            .navigationTitle(SubpostSheetTitle.text(floor: post.floor, count: subposts.count))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("完成") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+private struct SavedSubpostRow: View {
+    @Environment(\.readingPreferences) private var readingPreferences
+    let subpost: Subpost
+    let threadAuthorID: Int64?
+
+    var body: some View {
+        ReaderCard(contentBottomPadding: ThreadPostMetadataPlacement.standaloneReply.cardBottomPadding) {
+            VStack(alignment: .leading, spacing: ThreadReplyLayout.headerContentSpacing) {
+                UserHeaderView(
+                    author: subpost.author,
+                    floor: subpost.floor,
+                    isThreadAuthor: threadAuthorID != 0 && subpost.author.id == threadAuthorID,
+                    nameTone: .secondary,
+                    trailingLikeCount: subpost.likeCount,
+                    isLiked: subpost.isLiked
+                )
+                VStack(alignment: .leading, spacing: ThreadReplyLayout.bodyStackSpacing) {
+                    ContentBlocksView(
+                        blocks: subpost.blocks,
+                        textStyle: .reply,
+                        readerFontSize: readingPreferences.fontSize,
+                        readerLineSpacing: readingPreferences.lineSpacing
+                    )
+                    ThreadPostMetadataView(
+                        createdAt: subpost.createdAt,
+                        ipAddress: ThreadPostMetadataText.firstLocation(
+                            subpost.ipAddress,
+                            subpost.author.ipAddress
+                        ),
+                        accessibilityIdentifier: "saved-thread-subpost-metadata"
+                    )
+                }
+                .padding(.leading, ThreadReplyLayout.bodyLeadingInset)
+            }
+        }
+    }
+}

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -74,6 +74,14 @@ struct SettingsView: View {
                 .accessibilityIdentifier("settings-reading-entry")
 
                 NavigationLink {
+                    SavedThreadsView()
+                } label: {
+                    Label("本地保存的帖子", systemImage: "internaldrive")
+                }
+                .accessibilityHint("查看和管理保存在这台设备上的完整帖子快照")
+                .accessibilityIdentifier("settings-saved-threads-entry")
+
+                NavigationLink {
                     BlocklistSettingsView()
                 } label: {
                     Label("屏蔽设置", systemImage: "hand.raised")

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -9,6 +9,7 @@ struct ThreadDetailView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.readingPreferences) private var readingPreferences
     private let localThreadLibraryStore = LocalThreadLibraryStore.shared
+    @ObservedObject private var savedThreadStore = SavedThreadStore.shared
     @ObservedObject private var blocklistStore = BlocklistStore.shared
     let account: Account?
     let threadID: Int64
@@ -88,6 +89,9 @@ struct ThreadDetailView: View {
     @State private var ownThreadDeletionNotice: OwnThreadDeletionNotice?
     @State private var isPageVisible = false
     @State private var dismissAfterOwnThreadDeletionWhenVisible = false
+    @State private var isSavingLocally = false
+    @State private var localSaveTask: Task<Void, Never>?
+    @State private var localSaveMessage: String?
 
     init(
         account: Account?,
@@ -211,6 +215,14 @@ struct ThreadDetailView: View {
             Button("好", role: .cancel) { accountFavoriteError = nil }
         } message: {
             Text(accountFavoriteError ?? "")
+        }
+        .alert("本地保存", isPresented: Binding(
+            get: { localSaveMessage != nil },
+            set: { if $0 == false { localSaveMessage = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(localSaveMessage ?? "")
         }
         .alert("提示", isPresented: likeActionErrorIsPresented) {
                 Button("好", role: .cancel) { likeActionError = nil }
@@ -349,6 +361,9 @@ struct ThreadDetailView: View {
     private func resetForAccountChange() {
         cancelAccountFavoritePresentation()
         cancelContentNavigation()
+        localSaveTask?.cancel()
+        localSaveTask = nil
+        isSavingLocally = false
         loadTask?.cancel()
         requestGeneration += 1
         threadPage = nil
@@ -442,6 +457,9 @@ struct ThreadDetailView: View {
             )
         }
         cancelContentNavigation()
+        localSaveTask?.cancel()
+        localSaveTask = nil
+        isSavingLocally = false
         loadTask?.cancel()
         requestGeneration += 1
         isLoading = false
@@ -744,6 +762,14 @@ struct ThreadDetailView: View {
             Button(action: requestMenuRefresh) {
                 Label("刷新", systemImage: "arrow.clockwise")
             }
+            Button(action: startLocalSave) {
+                Label(
+                    savedThreadStore.contains(threadID: threadID) ? "更新本地保存" : "保存到本地",
+                    systemImage: "arrow.down.doc"
+                )
+            }
+            .disabled(threadPage == nil || isSavingLocally)
+            .accessibilityIdentifier("thread-save-locally")
             Button(action: copyThreadLink) {
                 Label("复制链接", systemImage: "doc.on.doc")
             }
@@ -770,7 +796,7 @@ struct ThreadDetailView: View {
                     .foregroundStyle(.secondary)
             }
         } label: {
-            if isDeletingOwnThread {
+            if isDeletingOwnThread || isSavingLocally {
                 ProgressView()
                     .controlSize(.small)
             } else {
@@ -778,7 +804,9 @@ struct ThreadDetailView: View {
             }
         }
         .disabled(isDeletingOwnThread)
-        .accessibilityLabel(isDeletingOwnThread ? "正在删除帖子" : "更多")
+        .accessibilityLabel(
+            isDeletingOwnThread ? "正在删除帖子" : (isSavingLocally ? "正在保存帖子" : "更多")
+        )
     }
 
     private func openThreadSearch() {
@@ -804,6 +832,33 @@ struct ThreadDetailView: View {
 
     private func openThreadInBrowser() {
         openURL(threadWebURL)
+    }
+
+    private func startLocalSave() {
+        guard isSavingLocally == false, threadPage != nil else { return }
+        localSaveTask?.cancel()
+        isSavingLocally = true
+        let capture = SavedThreadCaptureService(api: environment.api)
+        localSaveTask = Task { @MainActor in
+            defer {
+                isSavingLocally = false
+                localSaveTask = nil
+            }
+            do {
+                let snapshot = try await capture.capture(
+                    account: account,
+                    threadID: threadID,
+                    forumID: forumID
+                )
+                try Task.checkCancellation()
+                try savedThreadStore.save(snapshot)
+                localSaveMessage = "已保存主楼、\(snapshot.replyCount)层回复和\(snapshot.subpostCount)条楼中楼。媒体仍需联网加载。"
+            } catch is CancellationError {
+                return
+            } catch {
+                localSaveMessage = error.localizedDescription
+            }
+        }
     }
 
     @MainActor

--- a/TiebaPureTests/SavedThreadTests.swift
+++ b/TiebaPureTests/SavedThreadTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import TiebaPure
+
+@MainActor
+final class SavedThreadTests: XCTestCase {
+    func testCaptureIncludesMainPostRepliesAndAllSubposts() async throws {
+        let snapshot = try await SavedThreadCaptureService(api: FixtureTiebaAPI()).capture(
+            account: nil,
+            threadID: FixtureTiebaAPI.threads[0].id,
+            forumID: FixtureTiebaAPI.forum.id,
+            savedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(snapshot.mainPost?.post.id, 2_001)
+        XCTAssertEqual(snapshot.posts.map(\.post.id), [2_001, 2_002])
+        XCTAssertEqual(snapshot.replyCount, 1)
+        XCTAssertEqual(snapshot.posts.first { $0.id == 2_002 }?.subposts.map(\.id), [3_001, 3_002])
+        XCTAssertEqual(snapshot.subpostCount, 2)
+    }
+
+    func testStoreRoundTripsAndUpdatesExistingThreadAtomically() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+
+        let original = try await SavedThreadCaptureService(api: FixtureTiebaAPI()).capture(
+            account: nil,
+            threadID: FixtureTiebaAPI.threads[0].id,
+            forumID: FixtureTiebaAPI.forum.id,
+            savedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        let store = SavedThreadStore(baseDirectoryURL: directory)
+        try store.save(original)
+
+        let reopened = SavedThreadStore(baseDirectoryURL: directory)
+        XCTAssertEqual(reopened.entries, [original])
+
+        var updated = original
+        updated.savedAt = Date(timeIntervalSince1970: 1_800_000_100)
+        updated.thread.title = "更新后的本地标题"
+        try reopened.save(updated)
+
+        let updatedStore = SavedThreadStore(baseDirectoryURL: directory)
+        XCTAssertEqual(updatedStore.entries.count, 1)
+        XCTAssertEqual(updatedStore.entries.first?.thread.title, "更新后的本地标题")
+        XCTAssertEqual(updatedStore.entries.first?.savedAt, updated.savedAt)
+    }
+
+    func testIncompleteMainPostDoesNotProduceSnapshot() async {
+        do {
+            _ = try await SavedThreadCaptureService(api: FixtureTiebaAPI(scenario: .missingMain)).capture(
+                account: nil,
+                threadID: FixtureTiebaAPI.threads[0].id,
+                forumID: FixtureTiebaAPI.forum.id
+            )
+            XCTFail("Expected incomplete thread failure")
+        } catch let error as SavedThreadError {
+            XCTAssertEqual(error, .incompleteThread)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -49,6 +49,43 @@ final class TiebaPureUITests: XCTestCase {
         )
     }
 
+    func testThreadCanBeSavedAndOpenedFromSettings() {
+        let app = launchApp(additionalArguments: ["UITEST_RESET_SAVED_THREADS"])
+        openFirstThread(in: app)
+
+        let more = app.buttons["更多"]
+        XCTAssertTrue(more.waitForExistence(timeout: 8))
+        more.tap()
+        let save = app.buttons["保存到本地"]
+        XCTAssertTrue(save.waitForExistence(timeout: 5))
+        save.tap()
+
+        XCTAssertTrue(app.alerts["本地保存"].waitForExistence(timeout: 12))
+        XCTAssertTrue(app.alerts["本地保存"].staticTexts.element(boundBy: 1).label.contains("已保存主楼"))
+        app.alerts["本地保存"].buttons["好"].tap()
+
+        let back = app.navigationBars.buttons.firstMatch
+        XCTAssertTrue(back.waitForExistence(timeout: 5))
+        back.tap()
+        let me = rootTab("我的", in: app)
+        XCTAssertTrue(me.waitForExistence(timeout: 5))
+        me.tap()
+
+        let settingsEntry = app.descendants(matching: .any)["app-settings-entry"]
+        XCTAssertTrue(revealBySwipingUp(settingsEntry, in: app, maxSwipes: 8))
+        settingsEntry.tap()
+        let savedEntry = app.buttons["settings-saved-threads-entry"]
+        XCTAssertTrue(savedEntry.waitForExistence(timeout: 5))
+        savedEntry.tap()
+
+        XCTAssertTrue(app.navigationBars["本地保存的帖子"].waitForExistence(timeout: 5))
+        let savedThread = app.descendants(matching: .any)["saved-thread-1001"]
+        XCTAssertTrue(savedThread.waitForExistence(timeout: 5))
+        savedThread.tap()
+        XCTAssertTrue(app.staticTexts["确定性主帖：回复筛选与媒体布局"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "媒体需联网加载")).firstMatch.exists)
+    }
+
     func testThreadMainPostBlocklistShowsExplicitBlockedStateInsteadOfReplies() {
         let app = launchApp(
             additionalArguments: ["UITEST_SEED_MAIN_POST_BLOCKLIST"]


### PR DESCRIPTION
## Summary
- save the main post, every reply page, and all nested replies as one validated local snapshot
- add save/update actions in the thread menu plus a searchable saved-thread list in Settings
- render saved text and floor structure offline while clearly marking media URLs as network-dependent

## Validation
- full offline unit suite on iOS 26.5
- SavedThreadTests on iOS 16.4
- save -> Settings -> offline detail UI flow on iOS 16.4

Snapshots are written only after every requested page succeeds; incomplete captures do not replace an existing save.