### PR TITLE
fix: resolve iOS freezes and expand offline library

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B1C2D3E4F5061728394A5B6C /* SavedThreadMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* SavedThreadMedia.swift */; };
 		03BFC1CB27519F2A9851619C /* ContentDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1C1C285AED2131947564A /* ContentDraft.swift */; };
 		043AF9BB1E2EF30D61B1DC63 /* SwiftDataOrderedCollectionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67285F50B29BA765B74B5271 /* SwiftDataOrderedCollectionPersistence.swift */; };
 		06132F36C724DF5F6A7409D5 /* ThreadDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1626D4B0DD88E88576EBC2EB /* ThreadDetailView.swift */; };
@@ -258,6 +259,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A1B2C3D4E5F60718293A4B5C /* SavedThreadMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedThreadMedia.swift; sourceTree = "<group>"; };
 		00339148CB9511CB5F6A624F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0060EA54C03E209E46FB2C40 /* ForumThreadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumThreadsView.swift; sourceTree = "<group>"; };
 		00A0FAAA54B2D05276E46330 /* SessionExpirationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExpirationMonitorTests.swift; sourceTree = "<group>"; };
@@ -637,6 +639,7 @@
 				638DEF254549D0D4DE625487 /* ReadingPreferences.swift */,
 				FDE02417BF13C2E0A1D7824E /* RecentForum.swift */,
 				0DB03A9A81B77E7ECBD00B30 /* SavedThread.swift */,
+				A1B2C3D4E5F60718293A4B5C /* SavedThreadMedia.swift */,
 				24D4BAC59CD64A3B8F236258 /* SearchHistory.swift */,
 				16DDB351392A69BC42810B9E /* SearchResult.swift */,
 				6BBA032F531024778CFC5C0A /* SecureFilePersistence.swift */,
@@ -1219,6 +1222,7 @@
 				A4FCD6601BAA005BF0F264D0 /* RootView.swift in Sources */,
 				C02D20CEC3FEDED464983D96 /* SafariActionPayload.swift in Sources */,
 				1E84B72ACDF13678A6BE6CB8 /* SavedThread.swift in Sources */,
+				B1C2D3E4F5061728394A5B6C /* SavedThreadMedia.swift in Sources */,
 				985218E469AF18B5378E8549 /* SavedThreadsView.swift in Sources */,
 				CAA7C941E2D8AAA65B342CBA /* SearchHistory.swift in Sources */,
 				8028A9708BDE36C7BB815CEF /* SearchResult.swift in Sources */,

--- a/TiebaPure/App/RootView.swift
+++ b/TiebaPure/App/RootView.swift
@@ -431,24 +431,18 @@ private struct TabSelectionObserver: UIViewControllerRepresentable {
             visited: inout Set<ObjectIdentifier>
         ) -> UITabBarController? {
             guard let controller else { return nil }
-
-            let identifier = ObjectIdentifier(controller)
-            guard visited.insert(identifier).inserted else { return nil }
-
+            guard visited.insert(ObjectIdentifier(controller)).inserted else { return nil }
             if let tabBarController = controller as? UITabBarController {
                 return tabBarController
             }
-
             if let found = findTabBarController(from: controller.presentedViewController, visited: &visited) {
                 return found
             }
-
             for child in controller.children {
                 if let found = findTabBarController(from: child, visited: &visited) {
                     return found
                 }
             }
-
             return nil
         }
     }
@@ -467,9 +461,7 @@ private struct TabSelectionObserver: UIViewControllerRepresentable {
                 return
             }
             detach()
-            if tabBarController.delegate !== self {
-                previousDelegate = tabBarController.delegate
-            }
+            previousDelegate = tabBarController.delegate
             observedController = tabBarController
             tabBarController.delegate = self
         }
@@ -495,9 +487,7 @@ private struct TabSelectionObserver: UIViewControllerRepresentable {
             if tabBarController.selectedViewController === viewController,
                tabBarController.viewControllers?.first === viewController {
                 let callback = onReselectHome
-                DispatchQueue.main.async {
-                    callback()
-                }
+                DispatchQueue.main.async(execute: callback)
             }
             return true
         }

--- a/TiebaPure/App/TiebaPureApp.swift
+++ b/TiebaPure/App/TiebaPureApp.swift
@@ -6,6 +6,7 @@ struct TiebaPureApp: App {
     @StateObject private var environment = AppEnvironment.live()
     @StateObject private var appearanceStore = AppAppearanceStore.live()
     @StateObject private var readingPreferencesStore = ReadingPreferencesStore.live()
+    @StateObject private var readerFontStore = ReaderFontStore.shared
 
     var body: some Scene {
         WindowGroup {
@@ -30,8 +31,13 @@ struct TiebaPureApp: App {
             .environmentObject(environment.forumSignCoordinator)
             .environmentObject(appearanceStore)
             .environmentObject(readingPreferencesStore)
+            .environmentObject(readerFontStore)
             .environment(\.readingPreferences, readingPreferencesStore.preferences)
             .preferredColorScheme(appearanceStore.selection.preferredColorScheme)
+            .task(id: readerFontStore.isReady) {
+                guard readerFontStore.isReady else { return }
+                readingPreferencesStore.reconcileAvailableImportedFonts(readerFontStore.entries)
+            }
         }
     }
 }

--- a/TiebaPure/Core/UI/AvatarView.swift
+++ b/TiebaPure/Core/UI/AvatarView.swift
@@ -47,10 +47,15 @@ enum TiebaImageSourcePolicy {
     static func urls(primary: URL?, fallback: URL? = nil) -> [URL] {
         var result: [URL] = []
         for candidate in [primary, fallback].compactMap({ $0 }) {
-            guard let safeURL = TiebaURL.image(candidate.absoluteString),
-                  result.contains(safeURL) == false else {
+            let safeURL: URL
+            if SavedThreadMediaAuthorization.shared.allows(candidate) {
+                safeURL = candidate
+            } else if let validated = TiebaURL.image(candidate.absoluteString) {
+                safeURL = validated
+            } else {
                 continue
             }
+            guard result.contains(safeURL) == false else { continue }
             result.append(safeURL)
         }
         return result
@@ -271,8 +276,13 @@ actor TiebaImagePipeline {
     ) async throws -> UIImage {
         // Download the validated URL, not the caller's: validation may have
         // upgraded a legacy http source to https.
-        guard let safeURL = TiebaURL.image(url.absoluteString),
-              redirectScope.allows(safeURL) || Self.isSyntheticFixtureURL(safeURL) else {
+        let safeURL: URL
+        if SavedThreadMediaAuthorization.shared.allows(url) {
+            safeURL = url
+        } else if let validated = TiebaURL.image(url.absoluteString),
+                  redirectScope.allows(validated) || Self.isSyntheticFixtureURL(validated) {
+            safeURL = validated
+        } else {
             throw TiebaImagePipelineError.invalidURL
         }
         guard TiebaImageSourcePolicy.isSyntheticFailureURL(url) == false else {
@@ -386,7 +396,7 @@ actor TiebaImagePipeline {
             } catch {
                 result = .failure(error)
             }
-            await self.completeSharedRequest(
+            self.completeSharedRequest(
                 request,
                 operationID: operationID,
                 result: result
@@ -445,6 +455,25 @@ actor TiebaImagePipeline {
         session: URLSession,
         onProgress: (@Sendable (BoundedURLSessionProgress) async -> Void)?
     ) async throws -> UIImage {
+        if request.url.isFileURL {
+            guard SavedThreadMediaAuthorization.shared.allows(request.url) else {
+                throw TiebaImagePipelineError.invalidURL
+            }
+            let data = try Data(contentsOf: request.url, options: [.mappedIfSafe, .uncached])
+            guard data.isEmpty == false,
+                  data.count <= maximumImageBytes,
+                  let image = decodedImage(
+                    from: data,
+                    targetPixelSize: request.targetPixelSize
+                  ) else {
+                throw TiebaImagePipelineError.invalidImageData
+            }
+            await onProgress?(BoundedURLSessionProgress(
+                receivedBytes: data.count,
+                expectedBytes: data.count
+            ))
+            return image
+        }
         var attempt = 0
         while true {
             do {

--- a/TiebaPure/Core/UI/InteractiveNavigationPop.swift
+++ b/TiebaPure/Core/UI/InteractiveNavigationPop.swift
@@ -42,7 +42,12 @@ enum NativeEdgePopGestureActivationPolicy {
 
 enum NavigationPopGestureControlHostingPolicy {
     static func requiresController(systemMajorVersion: Int, isEnabled: Bool) -> Bool {
-        isEnabled == false || systemMajorVersion < 26
+        _ = systemMajorVersion
+        // A normal NavigationStack must keep complete ownership of its native
+        // recognizers. Hosting a controller merely to force-enable the edge
+        // recognizer raced SwiftUI's push transition on iOS 16-18, especially
+        // when two navigation stacks were visible in an iPad split view.
+        return isEnabled == false
     }
 }
 
@@ -171,7 +176,7 @@ private struct NativeNavigationPopGestureControl: UIViewControllerRepresentable 
         private func applyRequestedState() {
             guard requestedEnabled == false else {
                 restorePopGesturesIfNeeded()
-                enableNativeEdgePopIfNeeded()
+                updateDiagnostics(using: navigationController)
                 return
             }
             guard let navigationController else { return }

--- a/TiebaPure/Domain/Models/ContentBlock.swift
+++ b/TiebaPure/Domain/Models/ContentBlock.swift
@@ -107,8 +107,15 @@ enum ContentBlock: Equatable, Codable, Sendable {
 struct VoiceContent: Equatable, Codable, Sendable {
     let md5: String
     let durationMilliseconds: Int
+    var localURL: URL?
+    var offlineOnly: Bool?
 
-    init?(md5: String, durationMilliseconds: Int) {
+    init?(
+        md5: String,
+        durationMilliseconds: Int,
+        localURL: URL? = nil,
+        offlineOnly: Bool? = nil
+    ) {
         let normalizedMD5 = md5
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
@@ -119,6 +126,8 @@ struct VoiceContent: Equatable, Codable, Sendable {
 
         self.md5 = normalizedMD5
         self.durationMilliseconds = max(durationMilliseconds, 0)
+        self.localURL = localURL
+        self.offlineOnly = offlineOnly
     }
 
     private static func isLowercaseHexDigit(_ byte: UInt8) -> Bool {

--- a/TiebaPure/Domain/Models/ReadingPreferences.swift
+++ b/TiebaPure/Domain/Models/ReadingPreferences.swift
@@ -1,3 +1,5 @@
+import CoreGraphics
+import CoreText
 import Foundation
 import SwiftUI
 import UIKit
@@ -47,6 +49,80 @@ enum ReaderFontSize: String, CaseIterable, Identifiable, Sendable {
         case .extraLarge:
             return 1.25
         }
+    }
+}
+
+struct ReaderFontFamily: RawRepresentable, Equatable, Hashable, Identifiable, Sendable {
+    static let system = ReaderFontFamily(validatedRawValue: "system")
+    static let serif = ReaderFontFamily(validatedRawValue: "serif")
+    static let rounded = ReaderFontFamily(validatedRawValue: "rounded")
+    static let monospaced = ReaderFontFamily(validatedRawValue: "monospaced")
+    static let builtInChoices = [system, serif, rounded, monospaced]
+
+    let rawValue: String
+    var id: String { rawValue }
+
+    init?(rawValue: String) {
+        if Self.builtInRawValues.contains(rawValue) {
+            self.rawValue = rawValue
+            return
+        }
+        guard rawValue.hasPrefix(Self.importedPrefix),
+              let postScriptName = Self.normalizedImportedPostScriptName(
+                String(rawValue.dropFirst(Self.importedPrefix.count))
+              ),
+              rawValue == Self.importedPrefix + postScriptName else {
+            return nil
+        }
+        self.rawValue = rawValue
+    }
+
+    static func imported(postScriptName: String) -> ReaderFontFamily? {
+        guard let normalized = normalizedImportedPostScriptName(postScriptName) else { return nil }
+        return ReaderFontFamily(validatedRawValue: importedPrefix + normalized)
+    }
+
+    var importedPostScriptName: String? {
+        guard rawValue.hasPrefix(Self.importedPrefix) else { return nil }
+        return String(rawValue.dropFirst(Self.importedPrefix.count))
+    }
+
+    var title: String {
+        switch self {
+        case .system: return "系统默认"
+        case .serif: return "衬线"
+        case .rounded: return "圆体"
+        case .monospaced: return "等宽"
+        default: return importedPostScriptName ?? "自定义字体"
+        }
+    }
+
+    fileprivate var systemDesign: UIFontDescriptor.SystemDesign? {
+        switch self {
+        case .serif: return .serif
+        case .rounded: return .rounded
+        case .monospaced: return .monospaced
+        default: return nil
+        }
+    }
+
+    private init(validatedRawValue: String) {
+        rawValue = validatedRawValue
+    }
+
+    private static let importedPrefix = "imported:"
+    private static let builtInRawValues: Set<String> = ["system", "serif", "rounded", "monospaced"]
+
+    private static func normalizedImportedPostScriptName(_ value: String) -> String? {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.isEmpty == false,
+              normalized.utf8.count <= 512,
+              normalized.unicodeScalars.allSatisfy({
+                  CharacterSet.controlCharacters.contains($0) == false
+              }) else {
+            return nil
+        }
+        return normalized
     }
 }
 
@@ -112,12 +188,14 @@ enum ReaderMediaLoadingPolicy: String, CaseIterable, Identifiable, Sendable {
 
 struct ReadingPreferences: Equatable, Sendable {
     var fontSize: ReaderFontSize
+    var fontFamily: ReaderFontFamily = .system
     var lineSpacing: ReaderLineSpacing
     var defaultReplySort: ThreadReplySort
     var mediaLoading: ReaderMediaLoadingPolicy
 
     static let `default` = ReadingPreferences(
         fontSize: .standard,
+        fontFamily: .system,
         lineSpacing: .standard,
         defaultReplySort: .hot,
         mediaLoading: .automatic
@@ -134,6 +212,7 @@ enum ReaderTypographyPolicy {
         textStyle: UIFont.TextStyle,
         weight: UIFont.Weight = .regular,
         fontSize: ReaderFontSize,
+        fontFamily: ReaderFontFamily = .system,
         compatibleWith traitCollection: UITraitCollection? = nil
     ) -> UIFont {
         let referenceTraits = UITraitCollection(preferredContentSizeCategory: .large)
@@ -141,13 +220,22 @@ enum ReaderTypographyPolicy {
             forTextStyle: textStyle,
             compatibleWith: referenceTraits
         )
-        let descriptor = referenceFont.fontDescriptor.addingAttributes([
-            .traits: [UIFontDescriptor.TraitKey.weight: weight]
-        ])
-        let preferredFont = UIFont(
-            descriptor: descriptor,
-            size: referenceFont.pointSize * fontSize.scale
-        )
+        let pointSize = referenceFont.pointSize * fontSize.scale
+        let preferredFont: UIFont
+        if let postScriptName = fontFamily.importedPostScriptName,
+           let imported = UIFont(name: postScriptName, size: pointSize) {
+            let weightedDescriptor = imported.fontDescriptor.addingAttributes([
+                .traits: [UIFontDescriptor.TraitKey.weight: weight]
+            ])
+            preferredFont = UIFont(descriptor: weightedDescriptor, size: pointSize)
+        } else {
+            let weightedDescriptor = referenceFont.fontDescriptor.addingAttributes([
+                .traits: [UIFontDescriptor.TraitKey.weight: weight]
+            ])
+            let designedDescriptor = fontFamily.systemDesign
+                .flatMap { weightedDescriptor.withDesign($0) } ?? weightedDescriptor
+            preferredFont = UIFont(descriptor: designedDescriptor, size: pointSize)
+        }
         return UIFontMetrics(forTextStyle: textStyle).scaledFont(
             for: preferredFont,
             compatibleWith: traitCollection
@@ -244,12 +332,14 @@ enum ThreadInitialReplySortPolicy {
 final class ReadingPreferencesStore: ObservableObject {
     struct StorageKeys: Equatable, Sendable {
         var fontSize: String
+        var fontFamily: String = "dev.infinityf4p.tiebapure.reader.font-family"
         var lineSpacing: String
         var defaultReplySort: String
         var mediaLoading: String
 
         static let live = StorageKeys(
             fontSize: "dev.infinityf4p.tiebapure.reader.font-size",
+            fontFamily: "dev.infinityf4p.tiebapure.reader.font-family",
             lineSpacing: "dev.infinityf4p.tiebapure.reader.line-spacing",
             defaultReplySort: "dev.infinityf4p.tiebapure.reader.default-reply-sort",
             mediaLoading: "dev.infinityf4p.tiebapure.reader.media-loading"
@@ -277,6 +367,12 @@ final class ReadingPreferencesStore: ObservableObject {
             defaults: defaults,
             key: keys.lineSpacing
         )
+        let fontFamily = Self.readStringValue(
+            ReaderFontFamily.self,
+            defaultValue: ReadingPreferences.default.fontFamily,
+            defaults: defaults,
+            key: keys.fontFamily
+        )
         let defaultReplySort = Self.readReplySort(defaults: defaults, key: keys.defaultReplySort)
         let mediaLoading = Self.readStringValue(
             ReaderMediaLoadingPolicy.self,
@@ -286,6 +382,7 @@ final class ReadingPreferencesStore: ObservableObject {
         )
         preferences = ReadingPreferences(
             fontSize: fontSize,
+            fontFamily: fontFamily,
             lineSpacing: lineSpacing,
             defaultReplySort: defaultReplySort,
             mediaLoading: mediaLoading
@@ -294,6 +391,7 @@ final class ReadingPreferencesStore: ObservableObject {
 
     func update(_ preferences: ReadingPreferences) {
         persist(preferences.fontSize, defaultValue: ReadingPreferences.default.fontSize, key: keys.fontSize)
+        persist(preferences.fontFamily, defaultValue: ReadingPreferences.default.fontFamily, key: keys.fontFamily)
         persist(preferences.lineSpacing, defaultValue: ReadingPreferences.default.lineSpacing, key: keys.lineSpacing)
         persist(preferences.defaultReplySort, defaultValue: ReadingPreferences.default.defaultReplySort, key: keys.defaultReplySort)
         persist(preferences.mediaLoading, defaultValue: ReadingPreferences.default.mediaLoading, key: keys.mediaLoading)
@@ -306,6 +404,23 @@ final class ReadingPreferencesStore: ObservableObject {
         updated.fontSize = fontSize
         persist(fontSize, defaultValue: ReadingPreferences.default.fontSize, key: keys.fontSize)
         preferences = updated
+    }
+
+    func select(fontFamily: ReaderFontFamily) {
+        guard preferences.fontFamily != fontFamily else { return }
+        var updated = preferences
+        updated.fontFamily = fontFamily
+        persist(fontFamily, defaultValue: ReadingPreferences.default.fontFamily, key: keys.fontFamily)
+        preferences = updated
+        InlineContentTextMeasurementCache.drain()
+    }
+
+    func reconcileAvailableImportedFonts(_ fonts: [ImportedReaderFont]) {
+        guard let postScriptName = preferences.fontFamily.importedPostScriptName,
+              fonts.contains(where: { $0.postScriptName == postScriptName }) == false else {
+            return
+        }
+        select(fontFamily: .system)
     }
 
     func select(lineSpacing: ReaderLineSpacing) {
@@ -342,6 +457,7 @@ final class ReadingPreferencesStore: ObservableObject {
 
     func reset() {
         defaults.removeObject(forKey: keys.fontSize)
+        defaults.removeObject(forKey: keys.fontFamily)
         defaults.removeObject(forKey: keys.lineSpacing)
         defaults.removeObject(forKey: keys.defaultReplySort)
         defaults.removeObject(forKey: keys.mediaLoading)
@@ -418,6 +534,323 @@ final class ReadingPreferencesStore: ObservableObject {
         } else {
             defaults.set(value.rawValue, forKey: key)
         }
+    }
+}
+
+struct ImportedReaderFont: Identifiable, Equatable, Codable, Sendable {
+    var postScriptName: String
+    var displayName: String
+    var fileName: String
+    var sha256: String
+    var importedAt: Date
+
+    var id: String { postScriptName }
+    var family: ReaderFontFamily? { .imported(postScriptName: postScriptName) }
+}
+
+enum ReaderFontStoreError: LocalizedError, Equatable {
+    case persistenceUnavailable
+    case unsupportedFile
+    case fileTooLarge
+    case tooManyFonts
+    case invalidFont
+    case nameConflict
+    case registrationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .persistenceUnavailable:
+            return "自定义字体存储暂不可用。"
+        case .unsupportedFile:
+            return "请选择 TTF 或 OTF 字体文件。"
+        case .fileTooLarge:
+            return "字体文件超过 20 MB，未导入。"
+        case .tooManyFonts:
+            return "最多导入 20 个字体，请先删除不再使用的字体。"
+        case .invalidFont:
+            return "无法识别这个字体文件。"
+        case .nameConflict:
+            return "已存在同名但内容不同的字体，请先删除旧字体。"
+        case .registrationFailed:
+            return "字体注册失败，未更改阅读设置。"
+        }
+    }
+}
+
+struct PreparedReaderFontImport: Sendable {
+    var data: Data
+    var fileExtension: String
+    var postScriptName: String
+    var displayName: String
+    var sha256: String
+}
+
+@MainActor
+final class ReaderFontStore: ObservableObject {
+    static let shared = ReaderFontStore()
+    nonisolated static let maximumFontByteCount = 20 * 1_024 * 1_024
+    nonisolated static let maximumImportedFonts = 20
+
+    @Published private(set) var entries: [ImportedReaderFont] = []
+    @Published private(set) var persistenceError: String?
+    @Published private(set) var isReady = false
+
+    private let fileManager: FileManager
+    private var catalogFile: SecureCodableFile<[ImportedReaderFont]>?
+    private var directoryURL: URL?
+    private var isImporting = false
+
+    init(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        self.fileManager = fileManager
+        do {
+            let location = try SecurePersistenceLocation.applicationSupport(
+                fileManager: fileManager,
+                baseDirectoryURL: baseDirectoryURL
+            )
+            let directoryURL = location.directoryURL
+                .appendingPathComponent("reader-fonts", isDirectory: true)
+            let catalogFile = try SecureCodableFile<[ImportedReaderFont]>(
+                directoryURL: directoryURL,
+                fileName: "fonts.json",
+                fileManager: fileManager,
+                maximumByteCount: 512 * 1_024
+            )
+            self.directoryURL = directoryURL
+            self.catalogFile = catalogFile
+            var knownPostScriptNames = Set<String>()
+            let candidates = (try catalogFile.load() ?? [])
+                .sorted { $0.importedAt < $1.importedAt }
+                .filter { knownPostScriptNames.insert($0.postScriptName).inserted }
+                .prefix(Self.maximumImportedFonts)
+            Task { [weak self] in
+                await self?.loadStoredFonts(Array(candidates), directoryURL: directoryURL)
+            }
+        } catch {
+            persistenceError = error.localizedDescription
+            isReady = true
+        }
+    }
+
+    @discardableResult
+    func importFont(
+        from sourceURL: URL,
+        importedAt: Date = Date()
+    ) async throws -> ImportedReaderFont {
+        let prepared = try await Task.detached(priority: .userInitiated) {
+            try Self.prepareImport(from: sourceURL)
+        }.value
+        return try await importFont(prepared, importedAt: importedAt)
+    }
+
+    nonisolated static func prepareImport(from sourceURL: URL) throws -> PreparedReaderFontImport {
+        let fileExtension = sourceURL.pathExtension.lowercased()
+        guard ["ttf", "otf"].contains(fileExtension) else {
+            throw ReaderFontStoreError.unsupportedFile
+        }
+
+        let accessed = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessed { sourceURL.stopAccessingSecurityScopedResource() }
+        }
+        let values = try sourceURL.resourceValues(forKeys: [
+            .fileSizeKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey
+        ])
+        guard values.isRegularFile == true, values.isSymbolicLink != true else {
+            throw ReaderFontStoreError.invalidFont
+        }
+        if let fileSize = values.fileSize, fileSize > maximumFontByteCount {
+            throw ReaderFontStoreError.fileTooLarge
+        }
+        let data = try Data(contentsOf: sourceURL, options: [.mappedIfSafe, .uncached])
+        guard data.isEmpty == false, data.count <= maximumFontByteCount else {
+            throw data.count > maximumFontByteCount
+                ? ReaderFontStoreError.fileTooLarge
+                : ReaderFontStoreError.invalidFont
+        }
+        guard let provider = CGDataProvider(data: data as CFData),
+              let font = CGFont(provider),
+              let postScriptName = font.postScriptName as String?,
+              ReaderFontFamily.imported(postScriptName: postScriptName) != nil else {
+            throw ReaderFontStoreError.invalidFont
+        }
+        return PreparedReaderFontImport(
+            data: data,
+            fileExtension: fileExtension,
+            postScriptName: postScriptName,
+            displayName: (font.fullName as String?) ?? postScriptName,
+            sha256: SecurePersistenceDigest.sha256(data)
+        )
+    }
+
+    @discardableResult
+    func importFont(
+        _ prepared: PreparedReaderFontImport,
+        importedAt: Date = Date()
+    ) async throws -> ImportedReaderFont {
+        guard isReady, isImporting == false,
+              let directoryURL, let catalogFile else {
+            throw ReaderFontStoreError.persistenceUnavailable
+        }
+        guard ["ttf", "otf"].contains(prepared.fileExtension),
+              prepared.data.isEmpty == false,
+              prepared.data.count <= Self.maximumFontByteCount,
+              prepared.sha256.utf8.count == 64,
+              prepared.sha256.utf8.allSatisfy({
+                  (48...57).contains($0) || (97...102).contains($0)
+              }),
+              ReaderFontFamily.imported(postScriptName: prepared.postScriptName) != nil else {
+            throw ReaderFontStoreError.invalidFont
+        }
+        if let existing = entries.first(where: { $0.postScriptName == prepared.postScriptName }) {
+            guard existing.sha256 == prepared.sha256 else {
+                throw ReaderFontStoreError.nameConflict
+            }
+            return existing
+        }
+        guard entries.count < Self.maximumImportedFonts else {
+            throw ReaderFontStoreError.tooManyFonts
+        }
+
+        isImporting = true
+        defer { isImporting = false }
+        let fileName = "\(prepared.sha256).\(prepared.fileExtension)"
+        let destinationURL = directoryURL.appendingPathComponent(fileName, isDirectory: false)
+        let destinationExisted = fileManager.fileExists(atPath: destinationURL.path)
+        let displayName: String
+        do {
+            displayName = try await Task.detached(priority: .userInitiated) {
+                guard prepared.sha256 == SecurePersistenceDigest.sha256(prepared.data),
+                      let provider = CGDataProvider(data: prepared.data as CFData),
+                      let font = CGFont(provider),
+                      font.postScriptName as String? == prepared.postScriptName else {
+                    throw ReaderFontStoreError.invalidFont
+                }
+                try prepared.data.write(to: destinationURL, options: [.atomic])
+                try FileManager.default.setAttributes(
+                    Self.protectedFileAttributes,
+                    ofItemAtPath: destinationURL.path
+                )
+                return (font.fullName as String?) ?? prepared.postScriptName
+            }.value
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        }
+        guard registerFont(at: destinationURL, postScriptName: prepared.postScriptName),
+              UIFont(name: prepared.postScriptName, size: 17) != nil else {
+            try? fileManager.removeItem(at: destinationURL)
+            throw ReaderFontStoreError.registrationFailed
+        }
+
+        let imported = ImportedReaderFont(
+            postScriptName: prepared.postScriptName,
+            displayName: displayName,
+            fileName: fileName,
+            sha256: prepared.sha256,
+            importedAt: importedAt
+        )
+        do {
+            var updated = entries.filter { $0.sha256 != prepared.sha256 }
+            updated.append(imported)
+            updated.sort { $0.importedAt < $1.importedAt }
+            try catalogFile.replace(updated)
+            entries = updated
+            persistenceError = nil
+            return imported
+        } catch {
+            if destinationExisted == false { try? fileManager.removeItem(at: destinationURL) }
+            persistenceError = error.localizedDescription
+            throw error
+        }
+    }
+
+    func remove(_ font: ImportedReaderFont) throws {
+        guard isReady, isImporting == false,
+              let directoryURL, let catalogFile else {
+            throw ReaderFontStoreError.persistenceUnavailable
+        }
+        let updated = entries.filter { $0.id != font.id }
+        try catalogFile.replace(updated)
+        entries = updated
+        let fileURL = directoryURL.appendingPathComponent(font.fileName, isDirectory: false)
+        CTFontManagerUnregisterFontsForURL(fileURL as CFURL, .process, nil)
+        try? fileManager.removeItem(at: fileURL)
+        persistenceError = nil
+    }
+
+    func entry(for family: ReaderFontFamily) -> ImportedReaderFont? {
+        guard let postScriptName = family.importedPostScriptName else { return nil }
+        return entries.first { $0.postScriptName == postScriptName }
+    }
+
+    private func loadStoredFonts(
+        _ candidates: [ImportedReaderFont],
+        directoryURL: URL
+    ) async {
+        let validated = await Task.detached(priority: .utility) {
+            candidates.filter { Self.isStoredFontValid($0, directoryURL: directoryURL) }
+        }.value
+        entries = validated.filter { font in
+            let fileURL = directoryURL.appendingPathComponent(font.fileName, isDirectory: false)
+            return registerFont(at: fileURL, postScriptName: font.postScriptName)
+                && UIFont(name: font.postScriptName, size: 17) != nil
+        }
+        if entries.count != candidates.count {
+            persistenceError = ReaderFontStoreError.registrationFailed.localizedDescription
+        }
+        isReady = true
+    }
+
+    nonisolated private static func isStoredFontValid(
+        _ font: ImportedReaderFont,
+        directoryURL: URL
+    ) -> Bool {
+        let fileExtension = (font.fileName as NSString).pathExtension.lowercased()
+        guard ["ttf", "otf"].contains(fileExtension),
+              font.fileName == "\(font.sha256).\(fileExtension)",
+              font.sha256.utf8.count == 64,
+              font.sha256.utf8.allSatisfy({
+                  (48...57).contains($0) || (97...102).contains($0)
+              }),
+              ReaderFontFamily.imported(postScriptName: font.postScriptName) != nil else { return false }
+        let fileURL = directoryURL.appendingPathComponent(font.fileName, isDirectory: false)
+        guard let values = try? fileURL.resourceValues(forKeys: [
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+            .fileSizeKey
+        ]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              (values.fileSize ?? 0) > 0,
+              (values.fileSize ?? 0) <= Self.maximumFontByteCount,
+              let data = try? Data(contentsOf: fileURL, options: [.mappedIfSafe, .uncached]),
+              SecurePersistenceDigest.sha256(data) == font.sha256,
+              let provider = CGDataProvider(data: data as CFData),
+              let storedFont = CGFont(provider),
+              storedFont.postScriptName as String? == font.postScriptName else { return false }
+        return true
+    }
+
+    private func registerFont(at url: URL, postScriptName: String) -> Bool {
+        if UIFont(name: postScriptName, size: 17) != nil { return true }
+        var error: Unmanaged<CFError>?
+        let registered = CTFontManagerRegisterFontsForURL(url as CFURL, .process, &error)
+        return registered || UIFont(name: postScriptName, size: 17) != nil
+    }
+
+    nonisolated private static var protectedFileAttributes: [FileAttributeKey: Any] {
+        var attributes: [FileAttributeKey: Any] = [
+            .posixPermissions: NSNumber(value: Int16(0o600))
+        ]
+#if os(iOS)
+        attributes[.protectionKey] = FileProtectionType.complete
+#endif
+        return attributes
     }
 }
 

--- a/TiebaPure/Domain/Models/SavedThread.swift
+++ b/TiebaPure/Domain/Models/SavedThread.swift
@@ -15,21 +15,30 @@ struct SavedThreadPost: Identifiable, Equatable, Codable, Sendable {
 }
 
 struct SavedThreadSnapshot: Identifiable, Equatable, Codable, Sendable {
-    static let currentFormatVersion = 1
+    static let currentFormatVersion = 2
 
     var formatVersion: Int = currentFormatVersion
     var thread: ThreadSummary
     var forum: Forum
     var posts: [SavedThreadPost]
     var savedAt: Date
+    var mediaMode: SavedThreadMediaMode?
+    var mediaAssets: [SavedThreadMediaAsset]?
+    var latestCheckedAt: Date?
+    var latestReplyCount: Int?
 
     var id: Int64 { thread.id }
     var mainPost: SavedThreadPost? { posts.first { $0.post.floor == 1 } }
     var replyCount: Int { posts.reduce(0) { $0 + ($1.post.floor == 1 ? 0 : 1) } }
     var subpostCount: Int { posts.reduce(0) { $0 + $1.subposts.count } }
+    var effectiveMediaMode: SavedThreadMediaMode { mediaMode ?? .textOnly }
+    var effectiveMediaAssets: [SavedThreadMediaAsset] { mediaAssets ?? [] }
+    var newReplyCount: Int {
+        max((latestReplyCount ?? thread.replyCount) - thread.replyCount, 0)
+    }
 
     func validated() throws -> SavedThreadSnapshot {
-        guard formatVersion == Self.currentFormatVersion else {
+        guard (1...Self.currentFormatVersion).contains(formatVersion) else {
             throw SavedThreadError.unsupportedFormat
         }
         guard thread.id > 0,
@@ -44,7 +53,44 @@ struct SavedThreadSnapshot: Identifiable, Equatable, Codable, Sendable {
         guard Set(postIDs).count == postIDs.count else {
             throw SavedThreadError.inconsistentPagination
         }
-        return self
+        guard effectiveMediaAssets.allSatisfy(\.isValid) else {
+            throw SavedThreadError.invalidMediaManifest
+        }
+        let groupedFiles = Dictionary(grouping: effectiveMediaAssets, by: \.fileName)
+        guard groupedFiles.values.allSatisfy({ assets in
+            guard let first = assets.first else { return false }
+            return assets.allSatisfy {
+                $0.byteCount == first.byteCount && $0.sha256 == first.sha256
+            }
+        }) else {
+            throw SavedThreadError.invalidMediaManifest
+        }
+        let groupedSources = Dictionary(
+            grouping: effectiveMediaAssets.flatMap { asset in
+                asset.sourceIdentities.map { ($0, asset) }
+            },
+            by: { $0.0 }
+        )
+        guard groupedSources.values.allSatisfy({ values in
+            guard let first = values.first?.1 else { return false }
+            return values.allSatisfy {
+                $0.1.byteCount == first.byteCount && $0.1.sha256 == first.sha256
+            }
+        }) else {
+            throw SavedThreadError.invalidMediaManifest
+        }
+        let uniqueMediaBytes = groupedFiles.values.compactMap(\.first).reduce(0) {
+            $0 + $1.byteCount
+        }
+        guard uniqueMediaBytes <= SavedThreadPolicy.maximumMediaBytesPerThread,
+              effectiveMediaMode != .textOnly || effectiveMediaAssets.isEmpty else {
+            throw SavedThreadError.invalidMediaManifest
+        }
+        var result = self
+        result.formatVersion = Self.currentFormatVersion
+        result.mediaMode = effectiveMediaMode
+        result.mediaAssets = effectiveMediaAssets
+        return result
     }
 }
 
@@ -54,6 +100,11 @@ enum SavedThreadError: LocalizedError, Equatable {
     case inconsistentPagination
     case tooManyPages
     case unsupportedFormat
+    case invalidMediaManifest
+    case mediaDownloadFailed
+    case mediaStorageLimitExceeded
+    case backupStorageLimitExceeded
+    case invalidBackup
 
     var errorDescription: String? {
         switch self {
@@ -67,6 +118,16 @@ enum SavedThreadError: LocalizedError, Equatable {
             return "帖子页数超出本机保存上限。"
         case .unsupportedFormat:
             return "本地保存的数据版本无法读取。"
+        case .invalidMediaManifest:
+            return "离线媒体清单已损坏。"
+        case .mediaDownloadFailed:
+            return "部分媒体无法安全下载，原有保存未被覆盖。"
+        case .mediaStorageLimitExceeded:
+            return "这个帖子的离线媒体超过 512 MB 保存上限。"
+        case .backupStorageLimitExceeded:
+            return "备份内容超过 128 MB。请减少完整媒体保存后再试。"
+        case .invalidBackup:
+            return "备份文件无效或已损坏。"
         }
     }
 }
@@ -77,6 +138,10 @@ enum SavedThreadPolicy {
     static let maximumSubpostPages = 10_000
     static let subpostPageSize = 10
     static let maximumStorageByteCount = 128 * 1_024 * 1_024
+    static let maximumMediaBytesPerThread = 512 * 1_024 * 1_024
+    // FileDocument materializes package contents while handing them to the
+    // document picker. Keep a hard ceiling that remains safe on older devices.
+    static let maximumBackupBytes = 128 * 1_024 * 1_024
 }
 
 @MainActor
@@ -87,11 +152,21 @@ final class SavedThreadStore: ObservableObject {
     @Published private(set) var persistenceError: String?
 
     private var file: SecureCodableFile<[SavedThreadSnapshot]>?
+    let mediaStore: SavedThreadMediaStore
+
+    private struct BackupImportPlan {
+        var entries: [SavedThreadSnapshot]
+        var importedThreadIDs: Set<Int64>
+    }
 
     init(
         baseDirectoryURL: URL? = nil,
         fileManager: FileManager = .default
     ) {
+        mediaStore = (try? SavedThreadMediaStore(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager
+        )) ?? .unavailable
         do {
             let location = try SecurePersistenceLocation.applicationSupport(
                 fileManager: fileManager,
@@ -120,14 +195,113 @@ final class SavedThreadStore: ObservableObject {
     }
 
     func save(_ snapshot: SavedThreadSnapshot) throws {
+        try save(snapshot, preparedMedia: nil)
+    }
+
+    func save(
+        _ snapshot: SavedThreadSnapshot,
+        preparedMedia: PreparedSavedThreadMedia?
+    ) throws {
         guard let file else { throw SavedThreadError.persistenceUnavailable }
         let validated = try snapshot.validated()
+        try preparedMedia?.commit()
+        do {
+            entries = try file.update(default: []) { values in
+                values.removeAll { $0.id == validated.id }
+                values.insert(validated, at: 0)
+                values = Array(try Self.normalized(values).prefix(SavedThreadPolicy.maximumSavedThreads))
+            }
+            preparedMedia?.finish()
+            if validated.effectiveMediaMode == .textOnly {
+                try? mediaStore.remove(threadID: validated.id)
+            }
+        } catch {
+            preparedMedia?.rollback()
+            throw error
+        }
+        mediaStore.removeOrphans(keeping: Set(entries.map(\.id)))
+        persistenceError = nil
+    }
+
+    func recordUpdateCheck(
+        threadID: Int64,
+        latestReplyCount: Int,
+        checkedAt: Date = Date()
+    ) throws {
+        guard let file else { throw SavedThreadError.persistenceUnavailable }
         entries = try file.update(default: []) { values in
-            values.removeAll { $0.id == validated.id }
-            values.insert(validated, at: 0)
-            values = Array(try Self.normalized(values).prefix(SavedThreadPolicy.maximumSavedThreads))
+            guard let index = values.firstIndex(where: { $0.id == threadID }) else { return }
+            values[index].latestCheckedAt = checkedAt
+            values[index].latestReplyCount = max(latestReplyCount, values[index].thread.replyCount)
+            values = try Self.normalized(values)
         }
         persistenceError = nil
+    }
+
+    func importBackup(
+        snapshots: [SavedThreadSnapshot],
+        mediaFiles: [Int64: [String: Data]],
+        replacingExisting: Bool
+    ) throws {
+        let imported = try Self.normalized(snapshots)
+        guard imported.count <= SavedThreadPolicy.maximumSavedThreads else {
+            throw SavedThreadError.invalidBackup
+        }
+        var prepared: [PreparedSavedThreadMedia] = []
+        do {
+            for snapshot in imported {
+                prepared.append(try mediaStore.prepareImport(
+                    snapshot: snapshot,
+                    files: mediaFiles[snapshot.id] ?? [:]
+                ))
+            }
+            try commitBackupImport(
+                imported: imported,
+                prepared: prepared,
+                replacingExisting: replacingExisting
+            )
+        } catch {
+            prepared.reversed().forEach { $0.rollback() }
+            throw error
+        }
+    }
+
+    func importBackupWithoutBlocking(
+        snapshots: [SavedThreadSnapshot],
+        mediaFiles: [Int64: [String: Data]],
+        replacingExisting: Bool
+    ) async throws {
+        let imported = try Self.normalized(snapshots)
+        guard imported.count <= SavedThreadPolicy.maximumSavedThreads else {
+            throw SavedThreadError.invalidBackup
+        }
+        let mediaStore = mediaStore
+        let prepared = try await Task.detached(priority: .userInitiated) {
+            var values: [PreparedSavedThreadMedia] = []
+            do {
+                for snapshot in imported {
+                    try Task.checkCancellation()
+                    values.append(try mediaStore.prepareImport(
+                        snapshot: snapshot,
+                        files: mediaFiles[snapshot.id] ?? [:]
+                    ))
+                }
+                return values
+            } catch {
+                values.reversed().forEach { $0.rollback() }
+                throw error
+            }
+        }.value
+        do {
+            try commitBackupImport(
+                imported: imported,
+                prepared: prepared,
+                replacingExisting: replacingExisting
+            )
+        } catch {
+            prepared.reversed().forEach { $0.rollback() }
+            throw error
+        }
     }
 
     func remove(threadID: Int64) throws {
@@ -136,21 +310,88 @@ final class SavedThreadStore: ObservableObject {
             values.removeAll { $0.id == threadID }
             values = try Self.normalized(values)
         }
+        try mediaStore.remove(threadID: threadID)
         persistenceError = nil
     }
 
     func clear() throws {
         guard let file else { throw SavedThreadError.persistenceUnavailable }
         try file.replace([])
+        try mediaStore.clear()
         entries = []
         persistenceError = nil
+    }
+
+    private func commitBackupImport(
+        imported: [SavedThreadSnapshot],
+        prepared: [PreparedSavedThreadMedia],
+        replacingExisting: Bool
+    ) throws {
+        guard let file else { throw SavedThreadError.persistenceUnavailable }
+        guard imported.count == prepared.count else { throw SavedThreadError.invalidBackup }
+
+        // Preparation can run off the main actor. Recompute the winner against
+        // the latest store state so an older backup cannot replace newer media.
+        let plan = try Self.backupImportPlan(
+            imported: imported,
+            existing: entries,
+            replacingExisting: replacingExisting
+        )
+        let preparedBySnapshot = Array(zip(imported, prepared))
+        let selected = preparedBySnapshot.compactMap { snapshot, media in
+            plan.importedThreadIDs.contains(snapshot.id) ? media : nil
+        }
+        preparedBySnapshot
+            .filter { plan.importedThreadIDs.contains($0.0.id) == false }
+            .forEach { $0.1.rollback() }
+
+        try selected.forEach { try $0.commit() }
+        try file.replace(plan.entries)
+        entries = plan.entries
+        selected.forEach { $0.finish() }
+        mediaStore.removeOrphans(keeping: Set(entries.map(\.id)))
+        persistenceError = nil
+    }
+
+    private static func backupImportPlan(
+        imported: [SavedThreadSnapshot],
+        existing: [SavedThreadSnapshot],
+        replacingExisting: Bool
+    ) throws -> BackupImportPlan {
+        if replacingExisting {
+            let limited = Array(imported.prefix(SavedThreadPolicy.maximumSavedThreads))
+            return BackupImportPlan(
+                entries: limited,
+                importedThreadIDs: Set(limited.map(\.id))
+            )
+        }
+
+        var valuesByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        var importedThreadIDs = Set<Int64>()
+        for snapshot in imported {
+            if let current = valuesByID[snapshot.id], current.savedAt >= snapshot.savedAt {
+                continue
+            }
+            valuesByID[snapshot.id] = snapshot
+            importedThreadIDs.insert(snapshot.id)
+        }
+
+        let limited = Array(
+            try normalized(Array(valuesByID.values))
+                .prefix(SavedThreadPolicy.maximumSavedThreads)
+        )
+        importedThreadIDs.formIntersection(limited.map(\.id))
+        return BackupImportPlan(entries: limited, importedThreadIDs: importedThreadIDs)
     }
 
     private static func normalized(_ values: [SavedThreadSnapshot]) throws -> [SavedThreadSnapshot] {
         var knownIDs = Set<Int64>()
         return try values
             .map { try $0.validated() }
-            .sorted { $0.savedAt > $1.savedAt }
+            .sorted {
+                if $0.savedAt == $1.savedAt { return $0.id > $1.id }
+                return $0.savedAt > $1.savedAt
+            }
             .filter { knownIDs.insert($0.id).inserted }
     }
 }

--- a/TiebaPure/Domain/Models/SavedThreadMedia.swift
+++ b/TiebaPure/Domain/Models/SavedThreadMedia.swift
@@ -1,0 +1,830 @@
+import CryptoKit
+import Foundation
+
+enum SavedThreadMediaMode: String, CaseIterable, Codable, Identifiable, Sendable {
+    case textOnly
+    case images
+    case complete
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .textOnly: return "仅正文"
+        case .images: return "正文和图片"
+        case .complete: return "完整媒体"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .textOnly: return "保存主楼、回复和楼中楼，媒体仍需联网"
+        case .images: return "同时离线保存正文、头像、图片和视频封面"
+        case .complete: return "同时离线保存图片、视频和语音"
+        }
+    }
+}
+
+enum SavedThreadMediaKind: String, Codable, Sendable {
+    case image
+    case avatar
+    case videoCover
+    case video
+    case audio
+}
+
+struct SavedThreadMediaAsset: Identifiable, Equatable, Codable, Sendable {
+    var sourceIdentities: [String]
+    var kind: SavedThreadMediaKind
+    var fileName: String
+    var byteCount: Int
+    var sha256: String
+
+    var id: String { "\(kind.rawValue):\(fileName):\(sourceIdentities.joined(separator: "|"))" }
+
+    var isValid: Bool {
+        let normalizedSources = sourceIdentities.filter { source in
+            source.isEmpty == false && source.utf8.count <= 8_192
+        }
+        return normalizedSources.isEmpty == false
+            && Set(normalizedSources).count == normalizedSources.count
+            && fileName.isEmpty == false
+            && fileName == URL(fileURLWithPath: fileName).lastPathComponent
+            && fileName.contains("/") == false
+            && fileName.contains("\\") == false
+            && byteCount > 0
+            && byteCount <= TiebaVideoDownloadClient.maximumVideoBytes
+            && sha256.utf8.count == 64
+            && sha256.utf8.allSatisfy(Self.isLowercaseHexDigit)
+    }
+
+    private static func isLowercaseHexDigit(_ byte: UInt8) -> Bool {
+        (48...57).contains(byte) || (97...102).contains(byte)
+    }
+}
+
+final class SavedThreadMediaAuthorization: @unchecked Sendable {
+    static let shared = SavedThreadMediaAuthorization()
+
+    private let lock = NSLock()
+    private var rootPaths = Set<String>()
+
+    private init() {}
+
+    func register(rootURL: URL) {
+        let path = rootURL.resolvingSymlinksInPath().standardizedFileURL.path
+        _ = lock.withLock { rootPaths.insert(path) }
+    }
+
+    func allows(_ url: URL?) -> Bool {
+        guard let url, url.isFileURL else { return false }
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+        let path = resolved.path
+        let roots = lock.withLock { rootPaths }
+        guard roots.contains(where: { path.hasPrefix($0 + "/") }) else { return false }
+        do {
+            let values = try resolved.resourceValues(forKeys: [
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+                .fileSizeKey
+            ])
+            return values.isRegularFile == true
+                && values.isSymbolicLink != true
+                && (values.fileSize ?? 0) > 0
+                && (values.fileSize ?? 0) <= TiebaVideoDownloadClient.maximumVideoBytes
+        } catch {
+            return false
+        }
+    }
+}
+
+final class PreparedSavedThreadMedia: @unchecked Sendable {
+    let assets: [SavedThreadMediaAsset]
+
+    private let fileManager: FileManager
+    private let stagingURL: URL
+    private let finalURL: URL
+    private let rollbackURL: URL
+    private let lock = NSLock()
+    private var state: State = .prepared
+    private var hadPreviousDirectory = false
+
+    private enum State {
+        case prepared
+        case committed
+        case finished
+        case rolledBack
+    }
+
+    init(
+        assets: [SavedThreadMediaAsset],
+        stagingURL: URL,
+        finalURL: URL,
+        rootURL: URL,
+        fileManager: FileManager
+    ) {
+        self.assets = assets
+        self.stagingURL = stagingURL
+        self.finalURL = finalURL
+        rollbackURL = rootURL.appendingPathComponent(
+            ".rollback-\(finalURL.lastPathComponent)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        self.fileManager = fileManager
+    }
+
+    func commit() throws {
+        try lock.withLock {
+            guard state == .prepared else { return }
+            hadPreviousDirectory = fileManager.fileExists(atPath: finalURL.path)
+            if hadPreviousDirectory {
+                try fileManager.moveItem(at: finalURL, to: rollbackURL)
+            }
+            do {
+                try fileManager.moveItem(at: stagingURL, to: finalURL)
+                state = .committed
+            } catch {
+                if hadPreviousDirectory,
+                   fileManager.fileExists(atPath: rollbackURL.path) {
+                    try? fileManager.moveItem(at: rollbackURL, to: finalURL)
+                }
+                throw error
+            }
+        }
+    }
+
+    func finish() {
+        lock.withLock {
+            guard state == .committed else { return }
+            if fileManager.fileExists(atPath: rollbackURL.path) {
+                try? fileManager.removeItem(at: rollbackURL)
+            }
+            state = .finished
+        }
+    }
+
+    func rollback() {
+        lock.withLock {
+            switch state {
+            case .prepared:
+                if fileManager.fileExists(atPath: stagingURL.path) {
+                    try? fileManager.removeItem(at: stagingURL)
+                }
+            case .committed:
+                if fileManager.fileExists(atPath: finalURL.path) {
+                    try? fileManager.removeItem(at: finalURL)
+                }
+                if hadPreviousDirectory,
+                   fileManager.fileExists(atPath: rollbackURL.path) {
+                    try? fileManager.moveItem(at: rollbackURL, to: finalURL)
+                }
+            case .finished, .rolledBack:
+                break
+            }
+            state = .rolledBack
+        }
+    }
+
+    deinit {
+        rollback()
+    }
+}
+
+final class SavedThreadMediaStore: @unchecked Sendable {
+    static let unavailable = SavedThreadMediaStore()
+
+    private struct CaptureRequest {
+        var kind: SavedThreadMediaKind
+        var sourceIdentities: [String]
+        var candidates: [URL]
+        var voiceMD5: String?
+    }
+
+    private let fileManager: FileManager
+    private let rootURL: URL?
+
+    private init() {
+        fileManager = .default
+        rootURL = nil
+    }
+
+    init(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws {
+        let location = try SecurePersistenceLocation.applicationSupport(
+            fileManager: fileManager,
+            baseDirectoryURL: baseDirectoryURL
+        )
+        let root = location.directoryURL.appendingPathComponent(
+            "saved-thread-media",
+            isDirectory: true
+        )
+        try Self.prepareProtectedDirectory(root, fileManager: fileManager)
+        Self.cleanupAbandonedTransactions(in: root, fileManager: fileManager)
+        self.fileManager = fileManager
+        rootURL = root
+        SavedThreadMediaAuthorization.shared.register(rootURL: root)
+    }
+
+    func prepareCapture(
+        snapshot: SavedThreadSnapshot,
+        mode: SavedThreadMediaMode
+    ) async throws -> PreparedSavedThreadMedia {
+        guard let rootURL else { throw SavedThreadError.persistenceUnavailable }
+        let stagingURL = try makeStagingDirectory(threadID: snapshot.id, rootURL: rootURL)
+        do {
+            var assets: [SavedThreadMediaAsset] = []
+            var capturedFileNames = Set<String>()
+            var totalBytes = 0
+            for request in try captureRequests(snapshot: snapshot, mode: mode) {
+                try Task.checkCancellation()
+                let captured = try await capture(request, into: stagingURL)
+                if capturedFileNames.insert(captured.fileName).inserted {
+                    totalBytes += captured.byteCount
+                }
+                guard totalBytes <= SavedThreadPolicy.maximumMediaBytesPerThread else {
+                    throw SavedThreadError.mediaStorageLimitExceeded
+                }
+                assets.append(captured)
+            }
+            return PreparedSavedThreadMedia(
+                assets: assets,
+                stagingURL: stagingURL,
+                finalURL: directoryURL(threadID: snapshot.id, rootURL: rootURL),
+                rootURL: rootURL,
+                fileManager: fileManager
+            )
+        } catch {
+            try? fileManager.removeItem(at: stagingURL)
+            if error is CancellationError { throw error }
+            if let savedError = error as? SavedThreadError { throw savedError }
+            throw SavedThreadError.mediaDownloadFailed
+        }
+    }
+
+    func prepareImport(
+        snapshot: SavedThreadSnapshot,
+        files: [String: Data]
+    ) throws -> PreparedSavedThreadMedia {
+        guard let rootURL else { throw SavedThreadError.persistenceUnavailable }
+        let assets = snapshot.effectiveMediaAssets
+        let expectedNames = Set(assets.map(\.fileName))
+        guard Set(files.keys) == expectedNames else { throw SavedThreadError.invalidBackup }
+        let stagingURL = try makeStagingDirectory(threadID: snapshot.id, rootURL: rootURL)
+        do {
+            var totalBytes = 0
+            for fileName in expectedNames {
+                guard let data = files[fileName] else { throw SavedThreadError.invalidBackup }
+                let matching = assets.filter { $0.fileName == fileName }
+                guard let first = matching.first,
+                      matching.allSatisfy({
+                          $0.byteCount == first.byteCount && $0.sha256 == first.sha256
+                      }),
+                      data.count == first.byteCount,
+                      SecurePersistenceDigest.sha256(data) == first.sha256 else {
+                    throw SavedThreadError.invalidBackup
+                }
+                totalBytes += data.count
+                guard totalBytes <= SavedThreadPolicy.maximumMediaBytesPerThread else {
+                    throw SavedThreadError.mediaStorageLimitExceeded
+                }
+                try write(data, named: fileName, to: stagingURL)
+            }
+            return PreparedSavedThreadMedia(
+                assets: assets,
+                stagingURL: stagingURL,
+                finalURL: directoryURL(threadID: snapshot.id, rootURL: rootURL),
+                rootURL: rootURL,
+                fileManager: fileManager
+            )
+        } catch {
+            try? fileManager.removeItem(at: stagingURL)
+            throw error
+        }
+    }
+
+    func resolvedSnapshot(_ snapshot: SavedThreadSnapshot) -> SavedThreadSnapshot {
+        guard snapshot.effectiveMediaMode != .textOnly else { return snapshot }
+        var resolved: [String: URL] = [:]
+        for asset in snapshot.effectiveMediaAssets {
+            guard let localURL = verifiedURL(for: asset, threadID: snapshot.id) else { continue }
+            asset.sourceIdentities.forEach { resolved[$0] = localURL }
+        }
+        let mode = snapshot.effectiveMediaMode
+        var result = snapshot
+        result.thread.author = resolvedUser(result.thread.author, using: resolved)
+        result.thread.forumAvatarURL = resolvedURL(result.thread.forumAvatarURL, using: resolved)
+        result.thread.blocks = resolvedBlocks(result.thread.blocks, mode: mode, using: resolved)
+        result.forum.avatarURL = resolvedURL(result.forum.avatarURL, using: resolved)
+        result.posts = result.posts.map { savedPost in
+            var savedPost = savedPost
+            savedPost.post.author = resolvedUser(savedPost.post.author, using: resolved)
+            savedPost.post.blocks = resolvedBlocks(savedPost.post.blocks, mode: mode, using: resolved)
+            savedPost.post.previewSubposts = savedPost.post.previewSubposts.map {
+                resolvedSubpost($0, mode: mode, using: resolved)
+            }
+            savedPost.subposts = savedPost.subposts.map {
+                resolvedSubpost($0, mode: mode, using: resolved)
+            }
+            return savedPost
+        }
+        return result
+    }
+
+    func backupFiles(
+        for snapshot: SavedThreadSnapshot,
+        maximumTotalByteCount: Int = SavedThreadPolicy.maximumBackupBytes
+    ) throws -> [String: Data] {
+        let assetsByFileName = Dictionary(
+            grouping: snapshot.effectiveMediaAssets,
+            by: \.fileName
+        )
+        let expectedByteCount = assetsByFileName.values.compactMap(\.first).reduce(0) {
+            $0 + $1.byteCount
+        }
+        guard expectedByteCount <= maximumTotalByteCount else {
+            throw SavedThreadError.backupStorageLimitExceeded
+        }
+        var files: [String: Data] = [:]
+        for asset in assetsByFileName.values.compactMap(\.first) {
+            guard let url = verifiedURL(for: asset, threadID: snapshot.id) else {
+                throw SavedThreadError.invalidMediaManifest
+            }
+            let data = try Data(
+                contentsOf: url,
+                options: [.mappedIfSafe, .uncached]
+            )
+            guard data.count == asset.byteCount,
+                  SecurePersistenceDigest.sha256(data) == asset.sha256 else {
+                throw SavedThreadError.invalidMediaManifest
+            }
+            files[asset.fileName] = data
+        }
+        return files
+    }
+
+    func storageByteCount() -> Int64 {
+        guard let rootURL,
+              let enumerator = fileManager.enumerator(
+                at: rootURL,
+                includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey],
+                options: []
+              ) else { return 0 }
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            guard let values = try? url.resourceValues(forKeys: [
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+                .fileSizeKey
+            ]), values.isRegularFile == true, values.isSymbolicLink != true else { continue }
+            total += Int64(values.fileSize ?? 0)
+        }
+        return total
+    }
+
+    func remove(threadID: Int64) throws {
+        guard let rootURL else { throw SavedThreadError.persistenceUnavailable }
+        let url = directoryURL(threadID: threadID, rootURL: rootURL)
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    func clear() throws {
+        guard let rootURL else { throw SavedThreadError.persistenceUnavailable }
+        let children = try fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: nil
+        )
+        try children.forEach(fileManager.removeItem)
+    }
+
+    func removeOrphans(keeping threadIDs: Set<Int64>) {
+        guard let rootURL,
+              let children = try? fileManager.contentsOfDirectory(
+                at: rootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+              ) else { return }
+        for url in children {
+            guard let threadID = Int64(url.lastPathComponent),
+                  threadIDs.contains(threadID) == false else { continue }
+            try? fileManager.removeItem(at: url)
+        }
+    }
+
+    private static func cleanupAbandonedTransactions(
+        in rootURL: URL,
+        fileManager: FileManager
+    ) {
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: nil,
+            options: []
+        ) else { return }
+        for url in children where url.lastPathComponent.hasPrefix(".staging-")
+            || url.lastPathComponent.hasPrefix(".rollback-") {
+            try? fileManager.removeItem(at: url)
+        }
+    }
+
+    private func capture(
+        _ request: CaptureRequest,
+        into directoryURL: URL
+    ) async throws -> SavedThreadMediaAsset {
+        switch request.kind {
+        case .image, .avatar, .videoCover:
+            var lastError: Error?
+            for candidate in request.candidates {
+                do {
+                    let payload = try await TiebaImageDownloadClient.shared.download(from: candidate)
+                    let digest = SecurePersistenceDigest.sha256(payload.data)
+                    let fileName = Self.contentFileName(
+                        digest: digest,
+                        preferredExtension: URL(fileURLWithPath: payload.fileName).pathExtension,
+                        fallbackExtension: "img"
+                    )
+                    try writeIfNeeded(payload.data, named: fileName, to: directoryURL)
+                    return SavedThreadMediaAsset(
+                        sourceIdentities: request.sourceIdentities,
+                        kind: request.kind,
+                        fileName: fileName,
+                        byteCount: payload.data.count,
+                        sha256: digest
+                    )
+                } catch {
+                    lastError = error
+                }
+            }
+            throw lastError ?? SavedThreadError.mediaDownloadFailed
+        case .audio:
+            guard let md5 = request.voiceMD5 else { throw SavedThreadError.mediaDownloadFailed }
+            let payload = try await VoiceAudioClient.shared.load(md5: md5, onProgress: nil)
+            let digest = SecurePersistenceDigest.sha256(payload.data)
+            let fileName = Self.contentFileName(
+                digest: digest,
+                preferredExtension: Self.audioExtension(mimeType: payload.mimeType),
+                fallbackExtension: "audio"
+            )
+            try writeIfNeeded(payload.data, named: fileName, to: directoryURL)
+            return SavedThreadMediaAsset(
+                sourceIdentities: request.sourceIdentities,
+                kind: .audio,
+                fileName: fileName,
+                byteCount: payload.data.count,
+                sha256: digest
+            )
+        case .video:
+            guard let source = request.candidates.first else {
+                throw SavedThreadError.mediaDownloadFailed
+            }
+            let lease = try await TiebaVideoDownloadClient.shared.download(from: source)
+            defer { lease.release() }
+            let byteCount = try Self.regularFileByteCount(lease.fileURL)
+            let digest = try Self.sha256(fileURL: lease.fileURL)
+            let fileName = Self.contentFileName(
+                digest: digest,
+                preferredExtension: "mp4",
+                fallbackExtension: "mp4"
+            )
+            let destination = directoryURL.appendingPathComponent(fileName, isDirectory: false)
+            if fileManager.fileExists(atPath: destination.path) == false {
+                try fileManager.copyItem(at: lease.fileURL, to: destination)
+                try Self.secureFile(destination, fileManager: fileManager)
+            }
+            return SavedThreadMediaAsset(
+                sourceIdentities: request.sourceIdentities,
+                kind: .video,
+                fileName: fileName,
+                byteCount: byteCount,
+                sha256: digest
+            )
+        }
+    }
+
+    private func captureRequests(
+        snapshot: SavedThreadSnapshot,
+        mode: SavedThreadMediaMode
+    ) throws -> [CaptureRequest] {
+        guard mode != .textOnly else { return [] }
+        var requests: [CaptureRequest] = []
+        var visualAliasesToIndex: [String: Int] = [:]
+        var mediaIdentities = Set<String>()
+
+        func rebuildVisualAliasIndex() {
+            visualAliasesToIndex = [:]
+            for (index, request) in requests.enumerated()
+            where [.image, .avatar, .videoCover].contains(request.kind) {
+                request.sourceIdentities.forEach { visualAliasesToIndex[$0] = index }
+            }
+        }
+
+        func appendImage(
+            _ urls: [URL?],
+            kind: SavedThreadMediaKind,
+            required: Bool = false
+        ) throws {
+            let candidates = urls.compactMap { TiebaRemoteMediaPolicy.url($0?.absoluteString) }
+            let aliases = Array(Set(candidates.map(\.absoluteString))).sorted()
+            guard aliases.isEmpty == false else {
+                if required {
+                    throw SavedThreadError.mediaDownloadFailed
+                }
+                return
+            }
+
+            let existingIndices = Set(aliases.compactMap { visualAliasesToIndex[$0] })
+            if let primary = existingIndices.min() {
+                let matched = existingIndices.sorted()
+                let existingSources = matched.flatMap { requests[$0].sourceIdentities }
+                let existingCandidates = matched.flatMap { requests[$0].candidates }
+                requests[primary].sourceIdentities = Array(Set(existingSources + aliases)).sorted()
+                requests[primary].candidates = orderedUnique(existingCandidates + candidates)
+                for index in matched.reversed() where index != primary {
+                    requests.remove(at: index)
+                }
+                rebuildVisualAliasIndex()
+                return
+            }
+
+            let index = requests.count
+            requests.append(CaptureRequest(
+                kind: kind,
+                sourceIdentities: aliases,
+                candidates: candidates,
+                voiceMD5: nil
+            ))
+            aliases.forEach { visualAliasesToIndex[$0] = index }
+        }
+
+        func appendUser(_ user: UserSummary) throws {
+            try appendImage([TiebaURL.avatar(user.portrait)], kind: .avatar)
+        }
+
+        func appendBlocks(_ blocks: [ContentBlock]) throws {
+            for block in blocks {
+                switch block {
+                case let .image(image):
+                    try appendImage(
+                        [image.originalURL, image.thumbnailURL],
+                        kind: .image,
+                        required: true
+                    )
+                case let .video(video):
+                    try appendImage(
+                        [video.coverURL],
+                        kind: .videoCover,
+                        required: video.coverURL != nil
+                    )
+                    if mode == .complete {
+                        guard let url = TiebaVideoRemotePolicy.url(video.videoURL?.absoluteString) else {
+                            throw SavedThreadError.mediaDownloadFailed
+                        }
+                        let identity = url.absoluteString
+                        if mediaIdentities.insert("video:\(identity)").inserted {
+                            requests.append(CaptureRequest(
+                                kind: .video,
+                                sourceIdentities: [identity],
+                                candidates: [url],
+                                voiceMD5: nil
+                            ))
+                        }
+                    }
+                case let .voice(voice) where mode == .complete:
+                    let identity = Self.voiceIdentity(md5: voice.md5)
+                    if mediaIdentities.insert(identity).inserted {
+                        requests.append(CaptureRequest(
+                            kind: .audio,
+                            sourceIdentities: [identity],
+                            candidates: [],
+                            voiceMD5: voice.md5
+                        ))
+                    }
+                case .text, .link, .mention, .emoticon, .voice:
+                    break
+                }
+            }
+        }
+
+        try appendUser(snapshot.thread.author)
+        try appendImage([snapshot.thread.forumAvatarURL, snapshot.forum.avatarURL], kind: .avatar)
+        try appendBlocks(snapshot.thread.blocks)
+        for savedPost in snapshot.posts {
+            try appendUser(savedPost.post.author)
+            try appendBlocks(savedPost.post.blocks)
+            for subpost in savedPost.subposts {
+                try appendUser(subpost.author)
+                try appendBlocks(subpost.blocks)
+            }
+        }
+        return requests
+    }
+
+    private func orderedUnique(_ values: [URL]) -> [URL] {
+        var known = Set<String>()
+        return values.filter { known.insert($0.absoluteString).inserted }
+    }
+
+    private func resolvedBlocks(
+        _ blocks: [ContentBlock],
+        mode: SavedThreadMediaMode,
+        using resolved: [String: URL]
+    ) -> [ContentBlock] {
+        blocks.map { block in
+            switch block {
+            case var .image(image):
+                image.thumbnailURL = resolvedURL(image.thumbnailURL, using: resolved)
+                    ?? resolvedURL(image.originalURL, using: resolved)
+                image.originalURL = resolvedURL(image.originalURL, using: resolved)
+                    ?? image.thumbnailURL
+                return .image(image)
+            case var .video(video):
+                video.coverURL = resolvedURL(video.coverURL, using: resolved)
+                video.videoURL = mode == .complete
+                    ? resolvedURL(video.videoURL, using: resolved)
+                    : nil
+                video.webURL = nil
+                return .video(video)
+            case let .voice(voice):
+                guard let localURL = resolved[Self.voiceIdentity(md5: voice.md5)] else {
+                    var voice = voice
+                    voice.localURL = nil
+                    voice.offlineOnly = true
+                    return .voice(voice)
+                }
+                var voice = voice
+                voice.localURL = localURL
+                voice.offlineOnly = true
+                return .voice(voice)
+            case .text, .link, .mention, .emoticon:
+                return block
+            }
+        }
+    }
+
+    private func resolvedSubpost(
+        _ subpost: Subpost,
+        mode: SavedThreadMediaMode,
+        using resolved: [String: URL]
+    ) -> Subpost {
+        var result = subpost
+        result.author = resolvedUser(result.author, using: resolved)
+        result.blocks = resolvedBlocks(result.blocks, mode: mode, using: resolved)
+        return result
+    }
+
+    private func resolvedUser(_ user: UserSummary, using resolved: [String: URL]) -> UserSummary {
+        var result = user
+        result.portrait = TiebaURL.avatar(user.portrait)
+            .flatMap { resolved[$0.absoluteString] }?
+            .absoluteString ?? ""
+        return result
+    }
+
+    private func resolvedURL(_ url: URL?, using resolved: [String: URL]) -> URL? {
+        guard let url else { return nil }
+        if let safeURL = TiebaURL.make(url.absoluteString) {
+            return resolved[safeURL.absoluteString]
+        }
+        return nil
+    }
+
+    private func verifiedURL(for asset: SavedThreadMediaAsset, threadID: Int64) -> URL? {
+        guard let rootURL, asset.isValid else { return nil }
+        let url = directoryURL(threadID: threadID, rootURL: rootURL)
+            .appendingPathComponent(asset.fileName, isDirectory: false)
+        guard SavedThreadMediaAuthorization.shared.allows(url),
+              (try? Self.regularFileByteCount(url)) == asset.byteCount else { return nil }
+        return url
+    }
+
+    private func makeStagingDirectory(threadID: Int64, rootURL: URL) throws -> URL {
+        guard threadID > 0 else { throw SavedThreadError.incompleteThread }
+        let url = rootURL.appendingPathComponent(
+            ".staging-\(threadID)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try Self.prepareProtectedDirectory(url, fileManager: fileManager)
+        return url
+    }
+
+    private func directoryURL(threadID: Int64, rootURL: URL) -> URL {
+        rootURL.appendingPathComponent(String(threadID), isDirectory: true)
+    }
+
+    private func writeIfNeeded(_ data: Data, named name: String, to directory: URL) throws {
+        let url = directory.appendingPathComponent(name, isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path) == false else { return }
+        try write(data, named: name, to: directory)
+    }
+
+    private func write(_ data: Data, named name: String, to directory: URL) throws {
+        guard name == URL(fileURLWithPath: name).lastPathComponent,
+              name.contains("/") == false,
+              name.contains("\\") == false else {
+            throw SavedThreadError.invalidBackup
+        }
+        let url = directory.appendingPathComponent(name, isDirectory: false)
+        try data.write(to: url, options: [.atomic, .completeFileProtection])
+        try Self.secureFile(url, fileManager: fileManager)
+    }
+
+    private static func voiceIdentity(md5: String) -> String { "voice:\(md5)" }
+
+    private static func contentFileName(
+        digest: String,
+        preferredExtension: String,
+        fallbackExtension: String
+    ) -> String {
+        let candidate = preferredExtension.lowercased().filter {
+            $0.isASCII && ($0.isLetter || $0.isNumber)
+        }
+        return "\(digest).\(candidate.isEmpty ? fallbackExtension : candidate)"
+    }
+
+    private static func audioExtension(mimeType: String) -> String {
+        switch mimeType.lowercased() {
+        case "audio/wav", "audio/x-wav": return "wav"
+        case "audio/mpeg": return "mp3"
+        case "audio/mp4", "audio/x-m4a": return "m4a"
+        default: return "audio"
+        }
+    }
+
+    private static func regularFileByteCount(_ url: URL) throws -> Int {
+        let values = try url.resourceValues(forKeys: [
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+            .fileSizeKey
+        ])
+        guard values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              let count = values.fileSize,
+              count > 0,
+              count <= TiebaVideoDownloadClient.maximumVideoBytes else {
+            throw SavedThreadError.invalidMediaManifest
+        }
+        return count
+    }
+
+    private static func sha256(fileURL: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1_024 * 1_024), data.isEmpty == false {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func prepareProtectedDirectory(
+        _ url: URL,
+        fileManager: FileManager
+    ) throws {
+        if fileManager.fileExists(atPath: url.path) {
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            guard values.isDirectory == true, values.isSymbolicLink != true else {
+                throw SavedThreadError.persistenceUnavailable
+            }
+        } else {
+            try fileManager.createDirectory(
+                at: url,
+                withIntermediateDirectories: false,
+                attributes: [
+                    .posixPermissions: NSNumber(value: Int16(0o700)),
+                    .protectionKey: FileProtectionType.complete
+                ]
+            )
+        }
+    }
+
+    private static func secureFile(_ url: URL, fileManager: FileManager) throws {
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard values.isRegularFile == true, values.isSymbolicLink != true else {
+            throw SavedThreadError.invalidMediaManifest
+        }
+        try fileManager.setAttributes([
+            .posixPermissions: NSNumber(value: Int16(0o600)),
+            .protectionKey: FileProtectionType.complete
+        ], ofItemAtPath: url.path)
+    }
+}
+
+struct SavedThreadUpdateService {
+    let api: any TiebaAPIService
+
+    func latestReplyCount(snapshot: SavedThreadSnapshot, account: Account?) async throws -> Int {
+        let page = try await api.threadPage(
+            account: account,
+            threadID: snapshot.id,
+            page: 1,
+            forumID: snapshot.forum.id,
+            postID: nil,
+            seeLz: false,
+            sortType: .ascending
+        )
+        guard page.thread.id == snapshot.id else { throw SavedThreadError.inconsistentPagination }
+        return max(page.thread.replyCount, snapshot.thread.replyCount)
+    }
+}

--- a/TiebaPure/Domain/Models/TiebaURL.swift
+++ b/TiebaPure/Domain/Models/TiebaURL.swift
@@ -47,6 +47,11 @@ enum TiebaURL {
             return nil
         }
 
+        if let localURL = URL(string: text),
+           SavedThreadMediaAuthorization.shared.allows(localURL) {
+            return localURL
+        }
+
         if text.hasPrefix("//") {
             text = "https:" + text
         }

--- a/TiebaPure/Features/Forum/ForumThreadsView.swift
+++ b/TiebaPure/Features/Forum/ForumThreadsView.swift
@@ -23,6 +23,7 @@ struct ForumThreadsView: View {
     @State private var errorMessage: String?
     @State private var showsPinnedThreads = false
     @State private var activeSearch: ForumSearchLaunchRoute?
+    @State private var isStandaloneSearchPresented = false
     @State private var activeThread: ForumThreadRoute?
     @State private var selectedUser: UserSummary?
     @State private var navigationSourceLifecycle = NavigationSourceLifecycleState()
@@ -96,7 +97,20 @@ struct ForumThreadsView: View {
                 UserProfileView(account: account, user: selectedUser)
                     .interactiveNavigationPopStateSync {
                         self.selectedUser = nil
-                    }
+                }
+            }
+        }
+        .fullScreenCover(
+            isPresented: $isStandaloneSearchPresented,
+            onDismiss: { activeSearch = nil }
+        ) {
+            if let activeSearch {
+                StandaloneSearchNavigationView(
+                    account: account,
+                    scope: activeSearch.scope,
+                    initialKeyword: activeSearch.keyword,
+                    onClose: { isStandaloneSearchPresented = false }
+                )
             }
         }
         .task {
@@ -120,6 +134,7 @@ struct ForumThreadsView: View {
             errorMessage = nil
             showsPinnedThreads = false
             activeSearch = nil
+            isStandaloneSearchPresented = false
             activeThread = nil
             selectedUser = nil
             composerRoute = nil
@@ -519,7 +534,7 @@ struct ForumThreadsView: View {
 
     private var searchIsActive: Binding<Bool> {
         Binding(
-            get: { activeSearch != nil },
+            get: { activeSearch != nil && isStandaloneSearchPresented == false },
             set: { isActive in
                 if isActive == false {
                     activeSearch = nil
@@ -684,6 +699,12 @@ struct ForumThreadsView: View {
             openSearchInParent(route)
         } else {
             activeSearch = route
+            if NestedSearchOpenRoutingPolicy.destination(
+                hasParentHandler: false,
+                systemMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+            ) == .standaloneSearch {
+                isStandaloneSearchPresented = true
+            }
         }
     }
 

--- a/TiebaPure/Features/Media/ImageDownloadService.swift
+++ b/TiebaPure/Features/Media/ImageDownloadService.swift
@@ -35,6 +35,33 @@ struct TiebaImageDownloadClient: Sendable {
     }
 
     func download(from url: URL) async throws -> TiebaImageDownloadPayload {
+        if url.isFileURL {
+            return try await Task.detached(priority: .userInitiated) {
+                guard SavedThreadMediaAuthorization.shared.allows(url) else {
+                    throw TiebaImageDownloadError.invalidURL
+                }
+                let data = try Data(contentsOf: url, options: [.mappedIfSafe, .uncached])
+                guard data.isEmpty == false,
+                      data.count <= TiebaImagePipeline.maximumImageBytes,
+                      let source = CGImageSourceCreateWithData(data as CFData, nil),
+                      CGImageSourceGetCount(source) > 0,
+                      TiebaImageDownloadPolicy.allows(source: source) else {
+                    throw TiebaImageDownloadError.invalidImageData
+                }
+                let typeIdentifier = CGImageSourceGetType(source) as String?
+                let mimeType = typeIdentifier.flatMap { UTType($0)?.preferredMIMEType }
+                    ?? "image/jpeg"
+                return TiebaImageDownloadPayload(
+                    data: data,
+                    mimeType: mimeType,
+                    fileName: TiebaImageDownloadPolicy.fileName(
+                        for: url,
+                        mimeType: mimeType,
+                        typeIdentifier: typeIdentifier
+                    )
+                )
+            }.value
+        }
         // Request the validated URL, not the caller's: validation may have
         // upgraded a legacy http source to https.
         guard let safeURL = TiebaURL.image(url.absoluteString),

--- a/TiebaPure/Features/Media/ImageViewer.swift
+++ b/TiebaPure/Features/Media/ImageViewer.swift
@@ -2433,6 +2433,9 @@ enum FullScreenImageSourcePolicy {
     }
 
     private static func allowedImageURL(_ candidate: URL?) -> URL? {
+        if SavedThreadMediaAuthorization.shared.allows(candidate) {
+            return candidate
+        }
         guard let safeURL = TiebaURL.image(candidate?.absoluteString) else { return nil }
         if TiebaRemoteMediaPolicy.allows(safeURL) {
             return safeURL

--- a/TiebaPure/Features/Media/VideoDownloadService.swift
+++ b/TiebaPure/Features/Media/VideoDownloadService.swift
@@ -12,6 +12,12 @@ enum TiebaVideoDownloadError: Error, Equatable {
 
 enum TiebaVideoRemotePolicy {
     static func url(_ value: String?) -> URL? {
+        if let value,
+           let localURL = URL(string: value),
+           SavedThreadMediaAuthorization.shared.allows(localURL),
+           isDirectMP4(localURL) {
+            return localURL
+        }
         guard let url = TiebaURL.video(value), isDirectMP4(url) else { return nil }
         if TiebaRemoteMediaPolicy.allows(url) {
             return url
@@ -48,10 +54,16 @@ final class TiebaVideoFileLease: @unchecked Sendable {
     private let fileManager: FileManager
     private let lock = NSLock()
     private var isReleased = false
+    private let removesFileOnRelease: Bool
 
-    init(fileURL: URL, fileManager: FileManager = .default) {
+    init(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        removesFileOnRelease: Bool = true
+    ) {
         self.fileURL = fileURL
         self.fileManager = fileManager
+        self.removesFileOnRelease = removesFileOnRelease
     }
 
     func release() {
@@ -60,7 +72,7 @@ final class TiebaVideoFileLease: @unchecked Sendable {
             isReleased = true
             return true
         }
-        guard shouldRemove else { return }
+        guard shouldRemove, removesFileOnRelease else { return }
         try? fileManager.removeItem(at: fileURL)
     }
 
@@ -103,6 +115,17 @@ struct TiebaVideoDownloadClient: @unchecked Sendable {
     func download(from sourceURL: URL) async throws -> TiebaVideoFileLease {
         guard let safeURL = TiebaVideoRemotePolicy.url(sourceURL.absoluteString) else {
             throw TiebaVideoDownloadError.invalidURL
+        }
+
+        if safeURL.isFileURL {
+            guard SavedThreadMediaAuthorization.shared.allows(safeURL) else {
+                throw TiebaVideoDownloadError.invalidURL
+            }
+            return TiebaVideoFileLease(
+                fileURL: safeURL,
+                fileManager: fileManager,
+                removesFileOnRelease: false
+            )
         }
 
         let destinationURL = temporaryDirectory

--- a/TiebaPure/Features/Profile/UserProfileView.swift
+++ b/TiebaPure/Features/Profile/UserProfileView.swift
@@ -1206,11 +1206,14 @@ private struct UserProfileHeader: View {
             identityAndAction
 
             if profile.intro.isEmpty == false {
-                Text(profile.intro)
-                    .font(.body)
-                    .foregroundStyle(.primary)
+                InlineContentText(
+                    blocks: [.text(profile.intro)],
+                    style: .body,
+                    allowsLinkInteraction: false,
+                    allowsTextSelection: true,
+                    accessibilityIdentifier: "user-profile-intro"
+                )
                     .fixedSize(horizontal: false, vertical: true)
-                    .textSelection(.enabled)
                     .accessibilityLabel("个人简介：\(profile.intro)")
                     .padding(.top, TiebaPureTheme.Spacing.sm)
             }
@@ -1331,14 +1334,16 @@ private struct UserProfileHeader: View {
     }
 
     private var profileName: some View {
-        Text(profile.user.displayNameResolved)
-            .font(.title2.weight(.bold))
-            .foregroundStyle(.primary)
-            .lineLimit(2)
+        InlineContentText(
+            blocks: [.text(profile.user.displayNameResolved)],
+            style: .title,
+            lineLimit: 2,
+            allowsLinkInteraction: false,
+            allowsTextSelection: true,
+            accessibilityIdentifier: "user-profile-name"
+        )
             .fixedSize(horizontal: false, vertical: true)
             .layoutPriority(1)
-            .textSelection(.enabled)
-            .accessibilityIdentifier("user-profile-name")
     }
 
     private var followButton: some View {

--- a/TiebaPure/Features/Search/SearchResultsView.swift
+++ b/TiebaPure/Features/Search/SearchResultsView.swift
@@ -734,3 +734,25 @@ struct SearchRequestKey: Equatable {
     let sortType: Int
     let page: Int
 }
+
+struct StandaloneSearchNavigationView: View {
+    let account: Account?
+    let scope: SearchScope
+    let initialKeyword: String
+    let onClose: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            SearchResultsView(
+                account: account,
+                scope: scope,
+                initialKeyword: initialKeyword
+            )
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("关闭", action: onClose)
+                }
+            }
+        }
+    }
+}

--- a/TiebaPure/Features/Search/SearchRoute.swift
+++ b/TiebaPure/Features/Search/SearchRoute.swift
@@ -7,3 +7,23 @@ struct SearchRoute: Identifiable, Hashable {
         keyword
     }
 }
+
+enum NestedSearchOpenDestination: Equatable {
+    case parentPath
+    case localSearch
+    case standaloneSearch
+}
+
+enum NestedSearchOpenRoutingPolicy {
+    static func destination(
+        hasParentHandler: Bool,
+        systemMajorVersion: Int
+    ) -> NestedSearchOpenDestination {
+        if hasParentHandler {
+            return .parentPath
+        }
+        // iOS 16 can recurse through trait and layout updates when a view that
+        // is already a NavigationStack destination pushes another Bool route.
+        return systemMajorVersion < 17 ? .standaloneSearch : .localSearch
+    }
+}

--- a/TiebaPure/Features/Settings/ReadingSettingsView.swift
+++ b/TiebaPure/Features/Settings/ReadingSettingsView.swift
@@ -1,10 +1,71 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ReadingSettingsView: View {
     @EnvironmentObject private var store: ReadingPreferencesStore
+    @EnvironmentObject private var fontStore: ReaderFontStore
+    @State private var showsFontImporter = false
+    @State private var pendingFontDeletion: ImportedReaderFont?
+    @State private var fontErrorMessage: String?
+    @State private var isImportingFont = false
 
     var body: some View {
         Form {
+            Section {
+                Picker("字体", selection: fontFamilySelection) {
+                    ForEach(ReaderFontFamily.builtInChoices) { family in
+                        Text(family.title).tag(family)
+                    }
+                    ForEach(fontStore.entries) { font in
+                        if let family = font.family {
+                            Text(font.displayName).tag(family)
+                        }
+                    }
+                }
+                .pickerStyle(.menu)
+                .accessibilityIdentifier("reading-font-family-picker")
+
+                Button {
+                    showsFontImporter = true
+                } label: {
+                    if isImportingFont {
+                        HStack {
+                            ProgressView().controlSize(.small)
+                            Text("正在导入")
+                        }
+                    } else {
+                        Label("导入字体", systemImage: "doc.badge.plus")
+                    }
+                }
+                .disabled(isImportingFont || fontStore.isReady == false)
+                .accessibilityIdentifier("reading-font-import-button")
+
+                ForEach(fontStore.entries) { font in
+                    HStack(spacing: TiebaPureTheme.Spacing.sm) {
+                        VStack(alignment: .leading, spacing: TiebaPureTheme.Spacing.xxs) {
+                            Text(font.displayName)
+                                .lineLimit(1)
+                            Text(font.postScriptName)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: TiebaPureTheme.Spacing.sm)
+                        Button(role: .destructive) {
+                            pendingFontDeletion = font
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("删除字体\(font.displayName)")
+                    }
+                }
+            } header: {
+                Text("字体")
+            } footer: {
+                Text("支持 TTF 和 OTF，单个文件不超过 20 MB，最多导入 20 个。字体只保存在本机应用私有目录。")
+            }
+
             Section {
                 Picker("字号", selection: fontSizeSelection) {
                     ForEach(ReaderFontSize.allCases) { size in
@@ -29,6 +90,7 @@ struct ReadingSettingsView: View {
                     style: .body,
                     lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
                     readerFontSize: store.preferences.fontSize,
+                    readerFontFamily: store.preferences.fontFamily,
                     readerLineSpacing: store.preferences.lineSpacing,
                     allowsLinkInteraction: false,
                     accessibilityIdentifier: "reading-typography-preview"
@@ -87,6 +149,37 @@ struct ReadingSettingsView: View {
         }
         .navigationTitle("阅读设置")
         .fullScreenInteractiveNavigationPop()
+        .fileImporter(
+            isPresented: $showsFontImporter,
+            allowedContentTypes: [.font],
+            allowsMultipleSelection: false,
+            onCompletion: handleFontImport
+        )
+        .confirmationDialog(
+            "删除这个字体？",
+            isPresented: Binding(
+                get: { pendingFontDeletion != nil },
+                set: { if $0 == false { pendingFontDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let pendingFontDeletion {
+                Button("删除字体", role: .destructive) {
+                    removeFont(pendingFontDeletion)
+                }
+            }
+            Button("取消", role: .cancel) {}
+        } message: {
+            Text("删除后使用这个字体的阅读设置会恢复为系统默认。")
+        }
+        .alert("字体操作失败", isPresented: Binding(
+            get: { fontErrorMessage != nil },
+            set: { if $0 == false { fontErrorMessage = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(fontErrorMessage ?? "")
+        }
     }
 
     private var fontSizeSelection: Binding<ReaderFontSize> {
@@ -94,6 +187,49 @@ struct ReadingSettingsView: View {
             get: { store.preferences.fontSize },
             set: { store.select(fontSize: $0) }
         )
+    }
+
+    private var fontFamilySelection: Binding<ReaderFontFamily> {
+        Binding(
+            get: { store.preferences.fontFamily },
+            set: { store.select(fontFamily: $0) }
+        )
+    }
+
+    private func handleFontImport(_ result: Result<[URL], Error>) {
+        do {
+            guard let url = try result.get().first else { return }
+            guard isImportingFont == false else { return }
+            isImportingFont = true
+            Task {
+                do {
+                    let prepared = try await Task.detached(priority: .userInitiated) {
+                        try ReaderFontStore.prepareImport(from: url)
+                    }.value
+                    let imported = try await fontStore.importFont(prepared)
+                    guard let family = imported.family else {
+                        throw ReaderFontStoreError.invalidFont
+                    }
+                    store.select(fontFamily: family)
+                } catch {
+                    fontErrorMessage = error.localizedDescription
+                }
+                isImportingFont = false
+            }
+        } catch {
+            fontErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func removeFont(_ font: ImportedReaderFont) {
+        do {
+            let wasSelected = store.preferences.fontFamily == font.family
+            try fontStore.remove(font)
+            if wasSelected { store.select(fontFamily: .system) }
+            pendingFontDeletion = nil
+        } catch {
+            fontErrorMessage = error.localizedDescription
+        }
     }
 
     private var lineSpacingSelection: Binding<ReaderLineSpacing> {

--- a/TiebaPure/Features/Settings/SavedThreadsView.swift
+++ b/TiebaPure/Features/Settings/SavedThreadsView.swift
@@ -1,9 +1,28 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SavedThreadsView: View {
+    @EnvironmentObject private var environment: AppEnvironment
     @ObservedObject private var store = SavedThreadStore.shared
+    let account: Account?
+
     @State private var searchText = ""
     @State private var errorMessage: String?
+    @State private var resultMessage: String?
+    @State private var storageByteCount: Int64 = 0
+    @State private var storageRefreshGeneration = 0
+    @State private var isCheckingUpdates = false
+    @State private var isManagingBackup = false
+    @State private var backupDocument: SavedThreadBackupDocument?
+    @State private var showsBackupExporter = false
+    @State private var showsBackupImporter = false
+    @State private var pendingImport: SavedThreadBackupDocument?
+    @State private var showsImportOptions = false
+    @State private var confirmsClear = false
+
+    init(account: Account? = nil) {
+        self.account = account
+    }
 
     private var visibleEntries: [SavedThreadSnapshot] {
         let keyword = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -32,7 +51,9 @@ struct SavedThreadsView: View {
                     Section {
                         ForEach(visibleEntries) { snapshot in
                             NavigationLink {
-                                SavedThreadDetailView(snapshot: snapshot)
+                                SavedThreadDetailView(
+                                    snapshot: store.mediaStore.resolvedSnapshot(snapshot)
+                                )
                             } label: {
                                 SavedThreadRow(snapshot: snapshot)
                             }
@@ -44,7 +65,7 @@ struct SavedThreadsView: View {
                             }
                         }
                     } footer: {
-                        Text("正文和楼层结构保存在本机；图片、视频和语音仍需通过保存时的原地址联网加载。最多保存\(SavedThreadPolicy.maximumSavedThreads)个帖子。")
+                        Text("共占用 \(formattedStorageByteCount)，最多保存\(SavedThreadPolicy.maximumSavedThreads)个帖子。完整媒体保存会在无网络时直接读取本机文件。")
                     }
                 }
                 .listStyle(.insetGrouped)
@@ -53,7 +74,51 @@ struct SavedThreadsView: View {
         .navigationTitle("本地保存的帖子")
         .navigationBarTitleDisplayMode(.inline)
         .searchable(text: $searchText, prompt: "搜索标题、作者或贴吧")
-        .alert("无法删除", isPresented: Binding(
+        .refreshable { await checkAllUpdates(showsResult: false) }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button {
+                        Task { await checkAllUpdates(showsResult: true) }
+                    } label: {
+                        Label("检查新回复", systemImage: "arrow.triangle.2.circlepath")
+                    }
+                    .disabled(store.entries.isEmpty || isCheckingUpdates)
+
+                    Divider()
+
+                    Button(action: exportBackup) {
+                        Label("导出备份", systemImage: "square.and.arrow.up")
+                    }
+                    .disabled(store.entries.isEmpty || isManagingBackup)
+
+                    Button {
+                        showsBackupImporter = true
+                    } label: {
+                        Label("恢复备份", systemImage: "square.and.arrow.down")
+                    }
+                    .disabled(isManagingBackup)
+
+                    Divider()
+
+                    Button(role: .destructive) {
+                        confirmsClear = true
+                    } label: {
+                        Label("清空全部", systemImage: "trash")
+                    }
+                    .disabled(store.entries.isEmpty)
+                } label: {
+                    if isCheckingUpdates || isManagingBackup {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+                .accessibilityLabel("管理本地保存")
+                .accessibilityIdentifier("saved-threads-management")
+            }
+        }
+        .alert("操作失败", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if $0 == false { errorMessage = nil } }
         )) {
@@ -61,14 +126,194 @@ struct SavedThreadsView: View {
         } message: {
             Text(errorMessage ?? "")
         }
+        .alert("本地保存", isPresented: Binding(
+            get: { resultMessage != nil },
+            set: { if $0 == false { resultMessage = nil } }
+        )) {
+            Button("好", role: .cancel) {}
+        } message: {
+            Text(resultMessage ?? "")
+        }
+        .confirmationDialog(
+            "如何恢复这份备份？",
+            isPresented: $showsImportOptions,
+            titleVisibility: .visible
+        ) {
+            Button("合并到现有保存") { applyPendingImport(replacingExisting: false) }
+            Button("替换现有保存", role: .destructive) {
+                applyPendingImport(replacingExisting: true)
+            }
+            Button("取消", role: .cancel) { pendingImport = nil }
+        } message: {
+            Text("备份不包含账号登录状态。合并时，同一帖子保留保存时间较新的版本。")
+        }
+        .confirmationDialog(
+            "清空全部本地保存？",
+            isPresented: $confirmsClear,
+            titleVisibility: .visible
+        ) {
+            Button("清空全部", role: .destructive, action: clearAll)
+            Button("取消", role: .cancel) {}
+        } message: {
+            Text("帖子快照和离线媒体都会从这台设备删除。")
+        }
+        .fileExporter(
+            isPresented: $showsBackupExporter,
+            document: backupDocument,
+            contentType: .tiebaPureBackup,
+            defaultFilename: "TiebaPure-本地保存"
+        ) { result in
+            backupDocument = nil
+            if case let .failure(error) = result {
+                errorMessage = error.localizedDescription
+            } else {
+                resultMessage = "备份已导出。"
+            }
+        }
+        .fileImporter(
+            isPresented: $showsBackupImporter,
+            allowedContentTypes: [.tiebaPureBackup],
+            allowsMultipleSelection: false,
+            onCompletion: handleBackupImport
+        )
+        .task {
+            refreshStorageUsage()
+            if shouldAutomaticallyCheckUpdates {
+                await checkAllUpdates(showsResult: false)
+            }
+        }
         .fullScreenInteractiveNavigationPop()
     }
 
     private func remove(_ threadID: Int64) {
         do {
             try store.remove(threadID: threadID)
+            refreshStorageUsage()
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private var formattedStorageByteCount: String {
+        ByteCountFormatter.string(fromByteCount: storageByteCount, countStyle: .file)
+    }
+
+    private var shouldAutomaticallyCheckUpdates: Bool {
+        let cutoff = Date().addingTimeInterval(-6 * 60 * 60)
+        return store.entries.contains { ($0.latestCheckedAt ?? .distantPast) < cutoff }
+    }
+
+    @MainActor
+    private func checkAllUpdates(showsResult: Bool) async {
+        guard isCheckingUpdates == false, store.entries.isEmpty == false else { return }
+        isCheckingUpdates = true
+        defer { isCheckingUpdates = false }
+        let service = SavedThreadUpdateService(api: environment.api)
+        var updatedCount = 0
+        var failedCount = 0
+        for snapshot in store.entries {
+            do {
+                let latest = try await service.latestReplyCount(snapshot: snapshot, account: account)
+                try store.recordUpdateCheck(
+                    threadID: snapshot.id,
+                    latestReplyCount: latest
+                )
+                if latest > snapshot.thread.replyCount { updatedCount += 1 }
+            } catch is CancellationError {
+                return
+            } catch {
+                failedCount += 1
+            }
+        }
+        if showsResult {
+            resultMessage = failedCount == 0
+                ? "检查完成，\(updatedCount)个帖子有新回复。"
+                : "检查完成，\(updatedCount)个帖子有新回复，\(failedCount)个检查失败。"
+        }
+    }
+
+    private func exportBackup() {
+        guard isManagingBackup == false else { return }
+        isManagingBackup = true
+        let snapshots = store.entries
+        let mediaStore = store.mediaStore
+        Task {
+            do {
+                let document = try await Task.detached(priority: .userInitiated) {
+                    try SavedThreadBackupDocument(
+                        snapshots: snapshots,
+                        mediaStore: mediaStore
+                    )
+                }.value
+                backupDocument = document
+                showsBackupExporter = true
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isManagingBackup = false
+        }
+    }
+
+    private func handleBackupImport(_ result: Result<[URL], Error>) {
+        do {
+            guard let url = try result.get().first else { return }
+            guard isManagingBackup == false else { return }
+            isManagingBackup = true
+            Task {
+                do {
+                    pendingImport = try await Task.detached(priority: .userInitiated) {
+                        try SavedThreadBackupDocument.load(from: url)
+                    }.value
+                    showsImportOptions = true
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+                isManagingBackup = false
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func applyPendingImport(replacingExisting: Bool) {
+        guard let pendingImport, isManagingBackup == false else { return }
+        isManagingBackup = true
+        Task {
+            do {
+                try await store.importBackupWithoutBlocking(
+                    snapshots: pendingImport.snapshots,
+                    mediaFiles: pendingImport.mediaFiles,
+                    replacingExisting: replacingExisting
+                )
+                self.pendingImport = nil
+                refreshStorageUsage()
+                resultMessage = "备份处理完成，共读取\(pendingImport.snapshots.count)个帖子。"
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isManagingBackup = false
+        }
+    }
+
+    private func clearAll() {
+        do {
+            try store.clear()
+            refreshStorageUsage()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshStorageUsage() {
+        storageRefreshGeneration &+= 1
+        let generation = storageRefreshGeneration
+        let mediaStore = store.mediaStore
+        Task {
+            let byteCount = await Task.detached(priority: .utility) {
+                mediaStore.storageByteCount()
+            }.value
+            guard generation == storageRefreshGeneration else { return }
+            storageByteCount = byteCount
         }
     }
 }
@@ -89,22 +334,42 @@ private struct SavedThreadRow: View {
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
+
+            HStack(spacing: TiebaPureTheme.Spacing.xs) {
+                Label(snapshot.effectiveMediaMode.title, systemImage: mediaSystemImage)
+                if snapshot.newReplyCount > 0 {
+                    Text("新增 \(snapshot.newReplyCount)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(TiebaPureTheme.ColorToken.primaryAccent, in: Capsule())
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
         .padding(.vertical, TiebaPureTheme.Spacing.xxs)
+    }
+
+    private var mediaSystemImage: String {
+        switch snapshot.effectiveMediaMode {
+        case .textOnly: return "doc.text"
+        case .images: return "photo.on.rectangle"
+        case .complete: return "internaldrive.fill"
+        }
     }
 }
 
 struct SavedThreadDetailView: View {
+    @Environment(\.readingPreferences) private var readingPreferences
     let snapshot: SavedThreadSnapshot
     @State private var selectedPost: SavedThreadPost?
 
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                Label(
-                    "保存于 \(snapshot.savedAt.formatted(date: .abbreviated, time: .shortened))；媒体需联网加载",
-                    systemImage: "internaldrive"
-                )
+                Label(savedStatusText, systemImage: "internaldrive")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -143,6 +408,7 @@ struct SavedThreadDetailView: View {
             .readableWidth()
         }
         .background(TiebaPureTheme.ColorToken.readerGroupedBackground)
+        .environment(\.readingPreferences, offlineReadingPreferences)
         .navigationTitle(snapshot.forum.displayName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -165,6 +431,225 @@ struct SavedThreadDetailView: View {
 
     private var threadURL: URL {
         URL(string: "https://tieba.baidu.com/p/\(snapshot.id)")!
+    }
+
+    private var savedStatusText: String {
+        let time = snapshot.savedAt.formatted(date: .abbreviated, time: .shortened)
+        let update = snapshot.newReplyCount > 0 ? "；线上新增\(snapshot.newReplyCount)条回复" : ""
+        switch snapshot.effectiveMediaMode {
+        case .textOnly:
+            return "保存于 \(time)；媒体需联网加载\(update)"
+        case .images:
+            return "保存于 \(time)；图片已离线，视频和语音未离线\(update)"
+        case .complete:
+            return "保存于 \(time)；正文和媒体均已离线\(update)"
+        }
+    }
+
+    private var offlineReadingPreferences: ReadingPreferences {
+        guard snapshot.effectiveMediaMode != .textOnly else { return readingPreferences }
+        var preferences = readingPreferences
+        preferences.mediaLoading = .automatic
+        return preferences
+    }
+}
+
+private extension UTType {
+    static let tiebaPureBackup = UTType(
+        exportedAs: "dev.infinityf4p.tiebapure.saved-threads-backup",
+        conformingTo: .package
+    )
+}
+
+struct SavedThreadBackupDocument: FileDocument {
+    private struct Manifest: Codable {
+        static let currentFormatVersion = 1
+        var formatVersion: Int
+        var exportedAt: Date
+        var snapshots: [SavedThreadSnapshot]
+    }
+
+    static var readableContentTypes: [UTType] { [.tiebaPureBackup] }
+
+    let snapshots: [SavedThreadSnapshot]
+    let mediaFiles: [Int64: [String: Data]]
+
+    init(snapshots: [SavedThreadSnapshot], mediaStore: SavedThreadMediaStore) throws {
+        self.snapshots = try snapshots.map { try $0.validated() }
+        let manifestByteCount = try Self.encodedManifest(
+            snapshots: self.snapshots,
+            exportedAt: Date()
+        ).count
+        guard manifestByteCount < SavedThreadPolicy.maximumBackupBytes else {
+            throw SavedThreadError.backupStorageLimitExceeded
+        }
+        var files: [Int64: [String: Data]] = [:]
+        var remainingBytes = SavedThreadPolicy.maximumBackupBytes - manifestByteCount
+        for snapshot in self.snapshots {
+            let threadFiles = try mediaStore.backupFiles(
+                for: snapshot,
+                maximumTotalByteCount: remainingBytes
+            )
+            remainingBytes -= threadFiles.values.reduce(0) { $0 + $1.count }
+            files[snapshot.id] = threadFiles
+        }
+        mediaFiles = files
+    }
+
+    init(fileWrapper: FileWrapper) throws {
+        guard fileWrapper.isDirectory,
+              let root = fileWrapper.fileWrappers,
+              Set(root.keys) == ["manifest.json", "Media"],
+              let manifestWrapper = root["manifest.json"],
+              manifestWrapper.isRegularFile,
+              manifestWrapper.isSymbolicLink == false,
+              let manifestData = manifestWrapper.regularFileContents,
+              manifestData.count <= SavedThreadPolicy.maximumStorageByteCount else {
+            throw SavedThreadError.invalidBackup
+        }
+        let manifest = try JSONDecoder().decode(Manifest.self, from: manifestData)
+        guard manifest.formatVersion == Manifest.currentFormatVersion,
+              manifest.snapshots.count <= SavedThreadPolicy.maximumSavedThreads else {
+            throw SavedThreadError.invalidBackup
+        }
+        snapshots = try manifest.snapshots.map { try $0.validated() }
+
+        let snapshotIDs = snapshots.map(\.id)
+        guard Set(snapshotIDs).count == snapshotIDs.count,
+              let mediaWrapper = root["Media"],
+              mediaWrapper.isDirectory,
+              mediaWrapper.isSymbolicLink == false,
+              let mediaRoot = mediaWrapper.fileWrappers,
+              Set(mediaRoot.keys) == Set(snapshotIDs.map(String.init)) else {
+            throw SavedThreadError.invalidBackup
+        }
+
+        var files: [Int64: [String: Data]] = [:]
+        var totalBytes = manifestData.count
+        for snapshot in snapshots {
+            let expectedNames = Set(snapshot.effectiveMediaAssets.map(\.fileName))
+            guard let threadWrapper = mediaRoot[String(snapshot.id)],
+                  threadWrapper.isDirectory,
+                  threadWrapper.isSymbolicLink == false,
+                  let threadRoot = threadWrapper.fileWrappers,
+                  Set(threadRoot.keys) == expectedNames else {
+                throw SavedThreadError.invalidBackup
+            }
+            var threadFiles: [String: Data] = [:]
+            for name in expectedNames {
+                guard let wrapper = threadRoot[name],
+                      wrapper.isRegularFile,
+                      wrapper.isSymbolicLink == false,
+                      let data = wrapper.regularFileContents else {
+                    throw SavedThreadError.invalidBackup
+                }
+                totalBytes += data.count
+                guard totalBytes <= SavedThreadPolicy.maximumBackupBytes else {
+                    throw SavedThreadError.backupStorageLimitExceeded
+                }
+                threadFiles[name] = data
+            }
+            files[snapshot.id] = threadFiles
+        }
+        mediaFiles = files
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        try self.init(fileWrapper: configuration.file)
+    }
+
+    static func load(from url: URL, fileManager: FileManager = .default) throws -> Self {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        let rootValues = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        guard rootValues.isDirectory == true, rootValues.isSymbolicLink != true else {
+            throw SavedThreadError.invalidBackup
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [
+                .isDirectoryKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+                .fileSizeKey
+            ],
+            options: []
+        ) else {
+            throw SavedThreadError.invalidBackup
+        }
+        var totalBytes = 0
+        for case let child as URL in enumerator {
+            let values = try child.resourceValues(forKeys: [
+                .isDirectoryKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+                .fileSizeKey
+            ])
+            guard values.isSymbolicLink != true,
+                  values.isDirectory == true || values.isRegularFile == true else {
+                throw SavedThreadError.invalidBackup
+            }
+            if values.isRegularFile == true {
+                totalBytes += values.fileSize ?? 0
+                guard totalBytes <= SavedThreadPolicy.maximumBackupBytes else {
+                    throw SavedThreadError.backupStorageLimitExceeded
+                }
+            }
+        }
+        return try Self(fileWrapper: FileWrapper(url: url, options: [.immediate]))
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        let manifest = Manifest(
+            formatVersion: Manifest.currentFormatVersion,
+            exportedAt: Date(),
+            snapshots: snapshots
+        )
+        let manifestData = try Self.encodedManifest(manifest)
+        let mediaByteCount = mediaFiles.values.reduce(0) { partial, files in
+            partial + files.values.reduce(0) { $0 + $1.count }
+        }
+        guard manifestData.count + mediaByteCount <= SavedThreadPolicy.maximumBackupBytes else {
+            throw SavedThreadError.backupStorageLimitExceeded
+        }
+        let manifestWrapper = FileWrapper(regularFileWithContents: manifestData)
+        manifestWrapper.preferredFilename = "manifest.json"
+
+        var threadWrappers: [String: FileWrapper] = [:]
+        for snapshot in snapshots {
+            var fileWrappers: [String: FileWrapper] = [:]
+            for (name, data) in mediaFiles[snapshot.id] ?? [:] {
+                let wrapper = FileWrapper(regularFileWithContents: data)
+                wrapper.preferredFilename = name
+                fileWrappers[name] = wrapper
+            }
+            let wrapper = FileWrapper(directoryWithFileWrappers: fileWrappers)
+            wrapper.preferredFilename = String(snapshot.id)
+            threadWrappers[String(snapshot.id)] = wrapper
+        }
+        let mediaWrapper = FileWrapper(directoryWithFileWrappers: threadWrappers)
+        mediaWrapper.preferredFilename = "Media"
+        return FileWrapper(directoryWithFileWrappers: [
+            "manifest.json": manifestWrapper,
+            "Media": mediaWrapper
+        ])
+    }
+
+    private static func encodedManifest(
+        snapshots: [SavedThreadSnapshot],
+        exportedAt: Date
+    ) throws -> Data {
+        try encodedManifest(Manifest(
+            formatVersion: Manifest.currentFormatVersion,
+            exportedAt: exportedAt,
+            snapshots: snapshots
+        ))
+    }
+
+    private static func encodedManifest(_ manifest: Manifest) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(manifest)
     }
 }
 
@@ -217,6 +702,7 @@ private struct SavedSubpostRow: View {
                         blocks: subpost.blocks,
                         textStyle: .reply,
                         readerFontSize: readingPreferences.fontSize,
+                        readerFontFamily: readingPreferences.fontFamily,
                         readerLineSpacing: readingPreferences.lineSpacing
                     )
                     ThreadPostMetadataView(

--- a/TiebaPure/Features/Settings/SettingsView.swift
+++ b/TiebaPure/Features/Settings/SettingsView.swift
@@ -74,7 +74,7 @@ struct SettingsView: View {
                 .accessibilityIdentifier("settings-reading-entry")
 
                 NavigationLink {
-                    SavedThreadsView()
+                    SavedThreadsView(account: account)
                 } label: {
                     Label("本地保存的帖子", systemImage: "internaldrive")
                 }

--- a/TiebaPure/Features/Thread/ContentBlockView.swift
+++ b/TiebaPure/Features/Thread/ContentBlockView.swift
@@ -31,6 +31,7 @@ struct ContentBlocksView: View {
     var textStyle: InlineContentText.Style = .body
     var lineLimit: Int = ThreadContentDisplayPolicy.detailLineLimit
     var readerFontSize: ReaderFontSize = .standard
+    var readerFontFamily: ReaderFontFamily = .system
     var readerLineSpacing: ReaderLineSpacing = .standard
     var inlineAccessibilityIdentifier: String?
     var onOpenUser: ((UserSummary) -> Void)?
@@ -41,12 +42,31 @@ struct ContentBlocksView: View {
             ForEach(InlineContentGroup.groups(from: blocks)) { group in
                 switch group.kind {
                 case let .inline(inlineBlocks):
-                    if let plainText = InlinePlainTextPolicy.text(from: inlineBlocks) {
+                    if ThreadContentInteractionPolicy.allowsTextSelection(for: lineLimit) {
+                        // SwiftUI's native selection host can enter a layout loop
+                        // inside lazy reader scroll views on iOS 17/18. Keep every
+                        // selectable run on the controlled TextKit path used by
+                        // subposts so selection and measurement share one owner.
+                        InlineContentText(
+                            blocks: inlineBlocks,
+                            style: textStyle,
+                            lineLimit: lineLimit,
+                            readerFontSize: readerFontSize,
+                            readerFontFamily: readerFontFamily,
+                            readerLineSpacing: readerLineSpacing,
+                            allowsTextSelection: true,
+                            accessibilityIdentifier: inlineAccessibilityIdentifier,
+                            onOpenUser: onOpenUser,
+                            onPlainTextTap: onPlainTextTap
+                        )
+                        .fixedSize(horizontal: false, vertical: true)
+                    } else if let plainText = InlinePlainTextPolicy.text(from: inlineBlocks) {
                         PlainInlineContentText(
                             text: plainText,
                             style: textStyle,
                             lineLimit: lineLimit,
                             readerFontSize: readerFontSize,
+                            readerFontFamily: readerFontFamily,
                             readerLineSpacing: readerLineSpacing,
                             accessibilityIdentifier: inlineAccessibilityIdentifier,
                             onPlainTextTap: onPlainTextTap
@@ -57,6 +77,7 @@ struct ContentBlocksView: View {
                             style: textStyle,
                             lineLimit: lineLimit,
                             readerFontSize: readerFontSize,
+                            readerFontFamily: readerFontFamily,
                             readerLineSpacing: readerLineSpacing,
                             accessibilityIdentifier: inlineAccessibilityIdentifier,
                             onPlainTextTap: onPlainTextTap
@@ -68,6 +89,7 @@ struct ContentBlocksView: View {
                             style: textStyle,
                             lineLimit: lineLimit,
                             readerFontSize: readerFontSize,
+                            readerFontFamily: readerFontFamily,
                             readerLineSpacing: readerLineSpacing,
                             allowsTextSelection: ThreadContentInteractionPolicy.allowsTextSelection(
                                 for: lineLimit
@@ -89,6 +111,7 @@ struct ContentBlocksView: View {
                             style: textStyle,
                             lineLimit: lineLimit,
                             readerFontSize: readerFontSize,
+                            readerFontFamily: readerFontFamily,
                             readerLineSpacing: readerLineSpacing,
                             allowsTextSelection: false,
                             accessibilityIdentifier: inlineAccessibilityIdentifier
@@ -141,6 +164,7 @@ private struct NativeInlineContentText: View {
     let style: InlineContentText.Style
     let lineLimit: Int
     let readerFontSize: ReaderFontSize
+    let readerFontFamily: ReaderFontFamily
     let readerLineSpacing: ReaderLineSpacing
     let accessibilityIdentifier: String?
     let onPlainTextTap: (() -> Void)?
@@ -153,6 +177,7 @@ private struct NativeInlineContentText: View {
         style: InlineContentText.Style,
         lineLimit: Int,
         readerFontSize: ReaderFontSize,
+        readerFontFamily: ReaderFontFamily,
         readerLineSpacing: ReaderLineSpacing,
         accessibilityIdentifier: String?,
         onPlainTextTap: (() -> Void)?
@@ -161,6 +186,7 @@ private struct NativeInlineContentText: View {
         self.style = style
         self.lineLimit = lineLimit
         self.readerFontSize = readerFontSize
+        self.readerFontFamily = readerFontFamily
         self.readerLineSpacing = readerLineSpacing
         self.accessibilityIdentifier = accessibilityIdentifier
         self.onPlainTextTap = onPlainTextTap
@@ -171,7 +197,7 @@ private struct NativeInlineContentText: View {
 
     var body: some View {
         let _ = artwork.revision
-        let font = style.font(readerFontSize: readerFontSize)
+        let font = style.font(readerFontSize: readerFontSize, readerFontFamily: readerFontFamily)
         let maximumNumberOfLines = ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit)
         let content = composedText(font: font)
             .font(Font(font))
@@ -215,11 +241,9 @@ private struct NativeInlineContentText: View {
 
     @ViewBuilder
     private func selectableContent<Content: View>(_ content: Content) -> some View {
-        if ThreadContentInteractionPolicy.allowsTextSelection(for: lineLimit) {
-            identifiedContent(content.textSelection(.enabled))
-        } else {
-            identifiedContent(content.textSelection(.disabled))
-        }
+        // Selectable detail runs are routed to InlineContentText before this
+        // view is created. Native Text remains a compact, noninteractive summary.
+        identifiedContent(content.textSelection(.disabled))
     }
 
     @ViewBuilder
@@ -291,6 +315,7 @@ private struct PlainInlineContentText: View {
     let style: InlineContentText.Style
     let lineLimit: Int
     let readerFontSize: ReaderFontSize
+    let readerFontFamily: ReaderFontFamily
     let readerLineSpacing: ReaderLineSpacing
     let accessibilityIdentifier: String?
     let onPlainTextTap: (() -> Void)?
@@ -298,7 +323,7 @@ private struct PlainInlineContentText: View {
     var body: some View {
         let maximumNumberOfLines = ThreadContentDisplayPolicy.maximumNumberOfLines(for: lineLimit)
         let content = Text(verbatim: text)
-            .font(Font(style.font(readerFontSize: readerFontSize)))
+            .font(Font(style.font(readerFontSize: readerFontSize, readerFontFamily: readerFontFamily)))
             .foregroundStyle(Color(uiColor: style.foregroundColor))
             .lineSpacing(ReaderTypographyPolicy.lineSpacing(
                 readerLineSpacing,
@@ -312,11 +337,9 @@ private struct PlainInlineContentText: View {
 
     @ViewBuilder
     private func selectableContent<Content: View>(_ content: Content) -> some View {
-        if ThreadContentInteractionPolicy.allowsTextSelection(for: lineLimit) {
-            identifiedContent(content.textSelection(.enabled))
-        } else {
-            identifiedContent(content.textSelection(.disabled))
-        }
+        // Selectable detail runs are routed to InlineContentText before this
+        // view is created. Native Text remains a compact, noninteractive summary.
+        identifiedContent(content.textSelection(.disabled))
     }
 
     @ViewBuilder
@@ -352,9 +375,13 @@ struct ContentBlockView: View {
     var body: some View {
         switch block {
         case let .text(text):
-            Text(text)
-                .font(.body)
-                .textSelection(.enabled)
+            InlineContentText(
+                blocks: [.text(text)],
+                style: .body,
+                allowsLinkInteraction: false,
+                allowsTextSelection: true
+            )
+            .fixedSize(horizontal: false, vertical: true)
         case let .link(title, url):
             if let url, let safeURL = TiebaURL.webpage(url.absoluteString) {
                 Link(title.isEmpty ? safeURL.absoluteString : title, destination: safeURL)
@@ -965,32 +992,41 @@ struct InlineContentText: UIViewRepresentable {
         case reply
         case subpost
 
-        func font(readerFontSize: ReaderFontSize) -> UIFont {
+        func font(
+            readerFontSize: ReaderFontSize,
+            readerFontFamily: ReaderFontFamily = .system
+        ) -> UIFont {
             switch self {
             case .body:
                 return ReaderTypographyPolicy.font(
                     textStyle: .body,
-                    fontSize: readerFontSize
+                    fontSize: readerFontSize,
+                    fontFamily: readerFontFamily
                 )
             case .title:
                 return ReaderTypographyPolicy.font(
                     textStyle: .title2,
-                    fontSize: readerFontSize
+                    weight: .semibold,
+                    fontSize: readerFontSize,
+                    fontFamily: readerFontFamily
                 )
             case .preview:
                 return ReaderTypographyPolicy.font(
                     textStyle: .subheadline,
-                    fontSize: readerFontSize
+                    fontSize: readerFontSize,
+                    fontFamily: readerFontFamily
                 )
             case .reply:
                 return ReaderTypographyPolicy.font(
                     textStyle: .callout,
-                    fontSize: readerFontSize
+                    fontSize: readerFontSize,
+                    fontFamily: readerFontFamily
                 )
             case .subpost:
                 return ReaderTypographyPolicy.font(
                     textStyle: .subheadline,
-                    fontSize: readerFontSize
+                    fontSize: readerFontSize,
+                    fontFamily: readerFontFamily
                 )
             }
         }
@@ -1024,6 +1060,7 @@ struct InlineContentText: UIViewRepresentable {
     var style: Style = .body
     var lineLimit: Int = ThreadContentDisplayPolicy.detailLineLimit
     var readerFontSize: ReaderFontSize = .standard
+    var readerFontFamily: ReaderFontFamily = .system
     var readerLineSpacing: ReaderLineSpacing = .standard
     var prefix: String?
     var prefixParts: [PrefixPart] = []
@@ -1041,6 +1078,7 @@ struct InlineContentText: UIViewRepresentable {
         var blocks: [ContentBlock]
         var style: Style
         var readerFontSize: String
+        var readerFontFamily: String
         var readerLineSpacing: String
         var prefix: String?
         var prefixParts: [PrefixPart]
@@ -1299,11 +1337,12 @@ struct InlineContentText: UIViewRepresentable {
     }
 
     private var renderKey: RenderKey {
-        let font = style.font(readerFontSize: readerFontSize)
+        let font = style.font(readerFontSize: readerFontSize, readerFontFamily: readerFontFamily)
         return RenderKey(
             blocks: blocks,
             style: style,
             readerFontSize: readerFontSize.rawValue,
+            readerFontFamily: readerFontFamily.rawValue,
             readerLineSpacing: readerLineSpacing.rawValue,
             prefix: prefix,
             prefixParts: prefixParts,
@@ -1317,7 +1356,7 @@ struct InlineContentText: UIViewRepresentable {
 
     func attributedString() -> NSAttributedString {
         let result = NSMutableAttributedString()
-        let font = style.font(readerFontSize: readerFontSize)
+        let font = style.font(readerFontSize: readerFontSize, readerFontFamily: readerFontFamily)
         let paragraph = NSMutableParagraphStyle()
         paragraph.lineSpacing = ReaderTypographyPolicy.lineSpacing(
             readerLineSpacing,

--- a/TiebaPure/Features/Thread/PostRowView.swift
+++ b/TiebaPure/Features/Thread/PostRowView.swift
@@ -66,11 +66,18 @@ struct PostRowView: View {
 
                 VStack(alignment: .leading, spacing: ThreadReplyLayout.bodyStackSpacing) {
                     if isMainPost, let threadTitle, threadTitle.isEmpty == false {
-                        Text(threadTitle)
-                            .font(.title2.weight(.semibold))
-                            .lineSpacing(4)
+                        InlineContentText(
+                            blocks: [.text(threadTitle)],
+                            style: .title,
+                            lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
+                            readerFontSize: readingPreferences.fontSize,
+                            readerFontFamily: readingPreferences.fontFamily,
+                            readerLineSpacing: readingPreferences.lineSpacing,
+                            allowsLinkInteraction: false,
+                            allowsTextSelection: true,
+                            accessibilityIdentifier: "thread-main-title"
+                        )
                             .fixedSize(horizontal: false, vertical: true)
-                            .textSelection(.enabled)
                             .padding(.bottom, TiebaPureTheme.Spacing.sm)
                     }
 
@@ -79,6 +86,7 @@ struct PostRowView: View {
                         textStyle: isMainPost ? .body : .reply,
                         lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
                         readerFontSize: readingPreferences.fontSize,
+                        readerFontFamily: readingPreferences.fontFamily,
                         readerLineSpacing: readingPreferences.lineSpacing,
                         inlineAccessibilityIdentifier: isMainPost
                             ? "thread-main-text"

--- a/TiebaPure/Features/Thread/SubpostPreviewView.swift
+++ b/TiebaPure/Features/Thread/SubpostPreviewView.swift
@@ -96,6 +96,7 @@ struct SubpostInlineRow: View {
             style: .subpost,
             lineLimit: lineLimit,
             readerFontSize: readingPreferences.fontSize,
+            readerFontFamily: readingPreferences.fontFamily,
             readerLineSpacing: readingPreferences.lineSpacing,
             prefixParts: SubpostInlinePrefix.parts(
                 author: subpost.author,

--- a/TiebaPure/Features/Thread/ThreadDetailView.swift
+++ b/TiebaPure/Features/Thread/ThreadDetailView.swift
@@ -45,6 +45,7 @@ struct ThreadDetailView: View {
     @State private var userResolutionGeneration = 0
     @State private var userResolutionError: String?
     @State private var isSearchActive = false
+    @State private var isStandaloneSearchPresented = false
     @State private var didCopyLink = false
     @State private var pendingInitialPostID: UInt64?
     @State private var pendingInitialDestination: ThreadDetailInitialDestination?
@@ -92,6 +93,7 @@ struct ThreadDetailView: View {
     @State private var isSavingLocally = false
     @State private var localSaveTask: Task<Void, Never>?
     @State private var localSaveMessage: String?
+    @State private var showsLocalSaveOptions = false
 
     init(
         account: Account?,
@@ -201,8 +203,16 @@ struct ThreadDetailView: View {
                     ForumThreadsView(account: account, forum: selectedForum)
                         .interactiveNavigationPopStateSync {
                             self.selectedForum = nil
-                        }
+                    }
                 }
+            }
+            .fullScreenCover(isPresented: $isStandaloneSearchPresented) {
+                StandaloneSearchNavigationView(
+                    account: account,
+                    scope: searchScope,
+                    initialKeyword: "",
+                    onClose: { isStandaloneSearchPresented = false }
+                )
             }
     }
 
@@ -216,7 +226,19 @@ struct ThreadDetailView: View {
         } message: {
             Text(accountFavoriteError ?? "")
         }
-        .alert("本地保存", isPresented: Binding(
+            .confirmationDialog(
+                savedThreadStore.contains(threadID: threadID) ? "更新本地保存" : "保存到本地",
+                isPresented: $showsLocalSaveOptions,
+                titleVisibility: .visible
+            ) {
+                Button("完整媒体") { startLocalSave(mode: .complete) }
+                Button("正文和图片") { startLocalSave(mode: .images) }
+                Button("仅正文") { startLocalSave(mode: .textOnly) }
+                Button("取消", role: .cancel) {}
+            } message: {
+                Text("完整媒体会下载帖子中的图片、视频和语音；保存过程失败时不会覆盖已有版本。")
+            }
+            .alert("本地保存", isPresented: Binding(
             get: { localSaveMessage != nil },
             set: { if $0 == false { localSaveMessage = nil } }
         )) {
@@ -383,6 +405,8 @@ struct ThreadDetailView: View {
         pendingSubmissionAccount = nil
         pendingSubmissionRouteID = nil
         pendingSubpostInitialID = nil
+        isSearchActive = false
+        isStandaloneSearchPresented = false
         selectedUser = nil
         cancelUserResolution()
         userResolutionError = nil
@@ -442,6 +466,7 @@ struct ThreadDetailView: View {
     private func handleDisappear() {
         guard navigationSourceLifecycle.shouldTearDown(
             isPresentingLocalDestination: isSearchActive
+                || isStandaloneSearchPresented
                 || selectedUser != nil
                 || selectedForum != nil
         ) else { return }
@@ -762,7 +787,9 @@ struct ThreadDetailView: View {
             Button(action: requestMenuRefresh) {
                 Label("刷新", systemImage: "arrow.clockwise")
             }
-            Button(action: startLocalSave) {
+            Button {
+                showsLocalSaveOptions = true
+            } label: {
                 Label(
                     savedThreadStore.contains(threadID: threadID) ? "更新本地保存" : "保存到本地",
                     systemImage: "arrow.down.doc"
@@ -811,13 +838,18 @@ struct ThreadDetailView: View {
 
     private func openThreadSearch() {
         let scope = searchScope
-        if ThreadDetailSearchOpenRoutingPolicy.destination(
-            hasParentHandler: openSearchInParent != nil
-        ) == .parentPath, let openSearchInParent {
+        switch NestedSearchOpenRoutingPolicy.destination(
+            hasParentHandler: openSearchInParent != nil,
+            systemMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        ) {
+        case .parentPath:
+            guard let openSearchInParent else { return }
             navigationSourceLifecycle.beginParentNavigation()
             openSearchInParent(scope)
-        } else {
+        case .localSearch:
             isSearchActive = true
+        case .standaloneSearch:
+            isStandaloneSearchPresented = true
         }
     }
 
@@ -834,7 +866,7 @@ struct ThreadDetailView: View {
         openURL(threadWebURL)
     }
 
-    private func startLocalSave() {
+    private func startLocalSave(mode: SavedThreadMediaMode) {
         guard isSavingLocally == false, threadPage != nil else { return }
         localSaveTask?.cancel()
         isSavingLocally = true
@@ -845,14 +877,30 @@ struct ThreadDetailView: View {
                 localSaveTask = nil
             }
             do {
-                let snapshot = try await capture.capture(
+                var snapshot = try await capture.capture(
                     account: account,
                     threadID: threadID,
                     forumID: forumID
                 )
                 try Task.checkCancellation()
-                try savedThreadStore.save(snapshot)
-                localSaveMessage = "已保存主楼、\(snapshot.replyCount)层回复和\(snapshot.subpostCount)条楼中楼。媒体仍需联网加载。"
+                let preparedMedia = try await savedThreadStore.mediaStore.prepareCapture(
+                    snapshot: snapshot,
+                    mode: mode
+                )
+                try Task.checkCancellation()
+                snapshot.mediaMode = mode
+                snapshot.mediaAssets = preparedMedia.assets
+                snapshot.latestCheckedAt = nil
+                snapshot.latestReplyCount = nil
+                try savedThreadStore.save(snapshot, preparedMedia: preparedMedia)
+                let mediaBytes = Dictionary(grouping: preparedMedia.assets, by: \.fileName)
+                    .values
+                    .compactMap(\.first)
+                    .reduce(0) { $0 + $1.byteCount }
+                let mediaDescription = mode == .textOnly
+                    ? "媒体仍需联网加载"
+                    : "已离线保存\(preparedMedia.assets.count)项媒体（\(ByteCountFormatter.string(fromByteCount: Int64(mediaBytes), countStyle: .file))）"
+                localSaveMessage = "已保存主楼、\(snapshot.replyCount)层回复和\(snapshot.subpostCount)条楼中楼；\(mediaDescription)。"
             } catch is CancellationError {
                 return
             } catch {
@@ -2146,11 +2194,6 @@ struct ThreadDetailView: View {
     }
 }
 
-enum ThreadDetailSearchOpenDestination: Equatable {
-    case parentPath
-    case localSearch
-}
-
 private enum OwnThreadDeletionNotice: Identifiable {
     case failure(message: String)
     case resultPending
@@ -2162,14 +2205,6 @@ private enum OwnThreadDeletionNotice: Identifiable {
         case .resultPending:
             return "result-pending"
         }
-    }
-}
-
-enum ThreadDetailSearchOpenRoutingPolicy {
-    static func destination(
-        hasParentHandler: Bool
-    ) -> ThreadDetailSearchOpenDestination {
-        hasParentHandler ? .parentPath : .localSearch
     }
 }
 
@@ -2832,6 +2867,7 @@ private struct SubpostListSheet: View {
                                             textStyle: .reply,
                                             lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
                                             readerFontSize: readingPreferences.fontSize,
+                                            readerFontFamily: readingPreferences.fontFamily,
                                             readerLineSpacing: readingPreferences.lineSpacing,
                                             inlineAccessibilityIdentifier: "thread-subpost-parent-text",
                                             onPlainTextTap: contentSubmissionSettingsStore.repliesEnabled
@@ -3363,6 +3399,7 @@ private struct SubpostRowView: View {
                         textStyle: .reply,
                         lineLimit: ThreadContentDisplayPolicy.detailLineLimit,
                         readerFontSize: readingPreferences.fontSize,
+                        readerFontFamily: readingPreferences.fontFamily,
                         readerLineSpacing: readingPreferences.lineSpacing,
                         inlineAccessibilityIdentifier: "thread-subpost-text",
                         onOpenUser: onOpenUser,

--- a/TiebaPure/Features/Voice/VoicePlaybackControl.swift
+++ b/TiebaPure/Features/Voice/VoicePlaybackControl.swift
@@ -160,10 +160,25 @@ struct VoicePlaybackControl: View {
     }
 
     var body: some View {
-        let presentation = VoicePlaybackControlPolicy.presentation(
-            state: coordinator.state(forMD5: voice.md5),
-            fallbackDurationMilliseconds: voice.durationMilliseconds
-        )
+        let isUnavailableOffline = voice.offlineOnly == true && voice.localURL == nil
+        let presentation = isUnavailableOffline
+            ? VoicePlaybackControlPresentation(
+                title: "语音未离线保存",
+                detail: VoicePlaybackControlPolicy.clockText(
+                    TimeInterval(voice.durationMilliseconds) / 1_000
+                ),
+                systemImage: "icloud.slash",
+                accessibilityLabel: "语音未离线保存",
+                accessibilityValue: "",
+                accessibilityHint: "更新本地保存并选择完整媒体",
+                progress: nil,
+                action: .none,
+                isFailure: false
+            )
+            : VoicePlaybackControlPolicy.presentation(
+                state: coordinator.state(forMD5: voice.md5),
+                fallbackDurationMilliseconds: voice.durationMilliseconds
+            )
 
         Button {
             perform(presentation.action)
@@ -232,9 +247,17 @@ struct VoicePlaybackControl: View {
     private func perform(_ action: VoicePlaybackControlPresentation.Action) {
         switch action {
         case .toggle:
-            coordinator.toggle(md5: voice.md5)
+            coordinator.toggle(
+                md5: voice.md5,
+                localURL: voice.localURL,
+                offlineOnly: voice.offlineOnly == true
+            )
         case .retry:
-            coordinator.retry(md5: voice.md5)
+            coordinator.retry(
+                md5: voice.md5,
+                localURL: voice.localURL,
+                offlineOnly: voice.offlineOnly == true
+            )
         case .none:
             break
         }

--- a/TiebaPure/Features/Voice/VoicePlaybackCoordinator.swift
+++ b/TiebaPure/Features/Voice/VoicePlaybackCoordinator.swift
@@ -265,7 +265,11 @@ final class VoicePlaybackCoordinator: ObservableObject {
         return state
     }
 
-    func toggle(md5: String) {
+    func toggle(
+        md5: String,
+        localURL: URL? = nil,
+        offlineOnly: Bool = false
+    ) {
         guard let key = VoiceAudioURLPolicy.normalizedMD5(md5) else {
             cancel()
             state = .failed(key: nil, message: VoiceAudioClientError.invalidMD5.localizedDescription)
@@ -277,17 +281,17 @@ final class VoicePlaybackCoordinator: ObservableObject {
                 resumeCurrent(preservingPauseOnActivationFailure: true)
                 return
             }
-            beginLoading(key: key)
+            beginLoading(key: key, localURL: localURL, offlineOnly: offlineOnly)
             return
         }
 
         guard state.key == key else {
-            beginLoading(key: key)
+            beginLoading(key: key, localURL: localURL, offlineOnly: offlineOnly)
             return
         }
         switch state.phase {
         case .idle:
-            beginLoading(key: key)
+            beginLoading(key: key, localURL: localURL, offlineOnly: offlineOnly)
         case .loading:
             break
         case .playing:
@@ -297,18 +301,22 @@ final class VoicePlaybackCoordinator: ObservableObject {
         case .completed:
             replayCurrent()
         case .failed:
-            beginLoading(key: key)
+            beginLoading(key: key, localURL: localURL, offlineOnly: offlineOnly)
         }
     }
 
-    func retry(md5: String) {
+    func retry(
+        md5: String,
+        localURL: URL? = nil,
+        offlineOnly: Bool = false
+    ) {
         guard let key = VoiceAudioURLPolicy.normalizedMD5(md5) else {
             cancel()
             state = .failed(key: nil, message: VoiceAudioClientError.invalidMD5.localizedDescription)
             return
         }
         if isAudioSessionInterrupted, state.phase == .paused { return }
-        beginLoading(key: key)
+        beginLoading(key: key, localURL: localURL, offlineOnly: offlineOnly)
     }
 
     func cancel() {
@@ -396,7 +404,11 @@ final class VoicePlaybackCoordinator: ObservableObject {
         return didReleaseAudioSession
     }
 
-    private func beginLoading(key: String) {
+    private func beginLoading(
+        key: String,
+        localURL: URL? = nil,
+        offlineOnly: Bool = false
+    ) {
         generation &+= 1
         let requestGeneration = generation
         tearDownCurrentPlayback()
@@ -405,12 +417,35 @@ final class VoicePlaybackCoordinator: ObservableObject {
         loadTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let payload = try await loader.load(md5: key) { [weak self] progress in
-                    await self?.receiveLoadProgress(
-                        progress,
-                        key: key,
-                        generation: requestGeneration
-                    )
+                let payload: VoiceAudioPayload
+                if let localURL {
+                    payload = try await Task.detached(priority: .userInitiated) {
+                        guard SavedThreadMediaAuthorization.shared.allows(localURL) else {
+                            throw VoiceAudioClientError.invalidResponse
+                        }
+                        let data = try Data(
+                            contentsOf: localURL,
+                            options: [.mappedIfSafe, .uncached]
+                        )
+                        guard data.isEmpty == false,
+                              data.count <= VoiceAudioClient.maximumAudioBytes else {
+                            throw VoiceAudioClientError.emptyAudio
+                        }
+                        return VoiceAudioPayload(
+                            data: data,
+                            mimeType: "application/octet-stream"
+                        )
+                    }.value
+                } else if offlineOnly {
+                    throw VoiceAudioClientError.invalidResponse
+                } else {
+                    payload = try await loader.load(md5: key) { [weak self] progress in
+                        await self?.receiveLoadProgress(
+                            progress,
+                            key: key,
+                            generation: requestGeneration
+                        )
+                    }
                 }
                 try Task.checkCancellation()
                 guard isCurrent(key: key, generation: requestGeneration) else { return }

--- a/TiebaPure/Resources/Info.plist
+++ b/TiebaPure/Resources/Info.plist
@@ -29,6 +29,26 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.package</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>TiebaPure 本地保存备份</string>
+			<key>UTTypeIdentifier</key>
+			<string>dev.infinityf4p.tiebapure.saved-threads-backup</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tiebapurebackup</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/TiebaPureTests/CrossVersionStateRegressionTests.swift
+++ b/TiebaPureTests/CrossVersionStateRegressionTests.swift
@@ -415,6 +415,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
         let defaults = try makeScratchDefaults()
         let keys = ReadingPreferencesStore.StorageKeys(
             fontSize: "reader-font",
+            fontFamily: "reader-family",
             lineSpacing: "reader-spacing",
             defaultReplySort: "reader-sort",
             mediaLoading: "reader-media"
@@ -423,12 +424,15 @@ final class CrossVersionStateRegressionTests: XCTestCase,
 
         XCTAssertEqual(store.preferences, .default)
         XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertNil(defaults.object(forKey: keys.fontFamily))
         XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
         XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
         XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
 
         store.select(fontSize: .large)
+        store.select(fontFamily: .serif)
         XCTAssertEqual(defaults.string(forKey: keys.fontSize), ReaderFontSize.large.rawValue)
+        XCTAssertEqual(defaults.string(forKey: keys.fontFamily), ReaderFontFamily.serif.rawValue)
         XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
         XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
         XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
@@ -440,6 +444,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
             ReadingPreferencesStore(defaults: defaults, keys: keys).preferences,
             ReadingPreferences(
                 fontSize: .large,
+                fontFamily: .serif,
                 lineSpacing: .relaxed,
                 defaultReplySort: .descending,
                 mediaLoading: .manual
@@ -448,6 +453,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
 
         store.select(fontSize: .standard)
         XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertEqual(defaults.string(forKey: keys.fontFamily), ReaderFontFamily.serif.rawValue)
         XCTAssertEqual(defaults.string(forKey: keys.lineSpacing), ReaderLineSpacing.relaxed.rawValue)
         XCTAssertEqual(defaults.integer(forKey: keys.defaultReplySort), ThreadReplySort.descending.rawValue)
         XCTAssertEqual(defaults.string(forKey: keys.mediaLoading), ReaderMediaLoadingPolicy.manual.rawValue)
@@ -455,6 +461,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
         store.update(.default)
         XCTAssertEqual(store.preferences, .default)
         XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertNil(defaults.object(forKey: keys.fontFamily))
         XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
         XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
         XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
@@ -465,17 +472,20 @@ final class CrossVersionStateRegressionTests: XCTestCase,
         let defaults = try makeScratchDefaults()
         let keys = ReadingPreferencesStore.StorageKeys(
             fontSize: "reader-font",
+            fontFamily: "reader-family",
             lineSpacing: "reader-spacing",
             defaultReplySort: "reader-sort",
             mediaLoading: "reader-media"
         )
         defaults.set("oversized", forKey: keys.fontSize)
+        defaults.set(ReaderFontFamily.rounded.rawValue, forKey: keys.fontFamily)
         defaults.set(ReaderLineSpacing.compact.rawValue, forKey: keys.lineSpacing)
         defaults.set(ThreadReplySort.ascending.rawValue, forKey: keys.defaultReplySort)
         defaults.set(ReaderMediaLoadingPolicy.dataSaving.rawValue, forKey: keys.mediaLoading)
 
         let store = ReadingPreferencesStore(defaults: defaults, keys: keys)
         XCTAssertEqual(store.preferences.fontSize, .standard)
+        XCTAssertEqual(store.preferences.fontFamily, .rounded)
         XCTAssertEqual(store.preferences.lineSpacing, .compact)
         XCTAssertEqual(store.preferences.defaultReplySort, .ascending)
         XCTAssertEqual(store.preferences.mediaLoading, .dataSaving)
@@ -502,6 +512,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
         let defaults = try makeScratchDefaults()
         let keys = ReadingPreferencesStore.StorageKeys(
             fontSize: "reader-font",
+            fontFamily: "reader-family",
             lineSpacing: "reader-spacing",
             defaultReplySort: "reader-sort",
             mediaLoading: "reader-media"
@@ -509,6 +520,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
         let store = ReadingPreferencesStore(defaults: defaults, keys: keys)
         store.update(ReadingPreferences(
             fontSize: .extraLarge,
+            fontFamily: .monospaced,
             lineSpacing: .relaxed,
             defaultReplySort: .descending,
             mediaLoading: .manual
@@ -518,6 +530,7 @@ final class CrossVersionStateRegressionTests: XCTestCase,
 
         XCTAssertEqual(store.preferences, .default)
         XCTAssertNil(defaults.object(forKey: keys.fontSize))
+        XCTAssertNil(defaults.object(forKey: keys.fontFamily))
         XCTAssertNil(defaults.object(forKey: keys.lineSpacing))
         XCTAssertNil(defaults.object(forKey: keys.defaultReplySort))
         XCTAssertNil(defaults.object(forKey: keys.mediaLoading))
@@ -551,6 +564,61 @@ final class CrossVersionStateRegressionTests: XCTestCase,
             compatibleWith: accessibilityCategory
         )
         XCTAssertGreaterThan(accessibilityFont.pointSize, standardFont.pointSize)
+
+        let serifFont = ReaderTypographyPolicy.font(
+            textStyle: .body,
+            fontSize: .standard,
+            fontFamily: .serif,
+            compatibleWith: largeCategory
+        )
+        XCTAssertEqual(serifFont.pointSize, standardFont.pointSize, accuracy: 0.01)
+        XCTAssertNotEqual(serifFont.fontName, standardFont.fontName)
+    }
+
+    @MainActor
+    func testReaderFontStoreRejectsUnsupportedAndCorruptFiles() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let store = ReaderFontStore(baseDirectoryURL: directory)
+
+        let unsupported = directory.appendingPathComponent("font.txt")
+        try Data("not a font".utf8).write(to: unsupported)
+        XCTAssertThrowsError(try ReaderFontStore.prepareImport(from: unsupported)) { error in
+            XCTAssertEqual(error as? ReaderFontStoreError, .unsupportedFile)
+        }
+
+        let corrupt = directory.appendingPathComponent("font.ttf")
+        try Data("not a font".utf8).write(to: corrupt)
+        XCTAssertThrowsError(try ReaderFontStore.prepareImport(from: corrupt)) { error in
+            XCTAssertEqual(error as? ReaderFontStoreError, .invalidFont)
+        }
+        XCTAssertTrue(store.entries.isEmpty)
+    }
+
+    @MainActor
+    func testMissingImportedReaderFontSelectionFallsBackToSystem() throws {
+        let defaults = try makeScratchDefaults()
+        let keys = ReadingPreferencesStore.StorageKeys(
+            fontSize: "reader-font",
+            fontFamily: "reader-family",
+            lineSpacing: "reader-spacing",
+            defaultReplySort: "reader-sort",
+            mediaLoading: "reader-media"
+        )
+        let missingFamily = try XCTUnwrap(
+            ReaderFontFamily.imported(postScriptName: "MissingReaderFont-Regular")
+        )
+        defaults.set(missingFamily.rawValue, forKey: keys.fontFamily)
+        let store = ReadingPreferencesStore(defaults: defaults, keys: keys)
+
+        XCTAssertEqual(store.preferences.fontFamily, missingFamily)
+        store.reconcileAvailableImportedFonts([])
+
+        XCTAssertEqual(store.preferences.fontFamily, .system)
+        XCTAssertNil(defaults.object(forKey: keys.fontFamily))
+        XCTAssertNil(ReaderFontFamily(rawValue: "imported:Bad\nFont"))
     }
 
     func testReaderLineSpacingPreservesExistingDefaultsAndMapsPreferences() {

--- a/TiebaPureTests/NavigationSourceLifecycleTests.swift
+++ b/TiebaPureTests/NavigationSourceLifecycleTests.swift
@@ -23,14 +23,14 @@ final class NavigationSourceLifecycleTests: XCTestCase {
         XCTAssertTrue(state.shouldTearDown(isPresentingLocalDestination: false))
     }
 
-    func testNavigationGestureControllerHostsEdgeSystemsOrExplicitDisable() {
-        XCTAssertTrue(
+    func testNavigationGestureControllerOnlyHostsForExplicitDisable() {
+        XCTAssertFalse(
             NavigationPopGestureControlHostingPolicy.requiresController(
                 systemMajorVersion: 16,
                 isEnabled: true
             )
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             NavigationPopGestureControlHostingPolicy.requiresController(
                 systemMajorVersion: 18,
                 isEnabled: true
@@ -51,11 +51,7 @@ final class NavigationSourceLifecycleTests: XCTestCase {
     }
 
     @MainActor
-    func testGestureControlStateChangeKeepsPresentedContentIdentity() async throws {
-        guard ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 else {
-            throw XCTSkip("iOS 26 才会在启用状态省略手势控制器")
-        }
-
+    func testGestureControlStateChangeKeepsPresentedContentIdentity() async {
         let probe = NavigationGestureContentIdentityProbe()
         let host = UIHostingController(
             rootView: NavigationGestureContentIdentityHost(
@@ -90,7 +86,7 @@ final class NavigationSourceLifecycleTests: XCTestCase {
     @MainActor
     private func waitForRenderCycle() async {
         await Task.yield()
-        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        try? await Task.sleep(nanoseconds: 50_000_000)
     }
 
     func testMeHistoryThreadUserPathReturnsOneLevelAtATime() {

--- a/TiebaPureTests/SavedThreadTests.swift
+++ b/TiebaPureTests/SavedThreadTests.swift
@@ -61,4 +61,296 @@ final class SavedThreadTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    func testLegacyVersionOneSnapshotMigratesToTextOnly() async throws {
+        var snapshot = try await SavedThreadCaptureService(api: FixtureTiebaAPI()).capture(
+            account: nil,
+            threadID: FixtureTiebaAPI.threads[0].id,
+            forumID: FixtureTiebaAPI.forum.id
+        )
+        snapshot.formatVersion = 1
+        snapshot.mediaMode = nil
+        snapshot.mediaAssets = nil
+
+        let decoded = try JSONDecoder().decode(
+            SavedThreadSnapshot.self,
+            from: JSONEncoder().encode(snapshot)
+        )
+        let migrated = try decoded.validated()
+
+        XCTAssertEqual(migrated.formatVersion, SavedThreadSnapshot.currentFormatVersion)
+        XCTAssertEqual(migrated.effectiveMediaMode, .textOnly)
+        XCTAssertTrue(migrated.effectiveMediaAssets.isEmpty)
+    }
+
+    func testMediaImportCommitBackupAndRollbackAreIntegrityChecked() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = SavedThreadStore(baseDirectoryURL: directory)
+        let originalData = Data("original offline payload".utf8)
+        var original = try await capturedSnapshot()
+        let originalAsset = mediaAsset(data: originalData, source: "voice:" + String(repeating: "a", count: 32))
+        original.mediaMode = .complete
+        original.mediaAssets = [originalAsset]
+        let originalPrepared = try store.mediaStore.prepareImport(
+            snapshot: original,
+            files: [originalAsset.fileName: originalData]
+        )
+        try store.save(original, preparedMedia: originalPrepared)
+
+        XCTAssertEqual(
+            try store.mediaStore.backupFiles(for: original)[originalAsset.fileName],
+            originalData
+        )
+
+        let replacementData = Data("replacement offline payload".utf8)
+        var replacement = original
+        let replacementAsset = mediaAsset(
+            data: replacementData,
+            source: "voice:" + String(repeating: "b", count: 32)
+        )
+        replacement.mediaAssets = [replacementAsset]
+        let replacementPrepared = try store.mediaStore.prepareImport(
+            snapshot: replacement,
+            files: [replacementAsset.fileName: replacementData]
+        )
+        try replacementPrepared.commit()
+        replacementPrepared.rollback()
+
+        XCTAssertEqual(
+            try store.mediaStore.backupFiles(for: original)[originalAsset.fileName],
+            originalData,
+            "回滚必须恢复此前已提交的离线媒体"
+        )
+    }
+
+    func testBackupImportAndUpdateCountRoundTrip() async throws {
+        let sourceDirectory = try makeTemporaryDirectory()
+        let destinationDirectory = try makeTemporaryDirectory()
+        let sourceStore = SavedThreadStore(baseDirectoryURL: sourceDirectory)
+        let destinationStore = SavedThreadStore(baseDirectoryURL: destinationDirectory)
+        let data = Data("portable payload".utf8)
+        var snapshot = try await capturedSnapshot()
+        let asset = mediaAsset(data: data, source: "voice:" + String(repeating: "c", count: 32))
+        snapshot.mediaMode = .complete
+        snapshot.mediaAssets = [asset]
+        let prepared = try sourceStore.mediaStore.prepareImport(
+            snapshot: snapshot,
+            files: [asset.fileName: data]
+        )
+        try sourceStore.save(snapshot, preparedMedia: prepared)
+
+        try await destinationStore.importBackupWithoutBlocking(
+            snapshots: sourceStore.entries,
+            mediaFiles: [snapshot.id: try sourceStore.mediaStore.backupFiles(for: snapshot)],
+            replacingExisting: true
+        )
+        try destinationStore.recordUpdateCheck(
+            threadID: snapshot.id,
+            latestReplyCount: snapshot.thread.replyCount + 7,
+            checkedAt: Date(timeIntervalSince1970: 1_900_000_000)
+        )
+
+        XCTAssertEqual(destinationStore.entries.first?.newReplyCount, 7)
+        XCTAssertEqual(
+            try destinationStore.mediaStore.backupFiles(for: destinationStore.entries[0])[asset.fileName],
+            data
+        )
+    }
+
+    func testMergingOlderBackupKeepsNewerSnapshotAndItsMedia() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = SavedThreadStore(baseDirectoryURL: directory)
+        let currentData = Data("current offline payload".utf8)
+        var current = try await capturedSnapshot()
+        current.savedAt = Date(timeIntervalSince1970: 1_800_000_100)
+        current.thread.title = "本机较新版本"
+        let currentAsset = mediaAsset(
+            data: currentData,
+            source: "voice:" + String(repeating: "f", count: 32)
+        )
+        current.mediaMode = .complete
+        current.mediaAssets = [currentAsset]
+        let currentPrepared = try store.mediaStore.prepareImport(
+            snapshot: current,
+            files: [currentAsset.fileName: currentData]
+        )
+        try store.save(current, preparedMedia: currentPrepared)
+
+        let olderData = Data("older backup payload".utf8)
+        var older = current
+        older.savedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        older.thread.title = "备份中的旧版本"
+        let olderAsset = mediaAsset(
+            data: olderData,
+            source: "voice:" + String(repeating: "0", count: 32)
+        )
+        older.mediaAssets = [olderAsset]
+
+        try await store.importBackupWithoutBlocking(
+            snapshots: [older],
+            mediaFiles: [older.id: [olderAsset.fileName: olderData]],
+            replacingExisting: false
+        )
+
+        XCTAssertEqual(store.entries.first?.thread.title, "本机较新版本")
+        XCTAssertEqual(store.entries.first?.effectiveMediaAssets, [currentAsset])
+        XCTAssertEqual(
+            try store.mediaStore.backupFiles(for: store.entries[0])[currentAsset.fileName],
+            currentData
+        )
+    }
+
+    func testMediaManifestRejectsTraversalAndDigestConflicts() async throws {
+        var snapshot = try await capturedSnapshot()
+        let data = Data("payload".utf8)
+        var invalid = mediaAsset(data: data, source: "https://example.invalid/a")
+        invalid.fileName = "../outside.bin"
+        snapshot.mediaMode = .complete
+        snapshot.mediaAssets = [invalid]
+        XCTAssertThrowsError(try snapshot.validated()) { error in
+            XCTAssertEqual(error as? SavedThreadError, .invalidMediaManifest)
+        }
+    }
+
+    func testBackupRejectsOversizedMediaBeforeReadingFiles() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = SavedThreadStore(baseDirectoryURL: directory)
+        var snapshot = try await capturedSnapshot()
+        snapshot.mediaMode = .complete
+        snapshot.mediaAssets = [SavedThreadMediaAsset(
+            sourceIdentities: ["voice:" + String(repeating: "d", count: 32)],
+            kind: .audio,
+            fileName: String(repeating: "a", count: 64) + ".audio",
+            byteCount: SavedThreadPolicy.maximumBackupBytes + 1,
+            sha256: String(repeating: "a", count: 64)
+        )]
+
+        XCTAssertThrowsError(
+            try SavedThreadBackupDocument(snapshots: [snapshot], mediaStore: store.mediaStore)
+        ) { error in
+            XCTAssertEqual(error as? SavedThreadError, .backupStorageLimitExceeded)
+        }
+    }
+
+    func testBackupPreflightCountsHiddenFiles() throws {
+        let directory = try makeTemporaryDirectory()
+        let package = directory.appendingPathComponent("oversized.tiebapurebackup", isDirectory: true)
+        try FileManager.default.createDirectory(at: package, withIntermediateDirectories: false)
+        let hiddenFile = package.appendingPathComponent(".oversized")
+        XCTAssertTrue(FileManager.default.createFile(atPath: hiddenFile.path, contents: nil))
+        let handle = try FileHandle(forWritingTo: hiddenFile)
+        try handle.truncate(atOffset: UInt64(SavedThreadPolicy.maximumBackupBytes + 1))
+        try handle.close()
+
+        XCTAssertThrowsError(try SavedThreadBackupDocument.load(from: package)) { error in
+            XCTAssertEqual(error as? SavedThreadError, .backupStorageLimitExceeded)
+        }
+    }
+
+    func testBackupRejectsUnexpectedPackageEntriesAndDuplicateSnapshots() async throws {
+        let snapshot = try await capturedSnapshot()
+        let manifest = TestBackupManifest(
+            formatVersion: 1,
+            exportedAt: Date(timeIntervalSince1970: 1_900_000_000),
+            snapshots: [snapshot]
+        )
+        let manifestData = try JSONEncoder().encode(manifest)
+        let validMedia = FileWrapper(directoryWithFileWrappers: [
+            String(snapshot.id): FileWrapper(directoryWithFileWrappers: [:])
+        ])
+        let unexpectedRoot = FileWrapper(directoryWithFileWrappers: [
+            "manifest.json": FileWrapper(regularFileWithContents: manifestData),
+            "Media": validMedia,
+            ".unexpected": FileWrapper(regularFileWithContents: Data())
+        ])
+        XCTAssertThrowsError(try SavedThreadBackupDocument(fileWrapper: unexpectedRoot)) { error in
+            XCTAssertEqual(error as? SavedThreadError, .invalidBackup)
+        }
+
+        let duplicateManifest = TestBackupManifest(
+            formatVersion: 1,
+            exportedAt: Date(timeIntervalSince1970: 1_900_000_000),
+            snapshots: [snapshot, snapshot]
+        )
+        let duplicateRoot = FileWrapper(directoryWithFileWrappers: [
+            "manifest.json": FileWrapper(
+                regularFileWithContents: try JSONEncoder().encode(duplicateManifest)
+            ),
+            "Media": validMedia
+        ])
+        XCTAssertThrowsError(try SavedThreadBackupDocument(fileWrapper: duplicateRoot)) { error in
+            XCTAssertEqual(error as? SavedThreadError, .invalidBackup)
+        }
+    }
+
+    func testSavingTextOnlyRemovesPreviouslyCommittedMedia() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = SavedThreadStore(baseDirectoryURL: directory)
+        let data = Data("offline payload to remove".utf8)
+        var snapshot = try await capturedSnapshot()
+        let asset = mediaAsset(
+            data: data,
+            source: "voice:" + String(repeating: "e", count: 32)
+        )
+        snapshot.mediaMode = .complete
+        snapshot.mediaAssets = [asset]
+        let prepared = try store.mediaStore.prepareImport(
+            snapshot: snapshot,
+            files: [asset.fileName: data]
+        )
+        try store.save(snapshot, preparedMedia: prepared)
+
+        snapshot.mediaMode = .textOnly
+        snapshot.mediaAssets = []
+        try store.save(snapshot)
+
+        XCTAssertThrowsError(try store.mediaStore.backupFiles(for: snapshotWithAsset(
+            snapshot,
+            asset: asset
+        )))
+    }
+
+    private func capturedSnapshot() async throws -> SavedThreadSnapshot {
+        try await SavedThreadCaptureService(api: FixtureTiebaAPI()).capture(
+            account: nil,
+            threadID: FixtureTiebaAPI.threads[0].id,
+            forumID: FixtureTiebaAPI.forum.id,
+            savedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+    }
+
+    private func mediaAsset(data: Data, source: String) -> SavedThreadMediaAsset {
+        let digest = SecurePersistenceDigest.sha256(data)
+        return SavedThreadMediaAsset(
+            sourceIdentities: [source],
+            kind: .audio,
+            fileName: digest + ".audio",
+            byteCount: data.count,
+            sha256: digest
+        )
+    }
+
+    private func snapshotWithAsset(
+        _ snapshot: SavedThreadSnapshot,
+        asset: SavedThreadMediaAsset
+    ) -> SavedThreadSnapshot {
+        var result = snapshot
+        result.mediaMode = .complete
+        result.mediaAssets = [asset]
+        return result
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+
+    private struct TestBackupManifest: Encodable {
+        var formatVersion: Int
+        var exportedAt: Date
+        var snapshots: [SavedThreadSnapshot]
+    }
 }

--- a/TiebaPureTests/TiebaPureSmokeTests.swift
+++ b/TiebaPureTests/TiebaPureSmokeTests.swift
@@ -834,14 +834,23 @@ final class TiebaPureSmokeTests: XCTestCase {
 
     func testThreadDetailSearchStaysOnParentTypedPathBeforeMetadataLoads() {
         XCTAssertEqual(
-            ThreadDetailSearchOpenRoutingPolicy.destination(
-                hasParentHandler: true
+            NestedSearchOpenRoutingPolicy.destination(
+                hasParentHandler: true,
+                systemMajorVersion: 16
             ),
             .parentPath
         )
         XCTAssertEqual(
-            ThreadDetailSearchOpenRoutingPolicy.destination(
-                hasParentHandler: false
+            NestedSearchOpenRoutingPolicy.destination(
+                hasParentHandler: false,
+                systemMajorVersion: 16
+            ),
+            .standaloneSearch
+        )
+        XCTAssertEqual(
+            NestedSearchOpenRoutingPolicy.destination(
+                hasParentHandler: false,
+                systemMajorVersion: 17
             ),
             .localSearch
         )

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -59,6 +59,9 @@ final class TiebaPureUITests: XCTestCase {
         let save = app.buttons["保存到本地"]
         XCTAssertTrue(save.waitForExistence(timeout: 5))
         save.tap()
+        let textOnly = app.buttons["仅正文"]
+        XCTAssertTrue(textOnly.waitForExistence(timeout: 5))
+        textOnly.tap()
 
         XCTAssertTrue(app.alerts["本地保存"].waitForExistence(timeout: 12))
         XCTAssertTrue(app.alerts["本地保存"].staticTexts.element(boundBy: 1).label.contains("已保存主楼"))
@@ -82,7 +85,9 @@ final class TiebaPureUITests: XCTestCase {
         let savedThread = app.descendants(matching: .any)["saved-thread-1001"]
         XCTAssertTrue(savedThread.waitForExistence(timeout: 5))
         savedThread.tap()
-        XCTAssertTrue(app.staticTexts["确定性主帖：回复筛选与媒体布局"].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.descendants(matching: .any)["thread-main-title"].waitForExistence(timeout: 5)
+        )
         XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "媒体需联网加载")).firstMatch.exists)
     }
 
@@ -2612,29 +2617,22 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(rootTab("我的", in: app).exists)
     }
 
-    func testPreIOS26NativeEdgePopRecognizerIsReadyInSwiftUINavigationStack() throws {
+    func testPreIOS26NavigationRemainsResponsiveWithoutRecognizerOverride() throws {
         guard #unavailable(iOS 26.0) else {
             throw XCTSkip("iOS 26 uses the native content-pop recognizer")
         }
 
-        let app = launchApp(additionalArguments: ["UITEST_NAVIGATION_POP_DIAGNOSTICS"])
+        let app = launchApp()
         openFirstThread(in: app)
-
-        let diagnostics = app.descendants(matching: .any)["navigation-pop-gesture-diagnostics"]
-        XCTAssertTrue(diagnostics.waitForExistence(timeout: 8))
-        let ready = XCTNSPredicateExpectation(
-            predicate: NSPredicate(
-                format: "value CONTAINS %@ AND value CONTAINS %@ AND value CONTAINS %@ AND value CONTAINS %@ AND value CONTAINS %@",
-                "enabled=true",
-                "shouldBegin=true",
-                "depth=2",
-                "visible=true",
-                "attached=true"
-            ),
-            object: diagnostics
-        )
-        XCTAssertEqual(XCTWaiter.wait(for: [ready], timeout: 8), .completed)
         XCTAssertTrue(app.buttons["更多"].exists)
+
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        XCTAssertTrue(waitForHittable(backButton, expected: true, timeout: 5))
+        backButton.tap()
+        XCTAssertTrue(app.navigationBars["首页"].waitForExistence(timeout: 5))
+
+        openFirstThread(in: app)
+        XCTAssertTrue(app.buttons["更多"].waitForExistence(timeout: 5))
     }
 
     func testThreadShortRightDragCancelsWithoutChangingRoute() {
@@ -3836,6 +3834,98 @@ final class TiebaPureUITests: XCTestCase {
         XCTAssertTrue(
             app.navigationBars["2楼的回复(4条)"].waitForExistence(timeout: 8),
             "反复选择楼中楼文字后仍应可以打开回复列表"
+        )
+    }
+
+    func testIssue60IPadTitleAndMainPostSelectionStayResponsive() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            throw XCTSkip("仅在 iPad 设备矩阵中运行。")
+        }
+        let app = launchApp(scenario: "longContent", disableAnimations: false)
+        openFirstThread(in: app)
+
+        let targets = [
+            app.descendants(matching: .any)["thread-main-title"],
+            app.descendants(matching: .any)["thread-main-text"]
+        ]
+        for target in targets {
+            XCTAssertTrue(target.waitForExistence(timeout: 8))
+            XCTAssertTrue(waitForHittable(target, expected: true, timeout: 5))
+            for iteration in 0..<3 {
+                target.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.45))
+                    .press(forDuration: 1.2)
+                let copyControl = app.descendants(matching: .any)
+                    .matching(NSPredicate(format: "label IN %@", ["复制", "拷贝", "Copy"]))
+                    .firstMatch
+                XCTAssertTrue(
+                    copyControl.waitForExistence(timeout: 5),
+                    "第\(iteration + 1)次长按标题或主楼后界面失去响应"
+                )
+                XCTAssertTrue(waitForHittable(copyControl, expected: true, timeout: 5))
+                copyControl.tap()
+                XCTAssertTrue(
+                    app.buttons["更多"].waitForExistence(timeout: 5),
+                    "复制后帖子工具栏应继续响应"
+                )
+            }
+        }
+    }
+
+    func testIssue62ThreadSearchRepeatedlyOpensWithoutFreezing() {
+        let app = launchApp(disableAnimations: false)
+        openFirstThread(in: app)
+
+        for iteration in 0..<5 {
+            let search = app.buttons["搜索本吧"]
+            XCTAssertTrue(search.waitForExistence(timeout: 5))
+            XCTAssertTrue(waitForHittable(search, expected: true, timeout: 5))
+            search.tap()
+
+            let searchBar = app.navigationBars["测试吧搜索"]
+            XCTAssertTrue(
+                searchBar.waitForExistence(timeout: 8),
+                "第\(iteration + 1)次从帖子打开搜索时界面失去响应"
+            )
+            XCTAssertTrue(app.textFields["search-input"].exists)
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                let input = app.textFields["search-input"]
+                input.tap()
+                input.typeText("1")
+                XCTAssertTrue(
+                    (input.value as? String)?.contains("1") == true,
+                    "第\(iteration + 1)次打开搜索后输入框应继续响应"
+                )
+                rootTab("首页", in: app).tap()
+                XCTAssertTrue(threadRows(in: app).firstMatch.waitForExistence(timeout: 8))
+                if iteration < 4 { openFirstThread(in: app) }
+                continue
+            }
+            let back = searchBar.buttons.firstMatch
+            XCTAssertTrue(waitForHittable(back, expected: true, timeout: 5))
+            back.tap()
+            XCTAssertTrue(
+                app.buttons["更多"].waitForExistence(timeout: 8),
+                "第\(iteration + 1)次退出帖子搜索后来源页失去响应"
+            )
+        }
+    }
+
+    func testIssue63HomeAvatarProfileThreadNavigationStaysResponsive() {
+        let app = launchApp(disableAnimations: false)
+        let user = app.buttons["feed-user-button-1"].firstMatch
+        XCTAssertTrue(user.waitForExistence(timeout: 45))
+        XCTAssertTrue(waitForHittable(user, expected: true, timeout: 5))
+        user.tap()
+
+        let profile = app.descendants(matching: .any)["user-profile-screen"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 8), "从首页头像进入主页时不应卡死")
+        let profileThread = app.buttons["user-profile-thread-row-1002"]
+        XCTAssertTrue(profileThread.waitForExistence(timeout: 8))
+        XCTAssertTrue(scrollToHittable(profileThread, in: app.scrollViews["user-profile-screen"]))
+        profileThread.tap()
+        XCTAssertTrue(
+            app.buttons["更多"].waitForExistence(timeout: 8),
+            "从首页主页进入用户帖子时不应卡死"
         )
     }
 
@@ -5442,9 +5532,10 @@ final class TiebaPureUITests: XCTestCase {
             let searchNavigationBar = app.navigationBars["测试吧搜索"]
             XCTAssertTrue(searchNavigationBar.waitForExistence(timeout: 8))
             XCTAssertTrue(app.textFields["search-input"].exists)
-            let backButton = searchNavigationBar.buttons["BackButton"]
+            let backButton = searchNavigationBar.buttons.firstMatch
             XCTAssertTrue(
-                backButton.waitForExistence(timeout: 5),
+                backButton.waitForExistence(timeout: 5)
+                    && waitForHittable(backButton, expected: true, timeout: 5),
                 "第\(iteration + 1)次进入吧内搜索后应存在系统返回按钮"
             )
             backButton.tap()


### PR DESCRIPTION
## Summary
- fix iOS 16 nested search layout recursion and stop overriding native navigation gestures
- move selectable thread/profile text onto the controlled TextKit renderer and add reliable home-tab reselect refresh
- add built-in/custom reader fonts with validated private TTF/OTF storage
- add transactional offline media saves, backup import/export, storage management, and saved-thread reply update tracking
- move font, local media, voice, and storage file I/O away from the main actor

## Root cause
On iOS 16, opening a Boolean navigation destination from a view that was already a NavigationStack destination could recurse through SwiftUI trait/layout updates. The app main thread stayed in CA transaction and AttributeGraph layout while memory continuously grew. Old systems now open these nested searches inside an isolated full-screen NavigationStack; iOS 17 and later keep the local push route. Similar navigation destinations and synchronous local-file paths were audited.

## Verification
- TiebaPureTests: 831 executed, 8 skipped, 0 failures on iOS 18.3
- iOS 16.4 UI: forum search, repeated thread search, avatar/profile/thread navigation, local save/open, long-press copy
- iPadOS 18.3 UI: repeated title/main-post/subpost selection and both home reselect refresh paths
- prior targeted coverage also passed on iOS 18.3 and iOS 26.5

Fixes #60
Fixes #62
Fixes #63
Fixes #64
Fixes #65