### PR TITLE
Stabilize iPad landscape CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,9 @@ jobs:
             -derivedDataPath "$DERIVED_DATA" \
             -parallel-testing-enabled NO \
             test \
-            -only-testing:TiebaPureUITests/TiebaPureUITests/testIPadLandscapeReaderListUsesAvailableWidth
+            -only-testing:TiebaPureUITests/TiebaPureUITests/testIPadLandscapeReaderListUsesAvailableWidth \
+            -retry-tests-on-failure -test-iterations 2 \
+            -test-repetition-relaunch-enabled YES
 
       - name: Release build and bundled notices
         run: |

--- a/TiebaPureUITests/TiebaPureUITests.swift
+++ b/TiebaPureUITests/TiebaPureUITests.swift
@@ -5628,31 +5628,28 @@ final class TiebaPureUITests: XCTestCase {
         guard UIDevice.current.userInterfaceIdiom == .pad else {
             throw XCTSkip("仅在 iPad 设备矩阵中运行。")
         }
-        let app = launchApp()
-        XCUIDevice.shared.orientation = .landscapeLeft
         addTeardownBlock {
             XCUIDevice.shared.orientation = .portrait
         }
-
-        let landscape = XCTNSPredicateExpectation(
-            predicate: NSPredicate { object, _ in
-                guard let application = object as? XCUIApplication else { return false }
-                return application.frame.width > application.frame.height
-            },
-            object: app
-        )
-        XCTAssertEqual(XCTWaiter.wait(for: [landscape], timeout: 8), .completed)
+        XCUIDevice.shared.orientation = .landscapeLeft
+        let app = launchApp()
 
         let firstThreadRow = threadRows(in: app).firstMatch
         XCTAssertTrue(firstThreadRow.waitForExistence(timeout: 8))
+        let appFrame = app.frame
+        XCTAssertGreaterThan(
+            appFrame.width,
+            appFrame.height,
+            "iPad 横屏布局测试必须在横屏窗口中运行"
+        )
         XCTAssertGreaterThanOrEqual(
             firstThreadRow.frame.width,
-            app.frame.width * 0.35,
+            appFrame.width * 0.35,
             "iPad 横屏帖子行应使用足够的横向空间展示标题"
         )
         XCTAssertLessThan(
             firstThreadRow.frame.maxX,
-            app.frame.midX,
+            appFrame.midX,
             "左侧帖子列表不能挤占右侧详情栏"
         )
     }


### PR DESCRIPTION
## Summary
- rotate the iPad simulator before launching the fixture app
- validate the settled landscape frame after the first thread row is available
- retry the isolated iPad UI test at most once for runner-level failures

## Verification
- iOS 26.5 iPad Pro 11-inch (M5): CI-equivalent run passed without retry
- same target repeated 3 times with retries disabled: 3/3 passed
- workflow YAML parse passed
- git diff --check passed

This addresses the post-merge main failure in run 32680331379 without weakening the split-layout assertions.