### PR TITLE
chore: sync generated Xcode project

### DIFF
--- a/TiebaPure.xcodeproj/project.pbxproj
+++ b/TiebaPure.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B1C2D3E4F5061728394A5B6C /* SavedThreadMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* SavedThreadMedia.swift */; };
 		03BFC1CB27519F2A9851619C /* ContentDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A1C1C285AED2131947564A /* ContentDraft.swift */; };
 		043AF9BB1E2EF30D61B1DC63 /* SwiftDataOrderedCollectionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67285F50B29BA765B74B5271 /* SwiftDataOrderedCollectionPersistence.swift */; };
 		06132F36C724DF5F6A7409D5 /* ThreadDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1626D4B0DD88E88576EBC2EB /* ThreadDetailView.swift */; };
@@ -156,6 +155,7 @@
 		BF200F41FA7A88C525623215 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E425761E05D459199869361A /* AboutView.swift */; };
 		BF3E65570A0501F384F8C0BA /* ReaderStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475452DA26606C9EEF2982D2 /* ReaderStateView.swift */; };
 		C02D20CEC3FEDED464983D96 /* SafariActionPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872607E2663432D3116C5BB6 /* SafariActionPayload.swift */; };
+		C0504704A144B25F4915E062 /* SavedThreadMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBF9E6133FA9F395134196F /* SavedThreadMedia.swift */; };
 		C093E45405F12EC29B1F62B5 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB22109F3B9CFD8850C4BEE0 /* AuthSession.swift */; };
 		C0E5134C9E23DDD474D84DDA /* TiebaPureSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A22DDA746D43724E44B7D2 /* TiebaPureSmokeTests.swift */; };
 		C144376E190882BF6A323835 /* ForumHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3DFA01DD01FD4EA295E006 /* ForumHubView.swift */; };
@@ -259,7 +259,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		A1B2C3D4E5F60718293A4B5C /* SavedThreadMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedThreadMedia.swift; sourceTree = "<group>"; };
 		00339148CB9511CB5F6A624F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0060EA54C03E209E46FB2C40 /* ForumThreadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumThreadsView.swift; sourceTree = "<group>"; };
 		00A0FAAA54B2D05276E46330 /* SessionExpirationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExpirationMonitorTests.swift; sourceTree = "<group>"; };
@@ -433,6 +432,7 @@
 		C4B3F485FB45C4828FD7C5C6 /* AppPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPersistence.swift; sourceTree = "<group>"; };
 		C60B7C87AF367770BAF70762 /* SearchAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPITests.swift; sourceTree = "<group>"; };
 		C80CE02414B9F8BD668C519D /* FrsPage_FrsPage.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrsPage_FrsPage.pb.swift; sourceTree = "<group>"; };
+		CBBF9E6133FA9F395134196F /* SavedThreadMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedThreadMedia.swift; sourceTree = "<group>"; };
 		CBF457C95754D5EAA87ECEFD /* ForumSignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForumSignTests.swift; sourceTree = "<group>"; };
 		CD2C30123EFF90A5F9BEE7C2 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		D1180626C13544DCC568FA5B /* AccountThreadFavoritesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountThreadFavoritesTests.swift; sourceTree = "<group>"; };
@@ -639,7 +639,7 @@
 				638DEF254549D0D4DE625487 /* ReadingPreferences.swift */,
 				FDE02417BF13C2E0A1D7824E /* RecentForum.swift */,
 				0DB03A9A81B77E7ECBD00B30 /* SavedThread.swift */,
-				A1B2C3D4E5F60718293A4B5C /* SavedThreadMedia.swift */,
+				CBBF9E6133FA9F395134196F /* SavedThreadMedia.swift */,
 				24D4BAC59CD64A3B8F236258 /* SearchHistory.swift */,
 				16DDB351392A69BC42810B9E /* SearchResult.swift */,
 				6BBA032F531024778CFC5C0A /* SecureFilePersistence.swift */,
@@ -1222,7 +1222,7 @@
 				A4FCD6601BAA005BF0F264D0 /* RootView.swift in Sources */,
 				C02D20CEC3FEDED464983D96 /* SafariActionPayload.swift in Sources */,
 				1E84B72ACDF13678A6BE6CB8 /* SavedThread.swift in Sources */,
-				B1C2D3E4F5061728394A5B6C /* SavedThreadMedia.swift in Sources */,
+				C0504704A144B25F4915E062 /* SavedThreadMedia.swift in Sources */,
 				985218E469AF18B5378E8549 /* SavedThreadsView.swift in Sources */,
 				CAA7C941E2D8AAA65B342CBA /* SearchHistory.swift in Sources */,
 				8028A9708BDE36C7BB815CEF /* SearchResult.swift in Sources */,


### PR DESCRIPTION
## Summary
- regenerate the Xcode project from `project.yml`
- replace only the generated object IDs for `SavedThreadMedia.swift`
- restore the unsigned IPA project-consistency packaging gate

## Verification
- `git diff --check`
- generated project byte-for-byte matches a clean XcodeGen output
- PR #67 CI passed before this metadata-only follow-up