### PR TITLE
fix: allow selecting custom fonts

### DIFF
--- a/TiebaPure/Domain/Models/ReadingPreferences.swift
+++ b/TiebaPure/Domain/Models/ReadingPreferences.swift
@@ -3,6 +3,7 @@ import CoreText
 import Foundation
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 enum ReaderFontSize: String, CaseIterable, Identifiable, Sendable {
     case small
@@ -90,9 +91,9 @@ struct ReaderFontFamily: RawRepresentable, Equatable, Hashable, Identifiable, Se
     var title: String {
         switch self {
         case .system: return "系统默认"
-        case .serif: return "衬线"
-        case .rounded: return "圆体"
-        case .monospaced: return "等宽"
+        case .serif: return "衬线（西文）"
+        case .rounded: return "圆体（西文）"
+        case .monospaced: return "等宽（西文）"
         default: return importedPostScriptName ?? "自定义字体"
         }
     }
@@ -548,6 +549,21 @@ struct ImportedReaderFont: Identifiable, Equatable, Codable, Sendable {
     var family: ReaderFontFamily? { .imported(postScriptName: postScriptName) }
 }
 
+enum ReaderFontImportPolicy {
+    static let supportedFileExtensions = ["ttf", "otf"]
+
+    static var allowedContentTypes: [UTType] {
+        let contentTypes = supportedFileExtensions.compactMap {
+            UTType(filenameExtension: $0, conformingTo: .data)
+        }
+        return contentTypes.isEmpty ? [.data] : contentTypes
+    }
+
+    static func supports(fileExtension: String) -> Bool {
+        supportedFileExtensions.contains(fileExtension.lowercased())
+    }
+}
+
 enum ReaderFontStoreError: LocalizedError, Equatable {
     case persistenceUnavailable
     case unsupportedFile
@@ -647,7 +663,7 @@ final class ReaderFontStore: ObservableObject {
 
     nonisolated static func prepareImport(from sourceURL: URL) throws -> PreparedReaderFontImport {
         let fileExtension = sourceURL.pathExtension.lowercased()
-        guard ["ttf", "otf"].contains(fileExtension) else {
+        guard ReaderFontImportPolicy.supports(fileExtension: fileExtension) else {
             throw ReaderFontStoreError.unsupportedFile
         }
 
@@ -696,7 +712,7 @@ final class ReaderFontStore: ObservableObject {
               let directoryURL, let catalogFile else {
             throw ReaderFontStoreError.persistenceUnavailable
         }
-        guard ["ttf", "otf"].contains(prepared.fileExtension),
+        guard ReaderFontImportPolicy.supports(fileExtension: prepared.fileExtension),
               prepared.data.isEmpty == false,
               prepared.data.count <= Self.maximumFontByteCount,
               prepared.sha256.utf8.count == 64,

--- a/TiebaPure/Features/Settings/ReadingSettingsView.swift
+++ b/TiebaPure/Features/Settings/ReadingSettingsView.swift
@@ -63,7 +63,7 @@ struct ReadingSettingsView: View {
             } header: {
                 Text("字体")
             } footer: {
-                Text("支持 TTF 和 OTF，单个文件不超过 20 MB，最多导入 20 个。字体只保存在本机应用私有目录。")
+                Text("内置圆体、衬线和等宽只改变有对应字形的西文；更换中文字体请导入包含中文字形的 TTF 或 OTF。单个文件不超过 20 MB，最多导入 20 个，字体只保存在本机应用私有目录。")
             }
 
             Section {
@@ -151,7 +151,7 @@ struct ReadingSettingsView: View {
         .fullScreenInteractiveNavigationPop()
         .fileImporter(
             isPresented: $showsFontImporter,
-            allowedContentTypes: [.font],
+            allowedContentTypes: ReaderFontImportPolicy.allowedContentTypes,
             allowsMultipleSelection: false,
             onCompletion: handleFontImport
         )

--- a/TiebaPureTests/CrossVersionStateRegressionTests.swift
+++ b/TiebaPureTests/CrossVersionStateRegressionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import UniformTypeIdentifiers
 import XCTest
 @testable import TiebaPure
 
@@ -573,6 +574,32 @@ final class CrossVersionStateRegressionTests: XCTestCase,
         )
         XCTAssertEqual(serifFont.pointSize, standardFont.pointSize, accuracy: 0.01)
         XCTAssertNotEqual(serifFont.fontName, standardFont.fontName)
+    }
+
+    func testReaderFontImportPolicyExposesSelectableTTFAndOTFTypes() throws {
+        XCTAssertEqual(ReaderFontImportPolicy.supportedFileExtensions, ["ttf", "otf"])
+
+        let contentTypes = ReaderFontImportPolicy.allowedContentTypes
+        XCTAssertEqual(contentTypes.count, 2)
+        for (fileExtension, contentType) in zip(
+            ReaderFontImportPolicy.supportedFileExtensions,
+            contentTypes
+        ) {
+            let systemResolvedType = try XCTUnwrap(
+                UTType(filenameExtension: fileExtension)
+            )
+            XCTAssertEqual(contentType, systemResolvedType)
+            XCTAssertTrue(contentType.conforms(to: .data))
+            XCTAssertEqual(contentType.preferredFilenameExtension, fileExtension)
+            XCTAssertTrue(ReaderFontImportPolicy.supports(fileExtension: fileExtension.uppercased()))
+        }
+        XCTAssertFalse(ReaderFontImportPolicy.supports(fileExtension: "ttc"))
+    }
+
+    func testBuiltInReaderFontTitlesDescribeWesternGlyphScope() {
+        XCTAssertEqual(ReaderFontFamily.serif.title, "衬线（西文）")
+        XCTAssertEqual(ReaderFontFamily.rounded.title, "圆体（西文）")
+        XCTAssertEqual(ReaderFontFamily.monospaced.title, "等宽（西文）")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- resolve TTF and OTF picker filters from their actual filename-based data types instead of the generic font type
- share the supported extension policy with the existing validated font importer
- clarify that built-in rounded, serif, and monospaced designs affect supported Western glyphs, while Chinese typography requires an imported font with Chinese glyphs

## Verification
- iOS 16.4 targeted font regressions: 3 passed, 0 failed
- iOS 26.5 unit suite: 835 executed, 6 skipped, 0 failed
- iOS 26.5 reading-settings UI regression: 1 passed, 0 failed
- all test simulators shut down after use

A local iOS 27 runtime is not installed. The picker regression is covered by asserting that each allowed type exactly matches the system-resolved TTF/OTF type on iOS 16.4 and iOS 26.5.

Fixes #75